### PR TITLE
fix: update algolia-rs to fix bug with algolia integration

### DIFF
--- a/backend/api/Cargo.lock
+++ b/backend/api/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 [[package]]
 name = "algolia"
 version = "0.1.0"
-source = "git+https://gitlab.com/izik1/algolia-rs.git?rev=61911d09cbf0c4361c73afe64fdbd881cdbb0f95#61911d09cbf0c4361c73afe64fdbd881cdbb0f95"
+source = "git+https://gitlab.com/izik1/algolia-rs.git?rev=85975c32cc9396c3e4ae6df7158948579b9989f4#85975c32cc9396c3e4ae6df7158948579b9989f4"
 dependencies = [
  "chrono",
  "rand",

--- a/backend/api/Cargo.toml
+++ b/backend/api/Cargo.toml
@@ -13,7 +13,7 @@ actix-cors = "0.3.0"
 actix-rt = "1.0.0"
 actix-service = "1.0.5"
 actix-web = "3.0.0"
-algolia = { git = "https://gitlab.com/izik1/algolia-rs.git", rev = "61911d09cbf0c4361c73afe64fdbd881cdbb0f95" }
+algolia = { git = "https://gitlab.com/izik1/algolia-rs.git", rev = "85975c32cc9396c3e4ae6df7158948579b9989f4" }
 anyhow = "1.0.32"
 chrono = "0.4.13"
 chrono-tz = "0.5.3"


### PR DESCRIPTION
Should fix #197
Algolia will need to be "fixed" so, the following query needs to be run on the db:
```sql
-- the reason why we can get away with only hitting the ones that have been updated is because they were initially uploaded correctly, and the ones that have an `updated_at` are simply out of date.
update image_metadata set last_synced_at = null where updated_at is not null
```
Additionally, the object with `objectID: batch` in the `image` index needs to be removed because it's corrupted and algolia-rs doesn't handle the way it does that attribute properly (yet). There's probably some setting we could use while querying to just not get match information though