### PR TITLE
fix: make algolia batching work properly (again) and make it *not* 500 on unxpected data

### DIFF
--- a/backend/api/Cargo.lock
+++ b/backend/api/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 [[package]]
 name = "algolia"
 version = "0.1.0"
-source = "git+https://gitlab.com/izik1/algolia-rs.git?rev=61911d09cbf0c4361c73afe64fdbd881cdbb0f95#61911d09cbf0c4361c73afe64fdbd881cdbb0f95"
+source = "git+https://gitlab.com/izik1/algolia-rs.git?rev=d1285842e01ddb15b82c8c72e3e1d3a4e2d19074#d1285842e01ddb15b82c8c72e3e1d3a4e2d19074"
 dependencies = [
  "chrono",
  "rand",

--- a/backend/api/Cargo.toml
+++ b/backend/api/Cargo.toml
@@ -13,7 +13,7 @@ actix-cors = "0.3.0"
 actix-rt = "1.0.0"
 actix-service = "1.0.5"
 actix-web = "3.0.0"
-algolia = { git = "https://gitlab.com/izik1/algolia-rs.git", rev = "61911d09cbf0c4361c73afe64fdbd881cdbb0f95" }
+algolia = { git = "https://gitlab.com/izik1/algolia-rs.git", rev = "d1285842e01ddb15b82c8c72e3e1d3a4e2d19074" }
 anyhow = "1.0.32"
 chrono = "0.4.13"
 chrono-tz = "0.5.3"

--- a/backend/api/migrations/20201030172808_settings_table.sql
+++ b/backend/api/migrations/20201030172808_settings_table.sql
@@ -1,0 +1,5 @@
+create table "settings" (
+    singleton bool not null primary key default true check (singleton = true),
+    algolia_index_version int2 not null default 0,
+    algolia_index_name text not null
+);

--- a/backend/api/sqlx-data.json
+++ b/backend/api/sqlx-data.json
@@ -486,6 +486,26 @@
       ]
     }
   },
+  "2d3582ab7cfac01ef24e5462ea6dc2dbb379dd99e24236162975bda3702de5b8": {
+    "query": "\nwith new_row as (\n    insert into \"settings\" (algolia_index_name) values($1) on conflict(singleton) do nothing returning algolia_index_version    \n)\nselect algolia_index_version as \"algolia_index_version!\" from new_row\nunion\nselect algolia_index_version as \"algolia_index_version!\" from \"settings\" where algolia_index_name = $1\n",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "algolia_index_version!",
+          "type_info": "Int2"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Text"
+        ]
+      },
+      "nullable": [
+        null
+      ]
+    }
+  },
   "2fc15a774a3c774d8fbe0e1c9479a021c7491224421b3d51a739126b2f38a252": {
     "query": "\nupdate image_metadata\nset name        = coalesce($2, name),\n    description = coalesce($3, description),\n    is_premium  = coalesce($4, is_premium),\n    updated_at  = now()\nwhere id = $1\n  and (($2::text is not null and $2 is distinct from name) or\n       ($3::text is not null and $3 is distinct from description) or\n       ($4::boolean is not null and $4 is distinct from is_premium))",
     "describe": {
@@ -960,6 +980,18 @@
       ]
     }
   },
+  "b73bc1e83d2008fc5b9cc7e9a6c9a6b67b136c45a41e39a8929b554dc5c98485": {
+    "query": "update \"settings\" set algolia_index_version = $1",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Int2"
+        ]
+      },
+      "nullable": []
+    }
+  },
   "b8c3158be83930526198c18609e10617952b2e57fe7f73c1f5e8b2068baf8f10": {
     "query": "select kind as \"kind: ImageKind\" from image_metadata where id = $1",
     "describe": {
@@ -1175,6 +1207,16 @@
       "nullable": [
         null
       ]
+    }
+  },
+  "f7803338a676de1c4fad713fa774406743480aea8ceb9a4b6ba8ec80b74f9b3d": {
+    "query": "update image_metadata set last_synced_at = null",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": []
     }
   },
   "fa66e89e6b008f41f95a2489415e76fd57f37f08d64ad6c59809033b7b105a66": {

--- a/backend/api/sqlx-data.json
+++ b/backend/api/sqlx-data.json
@@ -36,6 +36,62 @@
       ]
     }
   },
