### PR TITLE
fix(tests): explicitly stop app at end of each test

### DIFF
--- a/backend/api/tests/integration/animation.rs
+++ b/backend/api/tests/integration/animation.rs
@@ -34,6 +34,8 @@ async fn create() -> anyhow::Result<()> {
 
     let body: CreateResponse<AnimationId> = resp.json().await?;
 
+    app.stop(false).await;
+
     insta::assert_json_snapshot!(body, {".id" => "[id]"});
 
     Ok(())
@@ -60,6 +62,8 @@ async fn get_metadata() -> anyhow::Result<()> {
     assert_eq!(resp.status(), StatusCode::OK);
 
     let body: serde_json::Value = resp.json().await?;
+
+    app.stop(false).await;
 
     insta::assert_json_snapshot!(body, {".metadata.updated_at" => "[timestamp]"});
 

--- a/backend/api/tests/integration/audio/user.rs
+++ b/backend/api/tests/integration/audio/user.rs
@@ -25,6 +25,8 @@ async fn create_returns_created() -> anyhow::Result<()> {
 
     let body: CreateResponse<AudioId> = resp.json().await?;
 
+    app.stop(false).await;
+
     insta::assert_json_snapshot!(body, {".id" => "[id]"});
 
     Ok(())

--- a/backend/api/tests/integration/category.rs
+++ b/backend/api/tests/integration/category.rs
@@ -33,6 +33,8 @@ async fn create() -> anyhow::Result<()> {
 
     let _body: NewCategoryResponse = resp.json().await?;
 
+    app.stop(false).await;
+
     Ok(())
 }
 
@@ -54,6 +56,8 @@ async fn get() -> anyhow::Result<()> {
     assert_eq!(resp.status(), StatusCode::OK);
 
     let body: serde_json::Value = resp.json().await?;
+
+    app.stop(false).await;
 
     insta::assert_json_snapshot!(body);
 
@@ -78,6 +82,8 @@ async fn get_nested_categories(query: &GetCategoryRequest) -> anyhow::Result<()>
     assert_eq!(resp.status(), StatusCode::OK);
 
     let body: serde_json::Value = resp.json().await?;
+
+    app.stop(false).await;
 
     insta::assert_json_snapshot!(body);
 
@@ -191,6 +197,8 @@ async fn upgdate_ordering() -> anyhow::Result<()> {
 
     let body: serde_json::Value = resp.json().await?;
 
+    app.stop(false).await;
+
     insta::assert_json_snapshot!(body, {".**.updated_at" => "[timestamp]"});
 
     Ok(())
@@ -227,6 +235,8 @@ async fn delete() -> anyhow::Result<()> {
 
     let body: serde_json::Value = resp.json().await?;
 
+    app.stop(false).await;
+
     insta::assert_json_snapshot!(body, {".**.updated_at" => "[timestamp]"});
 
     Ok(())
@@ -262,6 +272,8 @@ async fn update(id: Uuid, body: &serde_json::Value) -> anyhow::Result<()> {
     assert_eq!(resp.status(), StatusCode::OK);
 
     let body: serde_json::Value = resp.json().await?;
+
+    app.stop(false).await;
 
     insta::assert_json_snapshot!(body, {".**.updated_at" => "[timestamp]"});
 

--- a/backend/api/tests/integration/image.rs
+++ b/backend/api/tests/integration/image.rs
@@ -44,6 +44,8 @@ async fn create(
 
     let body: CreateResponse<ImageId> = resp.json().await?;
 
+    app.stop(false).await;
+
     insta::assert_json_snapshot!(body, {".id" => "[id]"});
 
     Ok(())
@@ -111,6 +113,8 @@ async fn create_error(kind: &str, id: &str) -> anyhow::Result<()> {
 
     let body: serde_json::Value = resp.json().await?;
 
+    app.stop(false).await;
+
     insta::assert_json_snapshot!(body);
 
     Ok(())
@@ -163,6 +167,8 @@ async fn get_metadata() -> anyhow::Result<()> {
 
     let body: serde_json::Value = resp.json().await?;
 
+    app.stop(false).await;
+
     insta::assert_json_snapshot!(body, {".metadata.updated_at" => "[timestamp]"});
 
     Ok(())
@@ -206,6 +212,8 @@ async fn update(req: &serde_json::Value) -> anyhow::Result<()> {
     assert_eq!(resp.status(), StatusCode::OK);
 
     let body: serde_json::Value = resp.json().await?;
+
+    app.stop(false).await;
 
     insta::assert_json_snapshot!(body, {".metadata.updated_at" => "[timestamp]"});
 

--- a/backend/api/tests/integration/jig/cover.rs
+++ b/backend/api/tests/integration/jig/cover.rs
@@ -40,6 +40,8 @@ async fn update_no_modules_changes() -> anyhow::Result<()> {
 
     let body: JigResponse = resp.json().await?;
 
+    app.stop(false).await;
+
     insta::assert_json_snapshot!(body.jig, {".**.updated_at" => "[updated_at]"});
 
     Ok(())

--- a/backend/api/tests/integration/jig/module.rs
+++ b/backend/api/tests/integration/jig/module.rs
@@ -41,6 +41,8 @@ async fn update_empty() -> anyhow::Result<()> {
 
     let body: serde_json::Value = resp.json().await?;
 
+    app.stop(false).await;
+
     insta::assert_json_snapshot!(body, {".**.updated_at" => "[timestamp]"});
 
     Ok(())
@@ -83,6 +85,8 @@ async fn update_contents() -> anyhow::Result<()> {
     assert_eq!(resp.status(), StatusCode::OK);
 
     let body: serde_json::Value = resp.json().await?;
+
+    app.stop(false).await;
 
     insta::assert_json_snapshot!(body, {".**.updated_at" => "[timestamp]"});
 

--- a/backend/api/tests/integration/locale.rs
+++ b/backend/api/tests/integration/locale.rs
@@ -22,6 +22,8 @@ async fn list_bundles() -> anyhow::Result<()> {
 
     let body: serde_json::Value = resp.json().await?;
 
+    app.stop(false).await;
+
     insta::assert_json_snapshot!(body);
 
     Ok(())
@@ -44,6 +46,8 @@ async fn list_item_kind() -> anyhow::Result<()> {
     assert_eq!(resp.status(), StatusCode::OK);
 
     let body: serde_json::Value = resp.json().await?;
+
+    app.stop(false).await;
 
     insta::assert_json_snapshot!(body);
 

--- a/backend/api/tests/integration/locale/entry.rs
+++ b/backend/api/tests/integration/locale/entry.rs
@@ -146,6 +146,8 @@ async fn create() -> anyhow::Result<()> {
 
     let body: serde_json::Value = resp.json().await?;
 
+    app.stop(false).await;
+
     insta::assert_json_snapshot!(body, {".id" => "[id]"});
 
     Ok(())

--- a/backend/api/tests/integration/main.rs
+++ b/backend/api/tests/integration/main.rs
@@ -21,5 +21,7 @@ async fn pass() -> anyhow::Result<()> {
 
     assert_eq!(resp.status(), http::StatusCode::NO_CONTENT);
 
+    app.stop(false).await;
+
     Ok(())
 }

--- a/backend/api/tests/integration/meta.rs
+++ b/backend/api/tests/integration/meta.rs
@@ -24,6 +24,8 @@ async fn get() -> anyhow::Result<()> {
 
     let body: serde_json::Value = resp.json().await?;
 
+    app.stop(false).await;
+
     insta::assert_json_snapshot!(body);
 
     Ok(())

--- a/backend/api/tests/integration/session.rs
+++ b/backend/api/tests/integration/session.rs
@@ -17,6 +17,8 @@ async fn create_401_no_auth() -> anyhow::Result<()> {
 
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 
+    app.stop(false).await;
+
     Ok(())
 }
 
@@ -41,6 +43,8 @@ async fn create_basic() -> anyhow::Result<()> {
     body.as_object()
         .expect("body wasn't a object")
         .contains_key("csrf");
+
+    app.stop(false).await;
 
     Ok(())
 }

--- a/backend/api/tests/integration/user.rs
+++ b/backend/api/tests/integration/user.rs
@@ -27,6 +27,8 @@ async fn get_profile() -> anyhow::Result<()> {
 
     let body: serde_json::Value = resp.json().await?;
 
+    app.stop(false).await;
+
     insta::assert_json_snapshot!(body);
 
     Ok(())

--- a/backend/api/tests/integration/user/color.rs
+++ b/backend/api/tests/integration/user/color.rs
@@ -25,6 +25,8 @@ async fn get_all() -> anyhow::Result<()> {
 
     let body: serde_json::Value = resp.json().await?;
 
+    app.stop(false).await;
+
     insta::assert_json_snapshot!(body);
 
     Ok(())
@@ -66,6 +68,8 @@ async fn update() -> anyhow::Result<()> {
 
     let body: serde_json::Value = resp.json().await?;
 
+    app.stop(false).await;
+
     insta::assert_json_snapshot!(body);
 
     Ok(())
@@ -98,6 +102,8 @@ async fn delete() -> anyhow::Result<()> {
     assert_eq!(resp.status(), StatusCode::OK);
 
     let body: serde_json::Value = resp.json().await?;
+
+    app.stop(false).await;
 
     insta::assert_json_snapshot!(body);
 
@@ -139,6 +145,8 @@ async fn create() -> anyhow::Result<()> {
     assert_eq!(resp.status(), StatusCode::OK);
 
     let body: serde_json::Value = resp.json().await?;
+
+    app.stop(false).await;
 
     insta::assert_json_snapshot!(body);
 

--- a/backend/api/tests/integration/user/font.rs
+++ b/backend/api/tests/integration/user/font.rs
@@ -25,6 +25,8 @@ async fn get_all() -> anyhow::Result<()> {
 
     let body: serde_json::Value = resp.json().await?;
 
+    app.stop(false).await;
+
     insta::assert_json_snapshot!(body);
 
     Ok(())
@@ -59,6 +61,8 @@ async fn update() -> anyhow::Result<()> {
 
     let body: serde_json::Value = resp.json().await?;
 
+    app.stop(false).await;
+
     insta::assert_json_snapshot!(body);
 
     Ok(())
@@ -91,6 +95,8 @@ async fn delete() -> anyhow::Result<()> {
     assert_eq!(resp.status(), StatusCode::OK);
 
     let body: serde_json::Value = resp.json().await?;
+
+    app.stop(false).await;
 
     insta::assert_json_snapshot!(body);
 
@@ -125,6 +131,8 @@ async fn create() -> anyhow::Result<()> {
     assert_eq!(resp.status(), StatusCode::OK);
 
     let body: serde_json::Value = resp.json().await?;
+
+    app.stop(false).await;
 
     insta::assert_json_snapshot!(body);
 


### PR DESCRIPTION
`cargo test` could sometimes fail a few integration tests by exceeding Postgres's default connection limit. This occurs when running too many tests w/o explicit server stop before reaching end of scope. Has to do with how dropping test threads is handled.

Adding explicit stops after test requests are handled fixes this. 