### PR TITLE
fix!: more closely follow what we wanted for the jig api

### DIFF
--- a/backend/api/migrations/20201015192354_add_jig_tables.sql
+++ b/backend/api/migrations/20201015192354_add_jig_tables.sql
@@ -1,18 +1,27 @@
 create table jig (
-    id           uuid primary key       default uuid_generate_v1mc(),
-    display_name text          not null,
-    cover        jsonb         not null,
-    ending       jsonb         not null,
+    id              uuid primary key       default uuid_generate_v1mc(),
+    display_name    text,
+    cover_id        uuid references jig (id) on delete set null,
+    ending_id       uuid references jig (id) on delete set null,
     -- The difference between the creator and the author is that the *creator* cannot be changed, and is a bit of record keeping.
     -- A author is the person currently in charge of the jig, whereas the creator is the person who was *originally* responsible for it.
-    creator_id   uuid references "user" (id) on delete set null,
-    author_id    uuid references "user" (id) on delete set null,
+    creator_id      uuid references "user" (id) on delete set null,
+    author_id       uuid references "user" (id) on delete set null,
+    created_at      timestamptz   not null default now(),
+    updated_at      timestamptz,
+    publish_at      timestamptz
+);
+
+create table module (
+    id uuid not null primary key,
     created_at   timestamptz   not null default now(),
     updated_at   timestamptz,
-    publish_at   timestamptz
+    contents jsonb
 );
 
 create table jig_module (
-    jig_id uuid  not null references jig (id) on delete cascade,
-    module jsonb not null
+    jig_id    uuid not null references jig (id) on delete cascade,
+    module_id uuid not null references module (id) on delete cascade,
+    "index"   int2 not null check("index" >= 0),
+    unique("index", jig_id) deferrable initially deferred
 );

--- a/backend/api/migrations/20201015192354_add_jig_tables.sql
+++ b/backend/api/migrations/20201015192354_add_jig_tables.sql
@@ -1,27 +1,18 @@
 create table jig (
-    id              uuid primary key       default uuid_generate_v1mc(),
-    display_name    text,
-    cover_id        uuid references jig (id) on delete set null,
-    ending_id       uuid references jig (id) on delete set null,
+    id           uuid primary key       default uuid_generate_v1mc(),
+    display_name text          not null,
+    cover        jsonb         not null,
+    ending       jsonb         not null,
     -- The difference between the creator and the author is that the *creator* cannot be changed, and is a bit of record keeping.
     -- A author is the person currently in charge of the jig, whereas the creator is the person who was *originally* responsible for it.
-    creator_id      uuid references "user" (id) on delete set null,
-    author_id       uuid references "user" (id) on delete set null,
-    created_at      timestamptz   not null default now(),
-    updated_at      timestamptz,
-    publish_at      timestamptz
-);
-
-create table module (
-    id uuid not null primary key,
+    creator_id   uuid references "user" (id) on delete set null,
+    author_id    uuid references "user" (id) on delete set null,
     created_at   timestamptz   not null default now(),
     updated_at   timestamptz,
-    contents jsonb
+    publish_at   timestamptz
 );
 
 create table jig_module (
-    jig_id    uuid not null references jig (id) on delete cascade,
-    module_id uuid not null references module (id) on delete cascade,
-    "index"   int2 not null check("index" >= 0),
-    unique("index", jig_id) deferrable initially deferred
+    jig_id uuid  not null references jig (id) on delete cascade,
+    module jsonb not null
 );

--- a/backend/api/migrations/20201023002445_fix_jig_tables.sql
+++ b/backend/api/migrations/20201023002445_fix_jig_tables.sql
@@ -1,0 +1,19 @@
+create table module (
+    id uuid not null primary key,
+    created_at   timestamptz   not null default now(),
+    updated_at   timestamptz,
+    kind         int2,
+    contents jsonb
+);
+
+alter table jig alter column display_name drop not null;
+alter table jig drop column cover;
+alter table jig drop column ending;
+alter table jig add column cover_id uuid references module(id) not null;
+alter table jig add column ending_id uuid references module(id) not null;
+
+
+alter table jig_module drop column module;
+alter table jig_module add column module_id uuid references module(id) on delete cascade;
+alter table jig_module add column "index"   int2 not null check("index" >= 0);
+alter table jig_module add unique("index", jig_id) deferrable initially deferred;

