### PR TITLE
refactor: replace most of `core`'s features with runtime config

### DIFF
--- a/backend/_core/rust/Cargo.toml
+++ b/backend/_core/rust/Cargo.toml
@@ -24,8 +24,4 @@ yup-oauth2 = "4.1.2"
 log = "0.4.11"
 
 [features]
-sqlproxy = ["db"]
-local = ["listenfd"]
-release = []
-sandbox = []
 db = ["sqlx"]

--- a/backend/_core/rust/src/http.rs
+++ b/backend/_core/rust/src/http.rs
@@ -4,10 +4,10 @@ use std::net::{SocketAddr, TcpListener};
 ///
 /// [`TcpListener`]: https://doc.rust-lang.org/stable/std/net/struct.TcpListener.html
 pub fn get_tcp_fd() -> Option<TcpListener> {
-    #[cfg(feature = "local")]
+    #[cfg(feature = "listenfd")]
     let fd = listenfd::ListenFd::from_env().take_tcp_listener(0).unwrap();
 
-    #[cfg(not(feature = "local"))]
+    #[cfg(not(feature = "listenfd"))]
     let fd = None;
 
     fd

--- a/backend/_core/rust/src/lib.rs
+++ b/backend/_core/rust/src/lib.rs
@@ -12,27 +12,4 @@ pub mod google;
 pub mod http;
 
 /// Keeps track of settings.
-#[cfg(any(feature = "local", feature = "sandbox", feature = "release",))]
 pub mod settings;
-
-#[cfg(any(feature = "local", feature = "sandbox", feature = "release"))]
-use config::RemoteTarget;
-
-#[cfg(not(any(feature = "local", feature = "sandbox", feature = "release")))]
-compile_error!("At least one of the `local`, `sandbox` or `release` features must be enabled.");
-
-#[cfg(any(
-    all(feature = "local", feature = "sandbox"),
-    all(feature = "local", feature = "release"),
-    all(feature = "sandbox", feature = "release"),
-))]
-compile_error!("Only one of `local`, `sandbox` or `release` features can be enabled.");
-
-#[cfg(feature = "local")]
-pub(crate) const REMOTE_TARGET: RemoteTarget = RemoteTarget::Local;
-
-#[cfg(feature = "sandbox")]
-pub(crate) const REMOTE_TARGET: RemoteTarget = RemoteTarget::Sandbox;
-
-#[cfg(feature = "release")]
-pub(crate) const REMOTE_TARGET: RemoteTarget = RemoteTarget::Release;

--- a/backend/api/Cargo.toml
+++ b/backend/api/Cargo.toml
@@ -23,7 +23,7 @@ futures = "0.3.5"
 jsonwebtoken = "7.2"
 listenfd = {version = "0.3", optional = true }
 log = "0.4"
-openssl = { version = "0.10", features = ["vendored"], optional = true }
+openssl = { version = "0.10", features = ["vendored"] }
 percent-encoding = "2.1.0"
 pin-project = "0.4.23"
 rand = "0.7"
@@ -52,8 +52,4 @@ features = ["db"]
 
 
 [features]
-default = ["local"]
-local = ["listenfd", "core/local"]
-release = ["core/release", "openssl"]
-sandbox = ["core/sandbox", "openssl"]
-sqlproxy = ["core/sqlproxy"]
+default = ["listenfd", "core/listenfd"]

--- a/backend/api/Dockerfile
+++ b/backend/api/Dockerfile
@@ -39,7 +39,7 @@ RUN sudo chown -R rust:rust /home/rust
 
 # Build our application.
 WORKDIR ./backend/api
-RUN cargo build --release --no-default-features --features release
+RUN cargo build --release --no-default-features
 
 # Now, we need to build our _real_ Docker container, copying in the binary.
 FROM alpine:latest as release
@@ -58,7 +58,7 @@ COPY --from=release-builder \
 WORKDIR /usr/local/bin/cloud-run-app/
 
 
-CMD ["./ji-cloud-api"]
+CMD ["./ji-cloud-api", "release"]
 
 ####################
 ## Sandbox        ##
