### PR TITLE
fix: allow for the algolia image index to be chosen manually if running locally

### DIFF
--- a/backend/_core/rust/src/env/keys.rs
+++ b/backend/_core/rust/src/env/keys.rs
@@ -30,6 +30,8 @@ pub mod algolia {
     pub const APPLICATION_ID_OLD: &str = "ALGOLIA_APPLICATION_ID";
     pub const APPLICATION_ID_NEW: &str = "ALGOLIA_PROJECT_ID";
 
+    pub const IMAGE_INDEX: &str = "ALGOLIA_IMAGE_INDEX";
+
     pub const KEY: &str = "ALGOLIA_KEY";
     pub const DISABLE: &str = "ALGOLIA_LOCAL_DISABLE_CLIENT";
 }

--- a/backend/_core/rust/src/settings.rs
+++ b/backend/_core/rust/src/settings.rs
@@ -113,6 +113,8 @@ pub struct AlgoliaSettings {
     pub application_id: String,
     /// The key to use for the algolia client.
     pub key: String,
+    /// The index to use for operations on the algolia client.
+    pub index: String,
 }
 
 /// Manages access to settings.
@@ -272,9 +274,18 @@ impl SettingsManager {
             return Ok(None);
         }
 
+        let index = match crate::REMOTE_TARGET.algolia_image_index() {
+            Some(it) => it.to_owned(),
+            None => match self.get_secret(keys::algolia::IMAGE_INDEX).await {
+                Ok(it) =>it,
+                Err(_) => return Ok(None),
+            }
+        };
+
         Ok(Some(AlgoliaSettings {
             application_id,
             key,
+            index,
         }))
     }
 

--- a/backend/api/src/algolia.rs
+++ b/backend/api/src/algolia.rs
@@ -151,6 +151,7 @@ pub struct ImageUpdate<'a> {
 #[derive(Clone)]
 pub struct AlgoliaClient {
     inner: Option<Inner>,
+    index: String,
 }
 
 fn filters_for_ids<T: Into<Uuid> + Copy>(
@@ -173,7 +174,7 @@ fn filters_for_ids<T: Into<Uuid> + Copy>(
 impl AlgoliaClient {
     async fn batch_images(&self, batch: BatchWriteRequests) -> anyhow::Result<Vec<Uuid>> {
         let resp = with_client!(self.inner; vec![])
-            .batch("image", &batch)
+            .batch(&self.index, &batch)
             .await?;
 
         let ids: Result<_, _> = resp
@@ -186,16 +187,21 @@ impl AlgoliaClient {
     }
 
     pub fn new(settings: Option<AlgoliaSettings>) -> anyhow::Result<Self> {
-        let inner = if let Some(settings) = settings {
+        if let Some(settings) = settings {
             let app_id = algolia::AppId::new(settings.application_id);
             let api_key = algolia::ApiKey(settings.key);
 
-            Some(Inner::new(app_id, api_key)?)
-        } else {
-            None
-        };
+            Ok(Self {
+                inner: Some(Inner::new(app_id, api_key)?),
+                index: settings.index,
+            })
 
-        Ok(Self { inner })
+        } else {
+            Ok(Self {
+                inner: None,
+                index: String::new(),
+            })    
+        }
     }
 
     // todo: return ImageId (can't because of repr issues in sqlx)
@@ -240,7 +246,7 @@ impl AlgoliaClient {
 
         let results: SearchResponse = client
             .search(
-                "image",
+                &self.index,
                 SearchQuery {
                     query: Some(query),
                     page,
@@ -274,7 +280,7 @@ impl AlgoliaClient {
 
     pub async fn try_delete_image(&self, ImageId(id): ImageId) -> anyhow::Result<()> {
         with_client!(self.inner)
-            .delete_object("image", &id.to_string())
+            .delete_object(&self.index, &id.to_string())
             .await?;
 
         Ok(())

--- a/config/rust/src/lib.rs
+++ b/config/rust/src/lib.rs
@@ -40,6 +40,14 @@ impl RemoteTarget {
         }
     }
 
+    pub const fn algolia_image_index(&self) -> Option<&'static str> {
+        match self {
+            Self::Local => None,
+            Self::Sandbox => Some("image_sandbox"),
+            Self::Release => Some("image_release"),
+        }
+    }
+
     pub const fn s3_bucket(&self) -> Option<&'static str> {
         match self {
             Self::Local => None,
@@ -94,7 +102,7 @@ impl RemoteTarget {
         }
     }
 
-    pub fn css_url(&self, minified:bool) -> String {
+    pub fn css_url(&self, minified: bool) -> String {
         if minified {
             format!("{}/_css/styles.min.css", self.frontend_url())
         } else {


### PR DESCRIPTION
Like #202, this requires re-syncing algolia, unlike #202, it needs to do a total re-sync
* the `image` index *should* be removed
the following sql needs to be ran:
```sql
update image_metadata set last_synced_at = null
```