--- a/backend/api/sqlx-data.json
+++ b/backend/api/sqlx-data.json
@@ -1,18 +1,5 @@
 {
   "db": "PostgreSQL",
-  "000c1e0b4e5fa3480f332977348170c6abb8f036e467ea432197f8af584fcd56": {
-    "query": "insert into jig_module (jig_id, module) values ($1, $2)",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Jsonb"
-        ]
-      },
-      "nullable": []
-    }
-  },
   "0352a39223a9bb7c9d4c66cc673a8324a3e56ea9c6fdc1b87f2dcb8233499eb3": {
     "query": "select id as \"id: AgeRangeId\", display_name, created_at, updated_at from age_range",
     "describe": {
@@ -250,6 +237,22 @@
       ]
     }
   },
+  "19cf8c137d4072d2231ba5708f31fbd415f665a338de2473cf1aca4390e46a61": {
+    "query": "\nupdate jig\nset display_name  = coalesce($2, display_name),\n    author_id  = coalesce($3, author_id),\n    cover_id  = coalesce($4, cover_id),\n    ending_id  = coalesce($5, ending_id),\n    updated_at  = now()\nwhere id = $1\n  and (($2::text is not null and $2 is distinct from display_name) or\n       ($3::uuid is not null and $3 is distinct from author_id) or\n       ($4::uuid is not null and $4 is distinct from cover_id) or\n       ($5::uuid is not null and $5 is distinct from ending_id))",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Text",
+          "Uuid",
+          "Uuid",
+          "Uuid"
+        ]
+      },
+      "nullable": []
+    }
+  },
   "1b88f0ec5158d04c34ef416bf283ddfc0d383330b242991a77db61e9b5de948c": {
     "query": "with recursive path(id, index, parent_id) as (\n    select id, ord, null::uuid\n    from category\n             inner join unnest(\n            $1::uuid[]) with ordinality t(id, ord)\n                        using (id)\n    union all\n    select c.id, c.index, p.id\n    from path p\n             inner join category c on (c.parent_id = p.id)\n)\nselect distinct id as \"id!\",\n       path.index::int2 as \"index!\",\n       path.parent_id,\n       name,\n       created_at,\n       updated_at,\n       (select count(*) from image_category where category_id = id)::int8 as \"image_count!\",\n       0::int8                                                            as \"jig_count!\"\n\nfrom path\n         inner join category using (id);\n",
     "describe": {
@@ -455,6 +458,20 @@
       "nullable": []
     }
   },
+  "46fccf7d3c9f71b3c15e06ef08705676557e4a47ab331baed7f1754804e0eaf6": {
+    "query": "\ninsert into jig_module (jig_id, \"index\", module_id)\nvalues ($1, $2, $3)",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Int2",
+          "Uuid"
+        ]
+      },
+      "nullable": []
+    }
+  },
   "47fb0f5546e32d096bbffdd9ffd5d17be73c08c132620e2a7fae90b87dd954e1": {
     "query": "select exists(select 1 from jig where id = $1) as \"exists!\"",
     "describe": {
@@ -505,68 +522,6 @@
       ]
     }
   },
-  "4b414785d2485e524942591110d8d281dd09461ba10d78b107954a2be51247d6": {
-    "query": "\nselect \n    id as \"id: JigId\",\n    display_name,\n    cover,\n    ending,\n    creator_id,\n    author_id,\n    publish_at,\n    array(select module from jig_module where jig_id = $1) as \"modules!\"\nfrom jig\nwhere id = $1\n",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id: JigId",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 1,
-          "name": "display_name",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 2,
-          "name": "cover",
-          "type_info": "Jsonb"
-        },
-        {
-          "ordinal": 3,
-          "name": "ending",
-          "type_info": "Jsonb"
-        },
-        {
-          "ordinal": 4,
-          "name": "creator_id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 5,
-          "name": "author_id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 6,
-          "name": "publish_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 7,
-          "name": "modules!",
-          "type_info": "JsonbArray"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid"
-        ]
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        true,
-        true,
-        true,
-        null
-      ]
-    }
-  },
   "51a40f41372d3ac245973b6c148c56e71684c771e64465cf5c188241d4416d4a": {
     "query": "\nupdate category\nset index = index - 1, updated_at = now()\nwhere index > $1 and index <= $2 is not false and parent_id is not distinct from $3\n",
     "describe": {
@@ -593,23 +548,19 @@
       "nullable": []
     }
   },