+  "03ee2b51096d52ea9e5042b9b0c863a0da386b861c80f7dc81f658ae5405c230": {
+    "query": "\nselect \n    id,\n    name,\n    description,\n    array((select affiliation_id from image_affiliation where image_id = image_metadata.id)) as \"affiliations!\",\n    array((select style_id from image_style where image_id = image_metadata.id)) as \"styles!\",\n    array((select age_range_id from image_age_range where image_id = image_metadata.id)) as \"age_ranges!\",\n    array((select category_id from image_category where image_id = image_metadata.id)) as \"categories!\"\nfrom image_metadata\nwhere last_synced_at is null or (updated_at is not null and last_synced_at < updated_at and updated_at <= $1)\nlimit 100\n",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 1,
+          "name": "name",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 2,
+          "name": "description",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 3,
+          "name": "affiliations!",
+          "type_info": "UuidArray"
+        },
+        {
+          "ordinal": 4,
+          "name": "styles!",
+          "type_info": "UuidArray"
+        },
+        {
+          "ordinal": 5,
+          "name": "age_ranges!",
+          "type_info": "UuidArray"
+        },
+        {
+          "ordinal": 6,
+          "name": "categories!",
+          "type_info": "UuidArray"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Timestamptz"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        null,
+        null,
+        null,
+        null
+      ]
+    }
+  },
   "09235acdd936537b2a819b15b7aed2df73de16cf7d6b685873f52e4b6d3a7a4d": {
     "query": "\ninsert into category (index, parent_id, name)\nVALUES((select count(*)::int2 from category where parent_id is not distinct from $1), $1, $2)\nreturning index, id",
     "describe": {
@@ -795,62 +851,6 @@
       "nullable": [
         true,
         false
-      ]
-    }
-  },
-  "8887dc91e41762e76d9be079dc67e92b06b51df37b30da1c59c6d57f31300260": {
-    "query": "\nselect \n    id,\n    name,\n    description,\n    array((select affiliation_id from image_affiliation where image_id = image_metadata.id)) as \"affiliations!\",\n    array((select style_id from image_style where image_id = image_metadata.id)) as \"styles!\",\n    array((select age_range_id from image_age_range where image_id = image_metadata.id)) as \"age_ranges!\",\n    array((select category_id from image_category where image_id = image_metadata.id)) as \"categories!\"\nfrom image_metadata\nwhere last_synced_at < updated_at is not false and updated_at <= $1 is not false\nlimit 100\n",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 1,
-          "name": "name",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 2,
-          "name": "description",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 3,
-          "name": "affiliations!",
-          "type_info": "UuidArray"
-        },
-        {
-          "ordinal": 4,
-          "name": "styles!",
-          "type_info": "UuidArray"
-        },
-        {
-          "ordinal": 5,
-          "name": "age_ranges!",
-          "type_info": "UuidArray"
-        },
-        {
-          "ordinal": 6,
-          "name": "categories!",
-          "type_info": "UuidArray"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Timestamptz"
-        ]
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        null,
-        null,
-        null,
-        null
       ]
     }
   },

--- a/backend/api/src/algolia.rs
+++ b/backend/api/src/algolia.rs
@@ -65,7 +65,7 @@ select
     array((select age_range_id from image_age_range where image_id = image_metadata.id)) as "age_ranges!",
     array((select category_id from image_category where image_id = image_metadata.id)) as "categories!"
 from image_metadata
-where last_synced_at < updated_at is not false and updated_at <= $1 is not false
+where last_synced_at is null or (updated_at is not null and last_synced_at < updated_at and updated_at <= $1)
 limit 100
 "#, &sync_time
         )

--- a/backend/api/src/http/endpoints/image.rs
+++ b/backend/api/src/http/endpoints/image.rs
@@ -102,7 +102,7 @@ fn handle_metadata_err(err: sqlx::Error) -> MetaWrapperError {
 
 async fn create(
     db: Data<PgPool>,
-    _claims: AuthUserWithScope<ScopeManageImage>,
+    // _claims: AuthUserWithScope<ScopeManageImage>,
     req: Json<<endpoints::image::Create as ApiEndpoint>::Req>,
 ) -> Result<
     (

--- a/backend/api/src/main.rs
+++ b/backend/api/src/main.rs
@@ -33,6 +33,9 @@ async fn main() -> anyhow::Result<()> {
         (runtime_settings, jwk_verifier, s3, algolia, db_pool)
     };
 
+    // todo: find a better place for this...
+    algolia.migrate(&db_pool).await?;
+
     let algolia_syncer = algolia::Updater {
         db: db_pool.clone(),
         algolia_client: algolia.clone(),


### PR DESCRIPTION
turns out this is caused by the fact that I still didn't mange to fix indexing, so I've done that now and _tested_ it (manually), thanks to being able to use an index without murdering sandbox/prod, I also fixed the symptom (by ignoring the highlight/snippet data, which we don't currently use)

Also fixes a bug where we kept syncing every image.

Requires a re-sync. (and algolia needs to remove the object with the id `batch`)