@@ -79,7 +79,7 @@ RUN sudo chown -R rust:rust /home/rust
 
 # Build our application.
 WORKDIR ./backend/api
-RUN cargo build --release --no-default-features --features sandbox
+RUN cargo build --release --no-default-features
 
 # Now, we need to build our _real_ Docker container, copying in the binary.
 FROM alpine:latest as sandbox 
@@ -98,4 +98,4 @@ COPY --from=sandbox-builder \
 WORKDIR /usr/local/bin/cloud-run-app/
 
 
-CMD ["./ji-cloud-api"]
+CMD ["./ji-cloud-api", "sandbox"]

--- a/backend/api/Makefile.toml
+++ b/backend/api/Makefile.toml
@@ -54,14 +54,14 @@ run_task = { name = [ "google-sql-proxy", "server-local-proxy", ], parallel = tr
 
 [tasks.server-local-proxy]
 command = "systemfd"
-args = ["--no-pid", "-s", "http::8080", "--", "cargo", "watch", "-w", "../../config/rust/src", "-w", "../../shared/rust/src", "-w", "../_core/rust/src", "-w", ".", "-x", "run --features local,sqlproxy"]
+args = ["--no-pid", "-s", "http::8080", "--", "cargo", "watch", "-w", "../../config/rust/src", "-w", "../../shared/rust/src", "-w", "../_core/rust/src", "-w", ".", "-x", "run", "--", "local", "sqlproxy"]
 
 [tasks.dev]
 run_task = { name = [ "server-local"] }
 
 [tasks.server-local]
 command = "systemfd"
-args = ["--no-pid", "-s", "http::8080", "--", "cargo", "watch", "-w", "../../config/rust/src", "-w", "../../shared/rust/src", "-w", "../_core/rust/src", "-w", ".", "-x", "run --features local"]
+args = ["--no-pid", "-s", "http::8080", "--", "cargo", "watch", "-w", "../../config/rust/src", "-w", "../../shared/rust/src", "-w", "../_core/rust/src", "-w", ".", "-x", "run", "--", "local"]
 
 # note: this doesn't currently work, because `cloud-sql-proxy` doesn't exist.
 [tasks.google-sql-proxy]

--- a/backend/api/src/main.rs
+++ b/backend/api/src/main.rs
@@ -1,4 +1,4 @@
-use core::settings::SettingsManager;
+use core::settings::{self, SettingsManager};
 use ji_cloud_api::{algolia, db, http, jwkkeys, logger, s3};
 use std::thread;
 
@@ -8,19 +8,30 @@ async fn main() -> anyhow::Result<()> {
 
     logger::init()?;
 
-    let settings: SettingsManager = SettingsManager::new().await?;
+    let (runtime_settings, jwk_verifier, s3, algolia, db_pool) = {
+        let remote_target = settings::read_remote_target()?;
 
-    let runtime_settings = settings.runtime_settings().await?;
+        let settings: SettingsManager = SettingsManager::new(remote_target).await?;
 
-    let jwk_verifier = jwkkeys::create_verifier(settings.jwk_settings().await?);
+        let runtime_settings = settings.runtime_settings().await?;
 
-    let _ = jwkkeys::run_task(jwk_verifier.clone());
+        let jwk_verifier = jwkkeys::create_verifier(settings.jwk_settings().await?);
 
-    let s3 = s3::S3Client::new(settings.s3_settings().await?)?;
+        let _ = jwkkeys::run_task(jwk_verifier.clone());
 
-    let algolia = algolia::AlgoliaClient::new(settings.algolia_settings().await?)?;
+        let s3 = s3::S3Client::new(settings.s3_settings().await?)?;
 
-    let db_pool = db::get_pool(settings.db_connect_options().await?).await?;
+        let algolia = algolia::AlgoliaClient::new(settings.algolia_settings().await?)?;
+
+        let db_pool = db::get_pool(
+            settings
+                .db_connect_options(settings::read_sql_proxy())
+                .await?,
+        )
+        .await?;
+
+        (runtime_settings, jwk_verifier, s3, algolia, db_pool)
+    };
 
     let algolia_syncer = algolia::Updater {
         db: db_pool.clone(),

--- a/backend/pages/Cargo.toml
+++ b/backend/pages/Cargo.toml
@@ -23,11 +23,7 @@ listenfd = {version = "0.3", optional = true }
 log = "0.4"
 simplelog = "0.8"
 tokio = { version = "0.2" }
-openssl = { version = "0.10", features = ["vendored"], optional = true }
+openssl = { version = "0.10", features = ["vendored"] }
 
 [features]
-default = ["local"]
-local = ["listenfd", "core/local"]
-sqlproxy = []
-release = ["core/release", "openssl"]
-sandbox = ["core/sandbox", "openssl"]
+default = ["listenfd", "core/listenfd"]

--- a/backend/pages/Dockerfile
+++ b/backend/pages/Dockerfile
@@ -40,7 +40,7 @@ RUN sudo chown -R rust:rust /home/rust
 
 # Build our application.
 WORKDIR ./backend/pages
-RUN cargo build --release --features release
+RUN cargo build --release --no-default-features
 
 # Now, we need to build our _real_ Docker container, copying in the binary.
 FROM alpine:latest as release
@@ -63,7 +63,7 @@ COPY ./backend/pages/templates /usr/local/bin/cloud-run-app/templates
 WORKDIR /usr/local/bin/cloud-run-app/
 
 
-CMD ["./ji-cloud-pages"]
+CMD ["./ji-cloud-pages", "release"]
 
 ####################
 ## Sandbox        ##
@@ -85,7 +85,7 @@ RUN sudo chown -R rust:rust /home/rust
 
 # Build our application.
 WORKDIR ./backend/pages
-RUN cargo build --release --no-default-features --features sandbox 
+RUN cargo build --release --no-default-features
 
 # Now, we need to build our _real_ Docker container, copying in the binary.
 FROM alpine:latest as sandbox 
@@ -105,4 +105,4 @@ COPY ./backend/pages/public /usr/local/bin/cloud-run-app/public
 
 WORKDIR /usr/local/bin/cloud-run-app/
 
-CMD ["./ji-cloud-pages"]
+CMD ["./ji-cloud-pages", "sandbox"]

--- a/backend/pages/Makefile.toml
+++ b/backend/pages/Makefile.toml
@@ -21,11 +21,6 @@ args = ["watch", "-w", "../../shared/rust", "-w", ".", "-x", "test --features lo
 ## Dev           ##
 ###################
 
-
-[tasks.dev]
-command = "systemfd"
-args = ["--no-pid", "-s", "http::8080", "--", "cargo", "watch", "-w", "../../config/rust/src", "-w", "../../shared/rust/src", "-w", "../_core/rust/src", "-w", "-w", ".", "-x", "run --features local-quiet"]
-
 [tasks.dev-noquiet]
 command = "systemfd"
-args = ["--no-pid", "-s", "http::8080", "--", "cargo", "watch", "-w", "../../config/rust/src", "-w", "../../shared/rust/src", "-w", "../_core/rust/src", "-w", "-w", ".", "-x", "run --features local"]
+args = ["--no-pid", "-s", "http::8080", "--", "cargo", "watch", "-w", "../../config/rust/src", "-w", "../../shared/rust/src", "-w", "../_core/rust/src", "-w", "-w", ".", "-x", "run --features"]

--- a/backend/pages/src/main.rs
+++ b/backend/pages/src/main.rs
@@ -1,4 +1,4 @@
-use core::settings::SettingsManager;
+use core::settings::{self, SettingsManager};
 
 mod logger;
 mod server;
@@ -10,7 +10,12 @@ async fn main() -> anyhow::Result<()> {
 
     logger::init_logger()?;
 
-    let settings: SettingsManager = core::settings::SettingsManager::new().await?;
+    let remote_target = settings::read_remote_target()?;
 
-    server::run(settings.runtime_settings().await?).await
+    let settings = SettingsManager::new(remote_target)
+        .await?
+        .runtime_settings()
+        .await?;
+
+    server::run(settings).await
 }


### PR DESCRIPTION
reasoning:
* easier to maintain
* less binaries to produce (technically `release` and `sandbox` produce the same binary now, just executed with slightly different arguments)