-  "61491c541cfadf8755f1dbc4c0fde1091d4648fb3c6da90a23c1cd01982befff": {
-    "query": "\ninsert into jig\n    (display_name, cover, ending, creator_id, author_id, publish_at)\nvalues ($1, $2, $3, $4, $4, $5)\nreturning id\n",
+  "5c0933d2cb483f10abe3ba1d6cbdb98206ce46b06b7180c9c10abbaa726efb23": {
+    "query": "\ninsert into module (kind)\nvalues ($1)\nreturning id as \"id: ModuleId\"\n",
     "describe": {
       "columns": [
         {
           "ordinal": 0,
-          "name": "id",
+          "name": "id: ModuleId",
           "type_info": "Uuid"
         }
       ],
       "parameters": {
         "Left": [
-          "Text",
-          "Jsonb",
-          "Jsonb",
-          "Uuid",
-          "Timestamptz"
+          "Int2"
         ]
       },
       "nullable": [
@@ -653,6 +604,30 @@
       ]
     }
   },
+  "62a5573f3774ed3c06160100a4a20acd85eee9df7ec45bdc5b55633765ddcbd4": {
+    "query": "\ninsert into jig\n    (display_name, cover_id, ending_id, creator_id, author_id, publish_at)\nvalues ($1, $2, $3, $4, $4, $5)\nreturning id\n",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Uuid"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Text",
+          "Uuid",
+          "Uuid",
+          "Uuid",
+          "Timestamptz"
+        ]
+      },
+      "nullable": [
+        false
+      ]
+    }
+  },
   "636342d58945675c620fb5016f6a32bb94c463f879276812bd5440405dc67cca": {
     "query": "delete from jig_module where jig_id = $1",
     "describe": {
@@ -689,6 +664,20 @@
         false,
         true
       ]
+    }
+  },
+  "6c014a25b393085067f53d03df2616cb161fe309c1c17b1a3054fdbced3bb123": {
+    "query": "insert into jig_module (jig_id, \"index\", module_id) values ($1, $2, $3)",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Int2",
+          "Uuid"
+        ]
+      },
+      "nullable": []
     }
   },
   "6f88dced30ef38b92e48c5b78cda75cfc877dff08195c25609ad0f19ddff49cc": {
@@ -853,20 +842,78 @@
       ]
     }
   },
