### PR TITLE
fix(backend/api): fix order of migrations

### DIFF
--- a/backend/api/migrations/20210428184042_user-font-table.sql
+++ b/backend/api/migrations/20210428184042_user-font-table.sql
@@ -1,6 +1,6 @@
 create table user_font (
     user_id     uuid    not null references "user" (id) on delete cascade,
-    "index"     int2    not null,
+    "index"     int2    not null check("index" >= 0),
     font_name   text    not null,
     unique (user_id, "index")
 );


### PR DESCRIPTION
cc @rrcwang, not a you problem, but, sqlx can't understand migrations being ran out of order, so I fixed that, and since I had to move the migration anyway, I added the `check` constraint