### PR TITLE
feat: allow media urls to be inferred from the media's ID

### DIFF
--- a/backend/api/src/http/endpoints/image.rs
+++ b/backend/api/src/http/endpoints/image.rs
@@ -3,7 +3,7 @@ use crate::{
     db::{self, nul_if_empty},
     extractor::{AuthUserWithScope, ScopeManageImage, WrapAuthClaimsNoDb},
     image_ops::generate_images,
-    s3::{S3Client, S3LibraryKind, S3MediaVariant},
+    s3::S3Client,
 };
 use actix_web::{
     http::{self, StatusCode},
@@ -22,17 +22,14 @@ use shared::{
         image::{CreateError, SearchError, UpdateError, UploadError},
         DeleteError, GetError,
     },
+    media::MediaLibraryKind,
+    media::MediaVariant,
 };
 use sqlx::{postgres::PgDatabaseError, PgPool};
 use uuid::Uuid;
 
 pub mod user {
-    use crate::{
-        db,
-        extractor::WrapAuthClaimsNoDb,
-        image_ops::generate_images,
-        s3::{S3Client, S3LibraryKind, S3MediaVariant},
-    };
+    use crate::{db, extractor::WrapAuthClaimsNoDb, image_ops::generate_images, s3::S3Client};
     use actix_web::{
         http,
         web::{Bytes, Data, Json, Path},
@@ -49,6 +46,8 @@ pub mod user {
             CreateResponse,
         },
         error::{image::UploadError, GetError},
+        media::MediaLibraryKind,
+        media::MediaVariant,
     };
     use sqlx::PgPool;
 
@@ -87,7 +86,7 @@ pub mod user {
         .await?;
 
         let (original, resized, thumbnail) = res?;
-        s3.upload_images(S3LibraryKind::User, id, original, resized, thumbnail)
+        s3.upload_images(MediaLibraryKind::User, id, original, resized, thumbnail)
             .await?;
 
         Ok(HttpResponse::NoContent().into())
@@ -104,11 +103,11 @@ pub mod user {
             .await
             .map_err(super::check_conflict_delete)?;
 
-        let delete_image = |kind| s3.delete_image(S3LibraryKind::Global, kind, image);
+        let delete_image = |kind| s3.delete_image(MediaLibraryKind::Global, kind, image);
         let ((), (), ()) = futures::future::join3(
-            delete_image(S3MediaVariant::Original),
-            delete_image(S3MediaVariant::Resized),
-            delete_image(S3MediaVariant::Thumbnail),
+            delete_image(MediaVariant::Original),
+            delete_image(MediaVariant::Resized),
+            delete_image(MediaVariant::Thumbnail),
         )
         .await;
 
@@ -117,7 +116,6 @@ pub mod user {
 
     pub(super) async fn get(
         db: Data<PgPool>,
-        s3: Data<S3Client>,
         _claims: WrapAuthClaimsNoDb,
         req: Path<ImageId>,
     ) -> Result<
@@ -128,22 +126,11 @@ pub mod user {
             .await?
             .ok_or(GetError::NotFound)?;
 
-        let id = metadata.id;
-
-        Ok(Json(GetResponse {
-            metadata,
-            url: s3.image_presigned_get_url(S3LibraryKind::Global, S3MediaVariant::Resized, id)?,
-            thumbnail_url: s3.image_presigned_get_url(
-                S3LibraryKind::Global,
-                S3MediaVariant::Thumbnail,
-                id,
-            )?,
-        }))
+        Ok(Json(GetResponse { metadata }))
     }
 
     pub(super) async fn list(
         db: Data<PgPool>,
-        s3: Data<S3Client>,
         _claims: WrapAuthClaimsNoDb,
     ) -> Result<
         Json<<endpoints::image::user::List as ApiEndpoint>::Res>,
@@ -151,21 +138,7 @@ pub mod user {
     > {
         let images: Vec<_> = db::image::user::list(db.as_ref())
             .err_into::<GetError>()
-            .and_then(|metadata: UserImage| async {
-                Ok(GetResponse {
-                    url: s3.image_presigned_get_url(
-                        S3LibraryKind::Global,
-                        S3MediaVariant::Resized,
-                        metadata.id,
-                    )?,
-                    thumbnail_url: s3.image_presigned_get_url(
-                        S3LibraryKind::Global,
-                        S3MediaVariant::Thumbnail,
-                        metadata.id,
-                    )?,
-                    metadata,
-                })
-            })
+            .and_then(|metadata: UserImage| async { Ok(GetResponse { metadata }) })
             .try_collect()
             .await?;
 
@@ -300,7 +273,7 @@ async fn upload(
     .await?;
 
     let (original, resized, thumbnail) = res?;
-    s3.upload_images(S3LibraryKind::Global, id, original, resized, thumbnail)
+    s3.upload_images(MediaLibraryKind::Global, id, original, resized, thumbnail)
         .await?;
 
     Ok(HttpResponse::NoContent().into())
@@ -308,7 +281,6 @@ async fn upload(
 
 async fn get_one(
     db: Data<PgPool>,
-    s3: Data<S3Client>,
     _claims: WrapAuthClaimsNoDb,
     req: Path<ImageId>,
 ) -> Result<
@@ -319,22 +291,11 @@ async fn get_one(
         .await?
         .ok_or(GetError::NotFound)?;
 
-    let id = metadata.id;
-
-    Ok(Json(GetResponse {
-        metadata,
-        url: s3.image_presigned_get_url(S3LibraryKind::Global, S3MediaVariant::Resized, id)?,
-        thumbnail_url: s3.image_presigned_get_url(
-            S3LibraryKind::Global,
-            S3MediaVariant::Thumbnail,
-            id,
-        )?,
-    }))
+    Ok(Json(GetResponse { metadata }))
 }
 
 async fn get(
     db: Data<PgPool>,
-    s3: Data<S3Client>,
     algolia: Data<AlgoliaClient>,
     _claims: WrapAuthClaimsNoDb,
     query: Option<Query<<endpoints::image::Search as ApiEndpoint>::Req>>,
@@ -359,21 +320,7 @@ async fn get(
 
     let images: Vec<_> = db::image::get(db.as_ref(), &ids)
         .err_into::<SearchError>()
-        .and_then(|metadata: Image| async {
-            Ok(GetResponse {
-                url: s3.image_presigned_get_url(
-                    S3LibraryKind::Global,
-                    S3MediaVariant::Resized,
-                    metadata.id,
-                )?,
-                thumbnail_url: s3.image_presigned_get_url(
-                    S3LibraryKind::Global,
-                    S3MediaVariant::Thumbnail,
-                    metadata.id,
-                )?,
-                metadata,
-            })
-        })
+        .and_then(|metadata: Image| async { Ok(GetResponse { metadata }) })
         .try_collect()
         .await?;
 
@@ -441,11 +388,11 @@ async fn delete(
         .await
         .map_err(check_conflict_delete)?;
 
-    let delete_image = |kind| s3.delete_image(S3LibraryKind::Global, kind, image);
+    let delete_image = |kind| s3.delete_image(MediaLibraryKind::Global, kind, image);
     let ((), (), (), ()) = futures::future::join4(
-        delete_image(S3MediaVariant::Original),
-        delete_image(S3MediaVariant::Resized),
-        delete_image(S3MediaVariant::Thumbnail),
+        delete_image(MediaVariant::Original),
+        delete_image(MediaVariant::Resized),
+        delete_image(MediaVariant::Thumbnail),
         algolia.delete_image(image),
     )
     .await;

--- a/shared/rust/src/domain/audio.rs
+++ b/shared/rust/src/domain/audio.rs
@@ -6,7 +6,6 @@ use uuid::Uuid;
 /// Types for user audio library.
 pub mod user {
     use serde::{Deserialize, Serialize};
-    use url::Url;
 
     use super::AudioId;
 
@@ -22,9 +21,6 @@ pub mod user {
     pub struct GetResponse {
         /// The audio file's metadata.
         pub metadata: UserAudio,
-
-        /// A url that can be used to retrieve the audio file.
-        pub url: Url,
     }
 
     /// Over the wire representation of an audio file's metadata.

--- a/shared/rust/src/domain/image.rs
+++ b/shared/rust/src/domain/image.rs
@@ -9,13 +9,12 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "backend")]
 use sqlx::postgres::PgRow;
-use url::Url;
+
 use uuid::Uuid;
 
 /// Types for user image library.
 pub mod user {
     use serde::{Deserialize, Serialize};
-    use url::Url;
 
     use super::ImageId;
 
@@ -31,12 +30,6 @@ pub mod user {
     pub struct GetResponse {
         /// The image metadata.
         pub metadata: UserImage,
-
-        /// A url that can be used to retrieve the image.
-        pub url: Url,
-
-        /// A url that can be used to retrieve a thumbnail of the image.
-        pub thumbnail_url: Url,
     }
 
     /// Over the wire representation of an image's metadata.
@@ -227,12 +220,6 @@ pub struct SearchResponse {
 pub struct GetResponse {
     /// The image metadata.
     pub metadata: Image,
-
-    /// A url that can be used to retrieve the image.
-    pub url: Url,
-
-    /// A url that can be used to retrieve a thumbnail of the image.
-    pub thumbnail_url: Url,
 }
 
 /// Over the wire representation of an image's metadata.

--- a/shared/rust/src/lib.rs
+++ b/shared/rust/src/lib.rs
@@ -5,3 +5,4 @@
 pub mod api;
 pub mod domain;
 pub mod error;
+pub mod media;

--- a/shared/rust/src/media.rs
+++ b/shared/rust/src/media.rs
@@ -1,0 +1,121 @@
+//! Mostly contains functions for getting the `key`/url of media stored in s3.
+
+use uuid::Uuid;
+
+use crate::domain::{audio::AudioId, image::ImageId};
+
+/// Media Kinds
+#[derive(Debug, Clone, Copy)]
+pub enum MediaKind {
+    /// Media is audio
+    Audio,
+
+    /// Media is an image
+    Image,
+}
+
+impl MediaKind {
+    /// returns `self` in a string representation.
+    pub fn to_str(self) -> &'static str {
+        match self {
+            Self::Audio => "audio",
+            Self::Image => "image",
+        }
+    }
+}
+
+/// Media Variants
+#[derive(Debug, Copy, Clone)]
+pub enum MediaVariant {
+    /// The original media
+    Original,
+
+    /// The resized media (for images)
+    Resized,
+
+    /// A thumbnail of the media (for images)
+    Thumbnail,
+}
+
+impl MediaVariant {
+    /// returns `self` in a string representation.
+    pub const fn to_str(self) -> &'static str {
+        match self {
+            Self::Original => "original",
+            Self::Resized => "resized",
+            Self::Thumbnail => "thumbnail",
+        }
+    }
+}
+
+/// Media Libraries
+#[derive(Debug, Copy, Clone)]
+pub enum MediaLibraryKind {
+    /// The default / global library
+    Global,
+
+    /// The user library
+    User,
+
+    /// The web library
+    Web,
+}
+
+impl MediaLibraryKind {
+    const fn image_prefix(self) -> &'static str {
+        match self {
+            Self::Global => "image",
+            Self::User => "image-user",
+            Self::Web => "image-web",
+        }
+    }
+
+    const fn audio_prefix(self) -> &'static str {
+        match self {
+            Self::Global => "audio/global",
+            Self::User => "audio/user",
+            Self::Web => "audio/web",
+        }
+    }
+
+    const fn prefix(self, media_kind: MediaKind) -> &'static str {
+        match media_kind {
+            MediaKind::Audio => self.audio_prefix(),
+            MediaKind::Image => self.image_prefix(),
+        }
+    }
+}
+
+fn id_to_key_inner(prefix: &str, variant: MediaVariant, id: Uuid) -> String {
+    format!("{}/{}/{}", prefix, variant.to_str(), id.to_hyphenated())
+}
+
+/// gives the key for a image with the given parameters
+/// this is *not* a full url, (for CDN it's missing the domain)
+pub fn image_id_to_key(
+    library_kind: MediaLibraryKind,
+    variant: MediaVariant,
+    id: ImageId,
+) -> String {
+    id_to_key_inner(library_kind.image_prefix(), variant, id.0)
+}
+
+/// gives the key for a audio-file with the given parameters
+/// this is *not* a full url, (for CDN it's missing the domain)
+pub fn audio_id_to_key(
+    library_kind: MediaLibraryKind,
+    variant: MediaVariant,
+    id: AudioId,
+) -> String {
+    id_to_key_inner(library_kind.audio_prefix(), variant, id.0)
+}
+
+/// Meant primarily for backend usage
+pub fn id_with_kind_to_key(
+    library_kind: MediaLibraryKind,
+    variant: MediaVariant,
+    id: Uuid,
+    media_kind: MediaKind,
+) -> String {
+    id_to_key_inner(library_kind.prefix(media_kind), variant, id)
+}


### PR DESCRIPTION
Apparently this also fixes #397 for newly uploaded images (so, PUTing the same content as the raw will fix it), did that without realizing it... Intends to close #396 