### PR TITLE
 fix: add `supports_credentials` to cors config 

### DIFF
--- a/backend/api/src/http/cors.rs
+++ b/backend/api/src/http/cors.rs
@@ -3,6 +3,7 @@ use config::CORS_ORIGINS;
 
 pub fn get_cors_actix(local_insecure: bool) -> actix_cors::Cors {
     let mut cors = actix_cors::Cors::new()
+        .supports_credentials()
         .allowed_methods(&[Method::GET, Method::POST, Method::DELETE, Method::OPTIONS])
         .allowed_headers(&[
             header::AUTHORIZATION,


### PR DESCRIPTION
closes #81  