-  "b7e7ca18332254ae31d2c83a9204cdb199d869f5b6fc9741b4ef6916290bafcc": {
-    "query": "\nupdate jig\nset display_name        = coalesce($2, display_name),\n    author_id  = coalesce($3, author_id),\n    cover  = coalesce($4, cover),\n    ending  = coalesce($5, ending),\n    updated_at  = now()\nwhere id = $1\n  and (($2::text is not null and $2 is distinct from display_name) or\n       ($3::uuid is not null and $3 is distinct from author_id) or\n       ($4::jsonb is not null and $4 is distinct from cover) or\n       ($5::jsonb is not null and $5 is distinct from ending))",
+  "b190ecb81821a1fdd8e475f05cfeb181c207ecb91f15d7daaf7fd664c51a1d86": {
+    "query": "\nselect id                                             as \"id: JigId\",\n       display_name,\n       cover_id                                       as \"cover_id: ModuleId\",\n       (select kind from module where id = cover_id)  as \"cover_kind: ModuleKind\",\n       ending_id                                      as \"ending_id: ModuleId\",\n       (select kind from module where id = ending_id) as \"ending_kind: ModuleKind\",\n       creator_id,\n       author_id,\n       publish_at,\n       array(select row (module_id, kind)\n             from jig_module\n                      inner join module on module_id = module.id\n             where jig_id = $1\n             order by \"index\")                        as \"modules!: Vec<(ModuleId, Option<ModuleKind>)>\"\nfrom jig\nwhere id = $1",
     "describe": {
-      "columns": [],
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id: JigId",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 1,
+          "name": "display_name",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 2,
+          "name": "cover_id: ModuleId",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 3,
+          "name": "cover_kind: ModuleKind",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 4,
+          "name": "ending_id: ModuleId",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 5,
+          "name": "ending_kind: ModuleKind",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 6,
+          "name": "creator_id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 7,
+          "name": "author_id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 8,
+          "name": "publish_at",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 9,
+          "name": "modules!: Vec<(ModuleId, Option<ModuleKind>)>",
+          "type_info": "RecordArray"
+        }
+      ],
       "parameters": {
         "Left": [
-          "Uuid",
-          "Text",
-          "Uuid",
-          "Jsonb",
-          "Jsonb"
+          "Uuid"
         ]
       },
-      "nullable": []
+      "nullable": [
+        false,
+        true,
+        false,
+        null,
+        false,
+        null,
+        true,
+        true,
+        true,
+        null
+      ]
     }
   },
   "b8c3158be83930526198c18609e10617952b2e57fe7f73c1f5e8b2068baf8f10": {

--- a/backend/api/src/db/jig.rs
+++ b/backend/api/src/db/jig.rs
@@ -1,7 +1,28 @@
+use std::borrow::Cow;
+
 use chrono::{DateTime, Utc};
-use shared::domain::jig::{Jig, JigId, ModuleId};
-use sqlx::PgPool;
+use shared::domain::jig::{Jig, JigId, LiteModule, ModuleId, ModuleKind};
+use sqlx::{PgConnection, PgPool};
 use uuid::Uuid;
+
+// todo: move this to a `module` mod.
+async fn module_of_kind(
+    conn: &mut PgConnection,
+    kind: Option<ModuleKind>,
+) -> anyhow::Result<ModuleId> {
+    sqlx::query!(
+        r#"
+insert into module (kind)
+values ($1)
+returning id as "id: ModuleId"
+"#,
+        kind.map(|it| it as i16)
+    )
+    .fetch_one(&mut *conn)
+    .await
+    .map(|it| it.id)
+    .map_err(Into::into)
+}
 
 pub async fn create(
     pool: &PgPool,
@@ -13,6 +34,22 @@ pub async fn create(
     publish_at: Option<DateTime<Utc>>,
 ) -> anyhow::Result<JigId> {
     let mut transaction = pool.begin().await?;
+
+    let cover_id = match cover_id {
+        Some(id) => id,
+        None => module_of_kind(&mut transaction, Some(ModuleKind::DesignPage)).await?,
+    };
+
+    let ending_id = match ending_id {
+        Some(id) => id,
+        None => module_of_kind(&mut transaction, Some(ModuleKind::DesignPage)).await?,
+    };
+
+    let module_ids = match module_ids.is_empty() {
+        false => Cow::Borrowed(module_ids),
+        true => Cow::Owned(vec![module_of_kind(&mut transaction, None).await?]),
+    };
+
     let jig = sqlx::query!(
         r#"
 insert into jig
@@ -21,8 +58,8 @@ values ($1, $2, $3, $4, $4, $5)
 returning id
 "#,
         display_name,
-        cover_id.map(|it| it.0),
-        ending_id.map(|it| it.0),
+        cover_id.0,
+        ending_id.0,
         creator_id,
         publish_at
     )
@@ -32,7 +69,9 @@ returning id
     // todo: batch
     for (idx, module_id) in module_ids.iter().enumerate() {
         sqlx::query!(
-            r#"insert into jig_module (jig_id, "index", module_id) values ($1, $2, $3)"#,
+            r#"
+insert into jig_module (jig_id, "index", module_id)
+values ($1, $2, $3)"#,
             jig.id,
             idx as i16,
             module_id.0
@@ -49,18 +88,22 @@ returning id
 pub async fn get(pool: &PgPool, id: JigId) -> anyhow::Result<Option<Jig>> {
     let jig = sqlx::query!(
         r#"
-select 
-    id as "id: JigId",
-    display_name,
-    cover_id,
-    ending_id,
-    creator_id,
-    author_id,
-    publish_at,
-    array(select module_id from jig_module where jig_id = $1 order by "index") as "module_ids!"
+select id                                             as "id: JigId",
+       display_name,
+       cover_id                                       as "cover_id: ModuleId",
+       (select kind from module where id = cover_id)  as "cover_kind: ModuleKind",
+       ending_id                                      as "ending_id: ModuleId",
+       (select kind from module where id = ending_id) as "ending_kind: ModuleKind",
+       creator_id,
+       author_id,
+       publish_at,
+       array(select row (module_id, kind)
+             from jig_module
+                      inner join module on module_id = module.id
+             where jig_id = $1
+             order by "index")                        as "modules!: Vec<(ModuleId, Option<ModuleKind>)>"
 from jig
-where id = $1
-"#,
+where id = $1"#,
         id.0
     )
     .fetch_optional(pool)
@@ -68,9 +111,17 @@ where id = $1
     .map(|row| Jig {
         id: row.id,
         display_name: row.display_name,
-        cover_id: row.cover_id.map(ModuleId),
-        ending_id: row.ending_id.map(ModuleId),
-        module_ids: row.module_ids.into_iter().map(ModuleId).collect(),
+        cover: LiteModule {
+            id: row.cover_id,
+            kind: row.cover_kind,
+        },
+        ending: LiteModule {
+            id: row.ending_id,
+            kind: row.ending_kind,
+        },
+        modules: row.modules.into_iter().map(|(id, kind)| LiteModule {
+            id, kind
+        }).collect(),
         creator_id: row.creator_id,
         author_id: row.author_id,
         publish_at: row.publish_at,

--- a/backend/api/src/db/jig.rs
+++ b/backend/api/src/db/jig.rs
@@ -1,14 +1,14 @@
 use chrono::{DateTime, Utc};
-use shared::domain::jig::{Jig, JigId};
+use shared::domain::jig::{Jig, JigId, ModuleId};
 use sqlx::PgPool;
 use uuid::Uuid;
 
 pub async fn create(
     pool: &PgPool,
-    display_name: &str,
-    cover: &serde_json::Value,
-    modules: &[serde_json::Value],
-    ending: &serde_json::Value,
+    display_name: Option<&str>,
+    cover_id: Option<ModuleId>,
+    module_ids: &[ModuleId],
+    ending_id: Option<ModuleId>,
     creator_id: Uuid,
     publish_at: Option<DateTime<Utc>>,
 ) -> anyhow::Result<JigId> {
@@ -16,13 +16,13 @@ pub async fn create(
     let jig = sqlx::query!(
         r#"
 insert into jig
-    (display_name, cover, ending, creator_id, author_id, publish_at)
+    (display_name, cover_id, ending_id, creator_id, author_id, publish_at)
 values ($1, $2, $3, $4, $4, $5)
 returning id
 "#,
         display_name,
-        cover,
-        ending,
+        cover_id.map(|it| it.0),
+        ending_id.map(|it| it.0),
         creator_id,
         publish_at
     )
@@ -30,11 +30,12 @@ returning id
     .await?;
 
     // todo: batch
-    for module in modules {
+    for (idx, module_id) in module_ids.iter().enumerate() {
         sqlx::query!(
-            "insert into jig_module (jig_id, module) values ($1, $2)",
+            r#"insert into jig_module (jig_id, "index", module_id) values ($1, $2, $3)"#,
             jig.id,
-            module
+            idx as i16,
+            module_id.0
         )
         .execute(&mut transaction)
         .await?;
@@ -46,26 +47,36 @@ returning id
 }
 
 pub async fn get(pool: &PgPool, id: JigId) -> anyhow::Result<Option<Jig>> {
-    sqlx::query_as!(
-        Jig,
+    let jig = sqlx::query!(
         r#"
 select 
     id as "id: JigId",
     display_name,
-    cover,
-    ending,
+    cover_id,
+    ending_id,
     creator_id,
     author_id,
     publish_at,
-    array(select module from jig_module where jig_id = $1) as "modules!"
+    array(select module_id from jig_module where jig_id = $1 order by "index") as "module_ids!"
 from jig
 where id = $1
 "#,
         id.0
     )
     .fetch_optional(pool)
-    .await
-    .map_err(Into::into)
+    .await?
+    .map(|row| Jig {
+        id: row.id,
+        display_name: row.display_name,
+        cover_id: row.cover_id.map(ModuleId),
+        ending_id: row.ending_id.map(ModuleId),
+        module_ids: row.module_ids.into_iter().map(ModuleId).collect(),
+        creator_id: row.creator_id,
+        author_id: row.author_id,
+        publish_at: row.publish_at,
+    });
+
+    Ok(jig)
 }
 
 pub async fn update(
@@ -73,9 +84,9 @@ pub async fn update(
     id: JigId,
     display_name: Option<&str>,
     author_id: Option<Uuid>,
-    cover: Option<&serde_json::Value>,
-    modules: Option<&[serde_json::Value]>,
-    ending: Option<&serde_json::Value>,
+    cover_id: Option<ModuleId>,
+    modules: Option<&[ModuleId]>,
+    ending_id: Option<ModuleId>,
     publish_at: Option<Option<DateTime<Utc>>>,
 ) -> anyhow::Result<bool> {
     let mut transaction = pool.begin().await?;
@@ -106,34 +117,35 @@ where id = $1 and $2 is distinct from publish_at"#,
     sqlx::query!(
         r#"
 update jig
-set display_name        = coalesce($2, display_name),
+set display_name  = coalesce($2, display_name),
     author_id  = coalesce($3, author_id),
-    cover  = coalesce($4, cover),
-    ending  = coalesce($5, ending),
+    cover_id  = coalesce($4, cover_id),
+    ending_id  = coalesce($5, ending_id),
     updated_at  = now()
 where id = $1
   and (($2::text is not null and $2 is distinct from display_name) or
        ($3::uuid is not null and $3 is distinct from author_id) or
-       ($4::jsonb is not null and $4 is distinct from cover) or
-       ($5::jsonb is not null and $5 is distinct from ending))"#,
+       ($4::uuid is not null and $4 is distinct from cover_id) or
+       ($5::uuid is not null and $5 is distinct from ending_id))"#,
         id.0,
         display_name,
         author_id,
-        cover,
-        ending
+        cover_id.map(|it| it.0),
+        ending_id.map(|it| it.0)
     )
     .execute(&mut transaction)
     .await?;
-    if let Some(modules) = modules {
+    if let Some(module_ids) = modules {
         sqlx::query!("delete from jig_module where jig_id = $1", id.0)
             .execute(&mut transaction)
             .await?;
 
-        for module in modules {
+        for (idx, module_id) in module_ids.iter().enumerate() {
             sqlx::query!(
-                "insert into jig_module (jig_id, module) values ($1, $2)",
+                r#"insert into jig_module (jig_id, "index", module_id) values ($1, $2, $3)"#,
                 id.0,
-                module
+                idx as i16,
+                module_id.0
             )
             .execute(&mut transaction)
             .await?;

--- a/backend/api/src/http/endpoints/jig.rs
+++ b/backend/api/src/http/endpoints/jig.rs
@@ -3,7 +3,14 @@ use actix_web::{
     HttpResponse,
 };
 use chrono::{DateTime, Utc};
-use shared::{api::{endpoints::jig, ApiEndpoint}, domain::jig::CreateResponse, domain::jig::GetResponse, domain::jig::{CreateRequest, JigId}, error::GetError, error::jig::UpdateError};
+use shared::{
+    api::{endpoints::jig, ApiEndpoint},
+    domain::jig::CreateResponse,
+    domain::jig::GetResponse,
+    domain::jig::{CreateRequest, JigId},
+    error::jig::UpdateError,
+    error::GetError,
+};
 use sqlx::PgPool;
 
 use crate::{

--- a/shared/rust/src/domain/jig.rs
+++ b/shared/rust/src/domain/jig.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-/// Wrapper type around [`Uuid`], represents the ID of a image.
+/// Wrapper type around [`Uuid`], represents the ID of a JIG.
 ///
 /// [`Uuid`]: ../../uuid/struct.Uuid.html
 #[derive(Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
@@ -13,22 +13,40 @@ use uuid::Uuid;
 #[cfg_attr(feature = "backend", sqlx(transparent))]
 pub struct JigId(pub Uuid);
 
+/// Wrapper type around [`Uuid`], represents the ID of a module.
+///
+/// [`Uuid`]: ../../uuid/struct.Uuid.html
+#[derive(Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "backend", derive(sqlx::Type))]
+#[cfg_attr(feature = "backend", sqlx(transparent))]
+pub struct ModuleId(pub Uuid);
+
 /// Request to create a new JIG.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Default)]
 pub struct CreateRequest {
     /// The JIG's name.
-    pub display_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub display_name: Option<String>,
 
     /// The JIG's cover module.
-    pub cover: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub cover: Option<ModuleId>,
 
     /// The JIG's ending module.
-    pub ending: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub ending: Option<ModuleId>,
 
     /// The JIG's remaining modules.
-    pub modules: Vec<serde_json::Value>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    pub modules: Vec<ModuleId>,
 
     /// When the JIG should be considered published (if at all).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub publish_at: Option<Publish>,
 }
 
@@ -49,13 +67,13 @@ pub struct Jig {
     pub display_name: String,
 
     /// The JIG's cover module.
-    pub cover: serde_json::Value,
+    pub cover_id: Option<ModuleId>,
 
     /// The JIG's ending module.
-    pub ending: serde_json::Value,
+    pub ending_id: Option<ModuleId>,
 
     /// The JIG's remaining modules.
-    pub modules: Vec<serde_json::Value>,
+    pub module_ids: Vec<ModuleId>,
 
     /// The ID of the JIG's original creator (`None` if unknown).
     pub creator_id: Option<Uuid>,
@@ -85,17 +103,17 @@ pub struct UpdateRequest {
     /// The JIG's cover module.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
-    pub cover: Option<serde_json::Value>,
+    pub cover: Option<ModuleId>,
 
     /// The JIG's ending module.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
-    pub ending: Option<serde_json::Value>,
+    pub ending: Option<ModuleId>,
 
     /// The JIG's remaining modules.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
-    pub modules: Option<Vec<serde_json::Value>>,
+    pub modules: Option<Vec<ModuleId>>,
 
     /// The current author
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/shared/rust/src/domain/jig.rs
+++ b/shared/rust/src/domain/jig.rs
@@ -64,16 +64,16 @@ pub struct Jig {
     pub id: JigId,
 
     /// The JIG's name.
-    pub display_name: String,
+    pub display_name: Option<String>,
 
     /// The JIG's cover module.
-    pub cover_id: Option<ModuleId>,
+    pub cover: LiteModule,
 
     /// The JIG's ending module.
-    pub ending_id: Option<ModuleId>,
+    pub ending: LiteModule,
 
     /// The JIG's remaining modules.
-    pub module_ids: Vec<ModuleId>,
+    pub modules: Vec<LiteModule>,
 
     /// The ID of the JIG's original creator (`None` if unknown).
     pub creator_id: Option<Uuid>,
@@ -83,6 +83,31 @@ pub struct Jig {
 
     /// When the JIG should be considered published (if at all).
     pub publish_at: Option<DateTime<Utc>>,
+}
+
+/// Represents the various kinds of data a module can represent.
+#[repr(i16)]
+#[cfg_attr(feature = "backend", derive(sqlx::Type))]
+#[derive(Serialize, Deserialize, Debug)]
+pub enum ModuleKind {
+    /// The module represents a Poster.
+    Poster = 0,
+
+    /// The module represents a Memory Game.
+    MemoryGame = 1,
+
+    /// The module represents the first / last page of a jig.
+    DesignPage = 2,
+}
+
+/// Minimal information about a module.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct LiteModule {
+    /// The module's ID.
+    pub id: ModuleId,
+
+    /// Which kind of module this is.
+    pub kind: Option<ModuleKind>,
 }
 
 /// The response returned when a request for `GET`ing a jig is successful.


### PR DESCRIPTION
fixes a inconsistency caused by a premature merge of #222, pending on the answer to
> When we return a jig, should we fetch the modules as `Vec<Module>` (plus `cover: Option<Module>` and `end` as the same) or should we just return the IDs

What this PR does:
* gives jigs a "default" (you can create them without them having basically anything)
* this causes fallout in the `GET` route, since more things can be null
* returns `ModuleId` for modules instead of `serde_json::Value` (the above question is in reference to this)
* allows re-ordering of modules by `PATCH`ing a jig and changing around the order

This unfortunately means that it's impossible to create modules again, I figured getting this done right away was more effective, given that I can add modules easily and without breaking anything.

edit: most recent commit:
* return a `LiteModule` which has both a ModuleId and `ModuleKind`
* jig default now creates cover/ending modules + a single module.