### PR TITLE
fix: unnest Option in display_name for jig & requests

### DIFF
--- a/backend/api/migrations/20210520130812_jig-display-name-option.sql
+++ b/backend/api/migrations/20210520130812_jig-display-name-option.sql
@@ -1,0 +1,3 @@
+alter table jig
+    alter column display_name set not null,
+    alter column display_name set default '';

--- a/backend/api/sqlx-data.json
+++ b/backend/api/sqlx-data.json
@@ -1457,7 +1457,7 @@
       },
       "nullable": [
         false,
-        true,
+        false,
         true,
         true,
         true,
@@ -1545,7 +1545,7 @@
       },
       "nullable": [
         false,
-        true,
+        false,
         true,
         true,
         true,
@@ -2419,7 +2419,7 @@
       },
       "nullable": [
         false,
-        true,
+        false,
         null,
         null,
         null,
@@ -3163,7 +3163,7 @@
       },
       "nullable": [
         false,
-        true,
+        false,
         true,
         true,
         true,

--- a/backend/api/src/algolia.rs
+++ b/backend/api/src/algolia.rs
@@ -35,7 +35,7 @@ const HAS_AUTHOR_TAG: &'static str = "hasAuthor";
 
 #[derive(Serialize)]
 struct BatchJig<'a> {
-    name: Option<&'a str>,
+    name: &'a str,
     // language: &'a str,
     age_ranges: &'a [Uuid],
     age_range_names: &'a [String],
@@ -299,7 +299,7 @@ for no key update skip locked;
 
             algolia::request::BatchWriteRequest::UpdateObject {
             body: match serde_json::to_value(&BatchJig {
-                name: row.name.as_deref(),
+                name: &row.name,
                 goals: &row.goals,
                 goal_names: &row.goal_names,
                 age_ranges: &row.age_ranges,

--- a/backend/api/src/db/jig.rs
+++ b/backend/api/src/db/jig.rs
@@ -16,7 +16,7 @@ use crate::error;
 
 pub async fn create(
     pool: &PgPool,
-    display_name: Option<&str>,
+    display_name: &str,
     goals: &[GoalId],
     categories: &[CategoryId],
     age_ranges: &[AgeRangeId],

--- a/backend/api/src/http/endpoints/jig.rs
+++ b/backend/api/src/http/endpoints/jig.rs
@@ -52,7 +52,7 @@ async fn create(
 
     let id = db::jig::create(
         &*db,
-        req.display_name.as_deref(),
+        &req.display_name,
         &req.goals,
         &req.categories,
         &req.age_ranges,

--- a/backend/api/tests/integration/snapshots/integration__jig__browse_own_simple.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__browse_own_simple.snap
@@ -7,7 +7,7 @@ expression: body
   "jigs": [
     {
       "id": "0cc084bc-7c83-11eb-9f77-e3218dffb008",
-      "display_name": null,
+      "display_name": "",
       "modules": [
         {
           "id": "0cbfdd82-7c83-11eb-9f77-d7d86264c3bc",

--- a/backend/api/tests/integration/snapshots/integration__jig__browse_simple.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__browse_simple.snap
@@ -7,7 +7,7 @@ expression: body
   "jigs": [
     {
       "id": "0cc084bc-7c83-11eb-9f77-e3218dffb008",
-      "display_name": null,
+      "display_name": "",
       "modules": [
         {
           "id": "0cbfdd82-7c83-11eb-9f77-d7d86264c3bc",

--- a/backend/api/tests/integration/snapshots/integration__jig__clone.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__clone.snap
@@ -6,7 +6,7 @@ expression: body
 {
   "jig": {
     "id": "[id]",
-    "display_name": null,
+    "display_name": "",
     "modules": [
       {
         "id": "[id]",

--- a/backend/api/tests/integration/snapshots/integration__jig__get.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__get.snap
@@ -6,7 +6,7 @@ expression: body
 {
   "jig": {
     "id": "0cc084bc-7c83-11eb-9f77-e3218dffb008",
-    "display_name": null,
+    "display_name": "",
     "modules": [
       {
         "id": "0cbfdd82-7c83-11eb-9f77-d7d86264c3bc",

--- a/shared/rust/src/domain/jig.rs
+++ b/shared/rust/src/domain/jig.rs
@@ -88,9 +88,8 @@ impl<'de> serde::Deserialize<'de> for UserOrMe {
 #[cfg_attr(feature = "backend", derive(Apiv2Schema))]
 pub struct JigCreateRequest {
     /// The JIG's name.
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
-    pub display_name: Option<String>,
+    pub display_name: String,
 
     /// The goals of this jig.
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -133,7 +132,7 @@ pub struct Jig {
     pub id: JigId,
 
     /// The JIG's name.
-    pub display_name: Option<String>,
+    pub display_name: String,
 
     /// The JIG's remaining modules.
     pub modules: Vec<LiteModule>,


### PR DESCRIPTION
closes #1045 
* `Jig.display_name` is now `String` 
* `JigCreateRequest.display_name` is now `String` with default `""` empty string
* `JigUpdateRequest.display_name` is unchanged