### PR TITLE
feat: add is_complete field to module get, update

### DIFF
--- a/backend/api/fixtures/8_jig.sql
+++ b/backend/api/fixtures/8_jig.sql
@@ -3,7 +3,7 @@ values
     ('0cc084bc-7c83-11eb-9f77-e3218dffb008', '1f241e1b-b537-493f-a230-075cb16315be', '1f241e1b-b537-493f-a230-075cb16315be', '2021-03-04 00:46:26.134651+00', 'en');
 
 
-insert into jig_module (jig_id, id, index, kind, contents, created_at)
+insert into jig_module (jig_id, id, index, kind, contents, created_at, is_complete)
 values
-    ('0cc084bc-7c83-11eb-9f77-e3218dffb008', '0cbfdd82-7c83-11eb-9f77-d7d86264c3bc', 0, 0, '{}', '2021-03-04 00:46:26.134651+00'),
-    ('0cc084bc-7c83-11eb-9f77-e3218dffb008', '0cc03a02-7c83-11eb-9f77-f77f9ad65e9a', 1, null, null, '2021-03-04 00:46:26.134651+00');
+    ('0cc084bc-7c83-11eb-9f77-e3218dffb008', '0cbfdd82-7c83-11eb-9f77-d7d86264c3bc', 0, 0, '{}', '2021-03-04 00:46:26.134651+00', false),
+    ('0cc084bc-7c83-11eb-9f77-e3218dffb008', '0cc03a02-7c83-11eb-9f77-f77f9ad65e9a', 1, null, null, '2021-03-04 00:46:26.134651+00', false);

--- a/backend/api/migrations/20210511104544_jig-module-is-complete.sql
+++ b/backend/api/migrations/20210511104544_jig-module-is-complete.sql
@@ -1,0 +1,2 @@
+alter table jig_module
+    add column is_complete bool default false not null;

--- a/backend/api/sqlx-data.json
+++ b/backend/api/sqlx-data.json
@@ -555,6 +555,46 @@
       ]
     }
   },
+  "1faa63098267504c5bf0c38977e850dc649dd5e357d7bfe6f893eeb03aafff5f": {
+    "query": "\nselect \n    id as \"id: ModuleId\",\n    contents as \"body\",\n    kind as \"kind: ModuleKind\",\n    is_complete as \"is_complete\"\nfrom jig_module\nwhere jig_id = $1 and (id is not distinct from $2 or index is not distinct from $3)\n",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id: ModuleId",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 1,
+          "name": "body",
+          "type_info": "Jsonb"
+        },
+        {
+          "ordinal": 2,
+          "name": "kind: ModuleKind",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 3,
+          "name": "is_complete",
+          "type_info": "Bool"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Uuid",
+          "Int2"
+        ]
+      },
+      "nullable": [
+        false,
+        true,
+        true,
+        false
+      ]
+    }
+  },
   "1fecc2613bdeb1cb5ef0e88661eb5a43f995623a28c26cf77cb01e50a7c9ebb7": {
     "query": "select exists(select 1 from \"user_scope\" where user_id = $1 and (scope = $2 or scope = $3)) as \"exists!\"",
     "describe": {
@@ -1106,6 +1146,22 @@
           "Int2",
           "Int2",
           "Uuid"
+        ]
+      },
+      "nullable": []
+    }
+  },
+  "51b5e589811bbe7936757b7247f31485244a2b0f027b6e5ec5a8be1f68bdd24f": {
+    "query": "\nupdate jig_module\nset contents = coalesce($3, contents),\n    kind = coalesce($4, kind),\n    is_complete = coalesce($5, is_complete)\nwhere jig_id = $1 and index = $2\n",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Int2",
+          "Jsonb",
+          "Int2",
+          "Bool"
         ]
       },
       "nullable": []
@@ -2027,55 +2083,6 @@
       },
       "nullable": [
         null
-      ]
-    }
-  },
-  "88331edb09a66dd64923f8bf0b5b7ff0546436cb615dd8611cc41707002a0a1e": {
-    "query": "\nupdate jig_module\nset contents = coalesce($3, contents),\n    kind = coalesce($4, kind)\nwhere jig_id = $1 and index = $2\n",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Int2",
-          "Jsonb",
-          "Int2"
-        ]
-      },
-      "nullable": []
-    }
-  },
-  "88c75cf29cb55aa0924802949ef5a5eed9dd3257e58d34329aeaf45c3fa28a63": {
-    "query": "\nselect \n    id as \"id: ModuleId\",\n    contents as \"body\",\n    kind as \"kind: ModuleKind\"\nfrom jig_module\nwhere jig_id = $1 and (id is not distinct from $2 or index is not distinct from $3)\n",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id: ModuleId",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 1,
-          "name": "body",
-          "type_info": "Jsonb"
-        },
-        {
-          "ordinal": 2,
-          "name": "kind: ModuleKind",
-          "type_info": "Int2"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Uuid",
-          "Int2"
-        ]
-      },
-      "nullable": [
-        false,
-        true,
-        true
       ]
     }
   },

--- a/backend/api/src/http/endpoints/module.rs
+++ b/backend/api/src/http/endpoints/module.rs
@@ -70,6 +70,7 @@ async fn update(
         ModuleIdOrIndex::Id(module),
         req.body.as_ref(),
         req.index,
+        req.is_complete,
     )
     .await?;
 

--- a/backend/api/tests/integration/jig/module.rs
+++ b/backend/api/tests/integration/jig/module.rs
@@ -62,6 +62,7 @@ async fn update_contents() -> anyhow::Result<()> {
         .login()
         .json(&ModuleUpdateRequest {
             body: Some(ModuleBody::MemoryGame(Default::default())),
+            is_complete: Some(true),
             ..ModuleUpdateRequest::default()
         })
         .send()

--- a/backend/api/tests/integration/jig/snapshots/integration__jig__module__update_contents.snap
+++ b/backend/api/tests/integration/jig/snapshots/integration__jig__module__update_contents.snap
@@ -16,6 +16,7 @@ expression: body
         "pairs": [],
         "theme_id": "None"
       }
-    }
+    },
+    "is_complete": true
   }
 }

--- a/backend/api/tests/integration/jig/snapshots/integration__jig__module__update_empty.snap
+++ b/backend/api/tests/integration/jig/snapshots/integration__jig__module__update_empty.snap
@@ -6,6 +6,7 @@ expression: body
 {
   "module": {
     "id": "0cbfdd82-7c83-11eb-9f77-d7d86264c3bc",
-    "body": "cover"
+    "body": "cover",
+    "is_complete": false
   }
 }

--- a/shared/rust/src/domain/jig/module.rs
+++ b/shared/rust/src/domain/jig/module.rs
@@ -141,6 +141,9 @@ pub struct Module {
 
     /// The module's body.
     pub body: Option<ModuleBody>,
+
+    /// Whether the module is complete or not.
+    pub is_complete: bool,
 }
 
 /// Request to create a new `Module`.
@@ -171,6 +174,9 @@ pub struct ModuleUpdateRequest {
     ///
     /// Numbers larger than the parent jig's module count will move it to the *end*.
     pub index: Option<u16>,
+
+    /// Whether the module is complete or not.
+    pub is_complete: Option<bool>,
 }
 
 into_uuid![ModuleId];


### PR DESCRIPTION
closes #1044
* adds `is_complete: bool` field for jig modules
  * defaults to `false` when modules are created
  * changes response for `GET /v1/jig/<jig_id>/module/<module_id>`
  * changes request and response for `PATCH`
* `LiteModule` is unchanged