### PR TITLE
feat(backend/api): api for a user recent images list

### DIFF
--- a/backend/api/fixtures/5_image.sql
+++ b/backend/api/fixtures/5_image.sql
@@ -1,2 +1,13 @@
 insert into image_metadata (id, name, description, is_premium, created_at, kind)
-values ('3095d05e-f2c7-11ea-89c3-3b621dd74a1f', 'test', 'testest', false, '2020-09-09T18:06:31.575087Z', 0);
+values ('3095d05e-f2c7-11ea-89c3-3b621dd74a1f', 'test', 'testest', false, '2020-09-09T18:06:31.575087Z', 0),
+       ('8cca6f3a-c4bb-11eb-8edf-13c75672da8f', 'test1', 'test description 1', false, '2021-05-01T18:06:31.575087Z', 0),
+       ('8cca7124-c4bb-11eb-8edf-7b42383ed8f5', 'test2', 'test description 2', false, '2021-05-01T18:06:31.575087Z', 0),
+       ('8cca719c-c4bb-11eb-8edf-f7accb638a15', 'test3', 'test description ', false, '2021-05-01T18:06:31.575087Z', 0),
+       ('8cca720a-c4bb-11eb-8edf-63da1d86939c', 'test4', 'test description ', false, '2021-05-01T18:06:31.575087Z', 0);
+
+
+insert into user_recent_image (user_id, image_id, media_library, last_used)
+values ('1f241e1b-b537-493f-a230-075cb16315be', '8cca6f3a-c4bb-11eb-8edf-13c75672da8f', 1, '2021-06-03 22:30:48.451362'),
+       ('1f241e1b-b537-493f-a230-075cb16315be', '8cca7124-c4bb-11eb-8edf-7b42383ed8f5', 1, '2021-06-03 22:30:45.451362'),
+       ('1f241e1b-b537-493f-a230-075cb16315be', '8cca719c-c4bb-11eb-8edf-f7accb638a15', 1, '2021-06-03 22:30:46.451362'),
+       ('1f241e1b-b537-493f-a230-075cb16315be', '8cca720a-c4bb-11eb-8edf-63da1d86939c', 1, '2021-06-03 22:30:47.451362');

--- a/backend/api/migrations/20210603033228_recent-user-images-list.sql
+++ b/backend/api/migrations/20210603033228_recent-user-images-list.sql
@@ -1,0 +1,10 @@
+-- Add migration script here
+create table user_recent_image
+(
+    user_id       uuid references "user" (id) on delete cascade,
+    image_id      uuid                        not null,
+    media_library smallint                    not null check (media_library >= 0),
+    last_used     timestamptz                 not null default now(),
+    unique(user_id, image_id)
+);
+

--- a/backend/api/sqlx-data.json
+++ b/backend/api/sqlx-data.json
@@ -656,6 +656,19 @@
       ]
     }
   },
+  "1e615fdd598c2e33192d23e3320cf6985e3d9a43ec58fbef8c24f92c79a66717": {
+    "query": "\nupdate user_recent_image\nset last_used = now()\nwhere user_id = $1 and image_id = $2\n            ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Uuid"
+        ]
+      },
+      "nullable": []
+    }
+  },
   "1f8df54bb87c543c4a975eb72c8c981ecd033664f68e66a2caff692ac30c14c3": {
     "query": "\nupdate category\nset parent_id = $1,\n    updated_at = now(),\n    index = (select count(*)::int2 from category where parent_id is not distinct from $1)\nwhere id = $2\nreturning index\n",
     "describe": {
@@ -1171,6 +1184,19 @@
       "nullable": []
     }
   },
+  "47f87006d700bed96cbf873d8addacbd9c160cf71e5cd0a4543b1fd7754d563d": {
+    "query": "\ndelete from user_recent_image\nwhere user_id = $1 and image_id = $2\n            ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Uuid"
+        ]
+      },
+      "nullable": []
+    }
+  },
   "4878ce8469a9ea044ceb5804770c99b8d587b7589e7d8d679cc0a5b19c103d0b": {
     "query": "\ninsert into jig_module (jig_id, kind, contents, index)\nvalues ($1, $2, $3, (select count(*) from jig_module where jig_id = $1))\nreturning id, \"index\"\n",
     "describe": {
@@ -1486,6 +1512,39 @@
       ]
     }
   },
+  "63282a245bbfff4db34ea00a9f53cf8f6cbbd26ff4106d3b53f3edf3e48197d0": {
+    "query": "\nselect image_id as \"id: ImageId\", media_library as \"library: MediaLibrary\", last_used as \"last_used: DateTime<Utc>\"\nfrom user_recent_image\nwhere user_id = $1\norder by last_used desc\nlimit $2\n            ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id: ImageId",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 1,
+          "name": "library: MediaLibrary",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 2,
+          "name": "last_used: DateTime<Utc>",
+          "type_info": "Timestamptz"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Int8"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
+        false
+      ]
+    }
+  },
   "63a9ba01a124f3d9755abb0c3649bc0224d1ac27f4fe3fb52399cde83d266fd0": {
     "query": "\n            select subject_id as \"id: SubjectId\", display_name, created_at, updated_at from subject\n            order by index\n        ",
     "describe": {
@@ -1725,6 +1784,40 @@
         ]
       },
       "nullable": []
+    }
+  },
+  "6f2efac54ea432d33d9d1a74ef07c9fb09eb8082a80cf4d36784f480b7eb8bb9": {
+    "query": "\ninsert into user_recent_image (user_id, image_id, media_library)\nvalues ($1, $2, $3)\nreturning image_id as \"id: ImageId\", media_library as \"library: MediaLibrary\", last_used as \"last_used: DateTime<Utc>\";\n            ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id: ImageId",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 1,
+          "name": "library: MediaLibrary",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 2,
+          "name": "last_used: DateTime<Utc>",
+          "type_info": "Timestamptz"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Uuid",
+          "Int2"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
+        false
+      ]
     }
   },
   "6f88dced30ef38b92e48c5b78cda75cfc877dff08195c25609ad0f19ddff49cc": {
@@ -2614,6 +2707,27 @@
         ]
       },
       "nullable": []
+    }
+  },
+  "a927e1b316983d98397a454a3198b08fcd37cb54056c0a5e57c18bbfcaa0985c": {
+    "query": "\nselect exists(select 1 from user_recent_image where user_id = $1 and image_id = $2) as \"exists!\"\n            ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "exists!",
+          "type_info": "Bool"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Uuid"
+        ]
+      },
+      "nullable": [
+        null
+      ]
     }
   },
   "a9780ea48594dbed705b4df8442e7c58416785833da7e04ef32aa8a3bfcd0e21": {

--- a/backend/api/src/db/image.rs
+++ b/backend/api/src/db/image.rs
@@ -176,6 +176,133 @@ delete from image_tag where index = $1
     }
 }
 
+pub mod recent {
+    use crate::error;
+    use chrono::{DateTime, Utc};
+    use shared::{
+        domain::image::{recent::UserRecentImageResponse, ImageId},
+        media::MediaLibrary,
+    };
+    use sqlx::PgPool;
+    use uuid::Uuid;
+
+    pub async fn create(
+        db: &PgPool,
+        user_id: Uuid,
+        image_id: ImageId,
+        library: MediaLibrary,
+    ) -> anyhow::Result<(ImageId, MediaLibrary, DateTime<Utc>), error::UserRecentImage> {
+        let mut txn = db.begin().await?;
+
+        let exists = sqlx::query!(
+            r#"
+select exists(select 1 from user_recent_image where user_id = $1 and image_id = $2) as "exists!"
+            "#,
+            user_id,
+            image_id.0,
+        )
+        .fetch_one(&mut txn)
+        .await?
+        .exists;
+
+        if exists {
+            return Err(error::UserRecentImage::Conflict);
+        }
+
+        let res = sqlx::query!(
+            r#"
+insert into user_recent_image (user_id, image_id, media_library)
+values ($1, $2, $3)
+returning image_id as "id: ImageId", media_library as "library: MediaLibrary", last_used as "last_used: DateTime<Utc>";
+            "#,
+            user_id,
+            image_id.0,
+            library as i16,
+        )
+        .fetch_one(&mut txn)
+        .await?;
+
+        txn.commit().await?;
+
+        Ok((res.id, res.library, res.last_used))
+    }
+
+    pub async fn update(
+        db: &PgPool,
+        user_id: Uuid,
+        image_id: ImageId,
+    ) -> anyhow::Result<(), error::UserRecentImage> {
+        let mut txn = db.begin().await?;
+
+        let exists = sqlx::query!(
+            r#"
+select exists(select 1 from user_recent_image where user_id = $1 and image_id = $2) as "exists!"
+            "#,
+            user_id,
+            image_id.0,
+        )
+        .fetch_one(&mut txn)
+        .await?
+        .exists;
+
+        if !exists {
+            return Err(error::UserRecentImage::ResourceNotFound);
+        }
+
+        sqlx::query!(
+            r#"
+update user_recent_image
+set last_used = now()
+where user_id = $1 and image_id = $2
+            "#,
+            user_id,
+            image_id.0,
+        )
+        .execute(&mut txn)
+        .await?;
+
+        txn.commit().await.map_err(Into::into)
+    }
+
+    pub async fn delete(db: &PgPool, user_id: Uuid, image_id: ImageId) -> sqlx::Result<()> {
+        sqlx::query!(
+            r#"
+delete from user_recent_image
+where user_id = $1 and image_id = $2
+            "#,
+            user_id,
+            image_id.0
+        )
+        .execute(db)
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn list(
+        db: &PgPool,
+        user_id: Uuid,
+        limit: Option<i64>,
+    ) -> sqlx::Result<Vec<UserRecentImageResponse>> {
+        // if let Some(limit) = limit { assert!(limit >= 0); }
+
+        sqlx::query_as!(
+            UserRecentImageResponse,
+            r#"
+select image_id as "id: ImageId", media_library as "library: MediaLibrary", last_used as "last_used: DateTime<Utc>"
+from user_recent_image
+where user_id = $1
+order by last_used desc
+limit $2
+            "#,
+            user_id,
+            limit
+        )
+        .fetch_all(db)
+        .await
+    }
+}
+
 pub async fn create(
     conn: &mut PgConnection,
     name: &str,

--- a/backend/api/src/error.rs
+++ b/backend/api/src/error.rs
@@ -591,3 +591,43 @@ impl Into<actix_web::Error> for Tag {
         }
     }
 }
+
+#[api_v2_errors(
+    code = 400,
+    code = 404,
+    code = 409,
+    description = "Conflict: an image with the same ID already exists for this user",
+    code = 500
+)]
+pub enum UserRecentImage {
+    ResourceNotFound,
+    Conflict,
+    InternalServerError(anyhow::Error),
+}
+
+impl<T: Into<anyhow::Error>> From<T> for UserRecentImage {
+    fn from(e: T) -> Self {
+        Self::InternalServerError(e.into())
+    }
+}
+
+impl Into<actix_web::Error> for UserRecentImage {
+    fn into(self) -> actix_web::Error {
+        match self {
+            Self::ResourceNotFound => BasicError::with_message(
+                http::StatusCode::NOT_FOUND,
+                "Image not found in recent images list for user".to_owned(),
+            )
+            .into(),
+
+            Self::Conflict => BasicError::with_message(
+                http::StatusCode::CONFLICT,
+                "An image with the same ID already exists in recent images list for user"
+                    .to_owned(),
+            )
+            .into(),
+
+            Self::InternalServerError(e) => ise(e),
+        }
+    }
+}

--- a/backend/api/src/http/endpoints/image.rs
+++ b/backend/api/src/http/endpoints/image.rs
@@ -239,6 +239,87 @@ pub mod tag {
     }
 }
 
+pub mod recent {
+    use crate::{db, error, extractor::TokenUser};
+    use chrono::{DateTime, Utc};
+    use paperclip::actix::{
+        api_v2_operation,
+        web::{Data, Json, Path, Query},
+        CreatedJson, NoContent,
+    };
+    use shared::{
+        api::{endpoints::image::recent, ApiEndpoint},
+        domain::image::{
+            recent::{UserRecentImageListResponse, UserRecentImageResponse},
+            ImageId,
+        },
+        media::MediaLibrary,
+    };
+    use sqlx::PgPool;
+
+    #[api_v2_operation]
+    pub(in super::super) async fn create(
+        db: Data<PgPool>,
+        claims: TokenUser,
+        req: Json<<recent::Create as ApiEndpoint>::Req>,
+    ) -> Result<CreatedJson<UserRecentImageResponse>, error::UserRecentImage> {
+        let req = req.into_inner();
+
+        let (id, library, last_used): (ImageId, MediaLibrary, DateTime<Utc>) =
+            db::image::recent::create(db.as_ref(), claims.0.user_id, req.id, req.library).await?;
+
+        Ok(CreatedJson(UserRecentImageResponse {
+            id,
+            library,
+            last_used,
+        }))
+    }
+
+    #[api_v2_operation]
+    pub(in super::super) async fn update(
+        db: Data<PgPool>,
+        claims: TokenUser,
+        req: Path<ImageId>,
+    ) -> Result<NoContent, error::UserRecentImage> {
+        db::image::recent::update(db.as_ref(), claims.0.user_id, req.into_inner()).await?;
+
+        Ok(NoContent)
+    }
+
+    #[api_v2_operation]
+    pub(in super::super) async fn delete(
+        db: Data<PgPool>,
+        claims: TokenUser,
+        req: Path<ImageId>,
+    ) -> Result<NoContent, error::UserRecentImage> {
+        db::image::recent::delete(db.as_ref(), claims.0.user_id, req.into_inner()).await?;
+
+        Ok(NoContent)
+    }
+
+    #[api_v2_operation]
+    pub(in super::super) async fn list(
+        db: Data<PgPool>,
+        claims: TokenUser,
+        req: Option<Query<<recent::List as ApiEndpoint>::Req>>,
+    ) -> Result<Json<<recent::List as ApiEndpoint>::Res>, error::UserRecentImage> {
+        // Handle optional limit here.
+        // `None` becomes `limit null` in postgres query. This means no limit.
+        let limit = match req {
+            None => None,
+            Some(query) => {
+                let limit = query.into_inner().limit;
+                Some(limit as i64)
+            }
+        };
+
+        let images: Vec<UserRecentImageResponse> =
+            db::image::recent::list(db.as_ref(), claims.0.user_id, limit).await?;
+
+        Ok(Json(UserRecentImageListResponse { images }))
+    }
+}
+
 /// Create an image in the global image library.
 #[api_v2_operation]
 async fn create(
@@ -546,5 +627,27 @@ pub fn configure(cfg: &mut ServiceConfig<'_>) {
     .route(
         image::tag::List::PATH,
         image::tag::List::METHOD.route().to(self::tag::list),
+    )
+    .route(
+        image::recent::Create::PATH,
+        image::recent::Create::METHOD
+            .route()
+            .to(self::recent::create),
+    )
+    .route(
+        image::recent::List::PATH,
+        image::recent::List::METHOD.route().to(self::recent::list),
+    )
+    .route(
+        image::recent::Update::PATH,
+        image::recent::Update::METHOD
+            .route()
+            .to(self::recent::update),
+    )
+    .route(
+        image::recent::Delete::PATH,
+        image::recent::Delete::METHOD
+            .route()
+            .to(self::recent::delete),
     );
 }

--- a/backend/api/tests/integration/image.rs
+++ b/backend/api/tests/integration/image.rs
@@ -478,3 +478,203 @@ mod tag {
         Ok(())
     }
 }
+
+mod recent {
+    use http::StatusCode;
+    use serde_json::json;
+
+    use crate::{
+        fixture::Fixture,
+        helpers::{initialize_server, LoginExt},
+    };
+    use shared::domain::image::recent::UserRecentImageListRequest;
+
+    #[actix_rt::test]
+    async fn create() -> anyhow::Result<()> {
+        let app = initialize_server(&[Fixture::User, Fixture::Image]).await;
+
+        let port = app.port();
+
+        let client = reqwest::Client::new();
+
+        let resp = client
+            .post(&format!("http://0.0.0.0:{}/v1/user/me/recent/image", port))
+            .json(&json!({
+                "id": "3095d05e-f2c7-11ea-89c3-3b621dd74a1f",
+                "library": "User",
+            }))
+            .login()
+            .send()
+            .await?
+            .error_for_status()?;
+
+        assert_eq!(resp.status(), StatusCode::CREATED);
+
+        let body: serde_json::Value = resp.json().await?;
+
+        app.stop(false).await;
+
+        insta::assert_json_snapshot!(body, {".last_used" => "[timestamp]"});
+
+        Ok(())
+    }
+
+    #[actix_rt::test]
+    async fn create_conflict() -> anyhow::Result<()> {
+        let app = initialize_server(&[Fixture::User, Fixture::Image]).await;
+
+        let port = app.port();
+
+        let client = reqwest::Client::new();
+
+        let resp = client
+            .post(&format!("http://0.0.0.0:{}/v1/user/me/recent/image", port))
+            .json(&json!({
+                //"id": "3095d05e-f2c7-11ea-89c3-3b621dd74a1f",
+                "id": "8cca6f3a-c4bb-11eb-8edf-13c75672da8f",
+                "library": "User",
+            }))
+            .login()
+            .send()
+            .await?;
+
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+
+        let body: serde_json::Value = resp.json().await?;
+
+        app.stop(false).await;
+
+        insta::assert_json_snapshot!(body, {".last_used" => "[timestamp]"});
+
+        Ok(())
+    }
+
+    #[actix_rt::test]
+    async fn list_no_limit() -> anyhow::Result<()> {
+        let app = initialize_server(&[Fixture::User, Fixture::Image]).await;
+
+        let port = app.port();
+
+        let client = reqwest::Client::new();
+
+        let resp = client
+            .get(&format!("http://0.0.0.0:{}/v1/user/me/recent/image", port))
+            .login()
+            .send()
+            .await?
+            .error_for_status()?;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body: serde_json::Value = resp.json().await?;
+
+        app.stop(false).await;
+
+        insta::assert_json_snapshot!(body);
+
+        Ok(())
+    }
+
+    #[actix_rt::test]
+    async fn list_with_limit() -> anyhow::Result<()> {
+        let app = initialize_server(&[Fixture::User, Fixture::Image]).await;
+
+        let port = app.port();
+
+        let client = reqwest::Client::new();
+
+        let resp = client
+            .get(&format!("http://0.0.0.0:{}/v1/user/me/recent/image", port))
+            .login()
+            .query(&UserRecentImageListRequest { limit: 3 })
+            .send()
+            .await?
+            .error_for_status()?;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body: serde_json::Value = resp.json().await?;
+
+        app.stop(false).await;
+
+        insta::assert_json_snapshot!(body);
+
+        Ok(())
+    }
+
+    #[actix_rt::test]
+    async fn update() -> anyhow::Result<()> {
+        let app = initialize_server(&[Fixture::User, Fixture::Image]).await;
+
+        let port = app.port();
+
+        let client = reqwest::Client::new();
+
+        let resp = client
+            .patch(&format!(
+                "http://0.0.0.0:{}/v1/user/me/recent/image/{}",
+                port, "8cca719c-c4bb-11eb-8edf-f7accb638a15"
+            ))
+            .login()
+            .send()
+            .await?
+            .error_for_status()?;
+
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+        let resp = client
+            .get(&format!("http://0.0.0.0:{}/v1/user/me/recent/image", port))
+            .login()
+            .send()
+            .await?
+            .error_for_status()?;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body: serde_json::Value = resp.json().await?;
+
+        app.stop(false).await;
+
+        insta::assert_json_snapshot!(body, {".**.last_used" => "[timestamp]"});
+
+        Ok(())
+    }
+
+    #[actix_rt::test]
+    async fn delete() -> anyhow::Result<()> {
+        let app = initialize_server(&[Fixture::User, Fixture::Image]).await;
+
+        let port = app.port();
+
+        let client = reqwest::Client::new();
+
+        let resp = client
+            .delete(&format!(
+                "http://0.0.0.0:{}/v1/user/me/recent/image/{}",
+                port, "8cca719c-c4bb-11eb-8edf-f7accb638a15"
+            ))
+            .login()
+            .send()
+            .await?
+            .error_for_status()?;
+
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+        let resp = client
+            .get(&format!("http://0.0.0.0:{}/v1/user/me/recent/image", port))
+            .login()
+            .send()
+            .await?
+            .error_for_status()?;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body: serde_json::Value = resp.json().await?;
+
+        app.stop(false).await;
+
+        insta::assert_json_snapshot!(body); //, {".**.last_used" => "[timestamp]"});
+
+        Ok(())
+    }
+}

--- a/backend/api/tests/integration/jig/additional_resource.rs
+++ b/backend/api/tests/integration/jig/additional_resource.rs
@@ -4,10 +4,7 @@ use crate::{
     fixture::Fixture,
     helpers::{initialize_server, LoginExt},
 };
-use shared::domain::jig::additional_resource::{
-    AdditionalResourceCreateRequest, AdditionalResourceUpdateRequest,
-};
-use url::Url;
+use shared::domain::jig::additional_resource::AdditionalResourceCreateRequest;
 
 #[actix_rt::test]
 async fn create() -> anyhow::Result<()> {

--- a/backend/api/tests/integration/jig/module.rs
+++ b/backend/api/tests/integration/jig/module.rs
@@ -1,9 +1,6 @@
 use http::StatusCode;
 
-use shared::domain::jig::module::{
-    body::{memory, ThemeChoice, ThemeId},
-    ModuleBody, ModuleUpdateRequest,
-};
+use shared::domain::jig::module::{body::memory, ModuleBody, ModuleUpdateRequest};
 
 use crate::{
     fixture::Fixture,

--- a/backend/api/tests/integration/snapshots/integration__image__recent__create.snap
+++ b/backend/api/tests/integration/snapshots/integration__image__recent__create.snap
@@ -1,0 +1,10 @@
+---
+source: tests/integration/image.rs
+expression: body
+
+---
+{
+  "id": "3095d05e-f2c7-11ea-89c3-3b621dd74a1f",
+  "library": "User",
+  "last_used": "[timestamp]"
+}

--- a/backend/api/tests/integration/snapshots/integration__image__recent__create_conflict.snap
+++ b/backend/api/tests/integration/snapshots/integration__image__recent__create_conflict.snap
@@ -1,0 +1,9 @@
+---
+source: tests/integration/image.rs
+expression: body
+
+---
+{
+  "code": 409,
+  "message": "An image with the same ID already exists in recent images list for user"
+}

--- a/backend/api/tests/integration/snapshots/integration__image__recent__delete.snap
+++ b/backend/api/tests/integration/snapshots/integration__image__recent__delete.snap
@@ -1,0 +1,24 @@
+---
+source: tests/integration/image.rs
+expression: body
+
+---
+{
+  "images": [
+    {
+      "id": "8cca6f3a-c4bb-11eb-8edf-13c75672da8f",
+      "library": "User",
+      "last_used": "2021-06-03T22:30:48.451362Z"
+    },
+    {
+      "id": "8cca720a-c4bb-11eb-8edf-63da1d86939c",
+      "library": "User",
+      "last_used": "2021-06-03T22:30:47.451362Z"
+    },
+    {
+      "id": "8cca7124-c4bb-11eb-8edf-7b42383ed8f5",
+      "library": "User",
+      "last_used": "2021-06-03T22:30:45.451362Z"
+    }
+  ]
+}

--- a/backend/api/tests/integration/snapshots/integration__image__recent__list_no_limit.snap
+++ b/backend/api/tests/integration/snapshots/integration__image__recent__list_no_limit.snap
@@ -1,0 +1,29 @@
+---
+source: tests/integration/image.rs
+expression: body
+
+---
+{
+  "images": [
+    {
+      "id": "8cca6f3a-c4bb-11eb-8edf-13c75672da8f",
+      "library": "User",
+      "last_used": "2021-06-03T22:30:48.451362Z"
+    },
+    {
+      "id": "8cca720a-c4bb-11eb-8edf-63da1d86939c",
+      "library": "User",
+      "last_used": "2021-06-03T22:30:47.451362Z"
+    },
+    {
+      "id": "8cca719c-c4bb-11eb-8edf-f7accb638a15",
+      "library": "User",
+      "last_used": "2021-06-03T22:30:46.451362Z"
+    },
+    {
+      "id": "8cca7124-c4bb-11eb-8edf-7b42383ed8f5",
+      "library": "User",
+      "last_used": "2021-06-03T22:30:45.451362Z"
+    }
+  ]
+}

--- a/backend/api/tests/integration/snapshots/integration__image__recent__list_with_limit.snap
+++ b/backend/api/tests/integration/snapshots/integration__image__recent__list_with_limit.snap
@@ -1,0 +1,24 @@
+---
+source: tests/integration/image.rs
+expression: body
+
+---
+{
+  "images": [
+    {
+      "id": "8cca6f3a-c4bb-11eb-8edf-13c75672da8f",
+      "library": "User",
+      "last_used": "2021-06-03T22:30:48.451362Z"
+    },
+    {
+      "id": "8cca720a-c4bb-11eb-8edf-63da1d86939c",
+      "library": "User",
+      "last_used": "2021-06-03T22:30:47.451362Z"
+    },
+    {
+      "id": "8cca719c-c4bb-11eb-8edf-f7accb638a15",
+      "library": "User",
+      "last_used": "2021-06-03T22:30:46.451362Z"
+    }
+  ]
+}

--- a/backend/api/tests/integration/snapshots/integration__image__recent__update.snap
+++ b/backend/api/tests/integration/snapshots/integration__image__recent__update.snap
@@ -1,0 +1,29 @@
+---
+source: tests/integration/image.rs
+expression: body
+
+---
+{
+  "images": [
+    {
+      "id": "8cca719c-c4bb-11eb-8edf-f7accb638a15",
+      "library": "User",
+      "last_used": "[timestamp]"
+    },
+    {
+      "id": "8cca6f3a-c4bb-11eb-8edf-13c75672da8f",
+      "library": "User",
+      "last_used": "[timestamp]"
+    },
+    {
+      "id": "8cca720a-c4bb-11eb-8edf-63da1d86939c",
+      "library": "User",
+      "last_used": "[timestamp]"
+    },
+    {
+      "id": "8cca7124-c4bb-11eb-8edf-7b42383ed8f5",
+      "library": "User",
+      "last_used": "[timestamp]"
+    }
+  ]
+}

--- a/shared/rust/src/api/endpoints/image.rs
+++ b/shared/rust/src/api/endpoints/image.rs
@@ -176,6 +176,91 @@ pub mod tag {
     }
 }
 
+/// Routes for a user's recently used images list.
+/// Note: this assumes that the image referred to exists or is valid.
+pub mod recent {
+    use crate::{
+        api::{ApiEndpoint, Method},
+        domain::{
+            image::{
+                recent::{
+                    UserRecentImageListRequest,
+                    UserRecentImageListResponse,
+                    UserRecentImageCreateRequest,
+                    UserRecentImageResponse,
+                },
+            },
+        },
+        error::EmptyError,
+    };
+
+    /// List recent images for the user.
+    /// Note: `limit` query is optional.
+    ///
+    /// # Errors
+    /// * [`Unauthorized`](http::StatusCode::UNAUTHORIZED) if authorization is not valid.
+    ///
+    /// * ['BadRequest'](http::StatusCode::BAD_REQUEST) if the request is malformed.
+    pub struct List;
+    impl ApiEndpoint for List {
+        type Req = UserRecentImageListRequest;
+        type Res = UserRecentImageListResponse;
+        type Err = EmptyError;
+        const PATH: &'static str = "/v1/user/me/recent/image";
+        const METHOD: Method = Method::Get;
+    }
+
+    /// Add an entry to the list of recent user images.
+    ///
+    /// # Errors
+    /// * [`Unauthorized`](http::StatusCode::UNAUTHORIZED) if authorization is not valid.
+    ///
+    /// * ['BadRequest'](http::StatusCode::BAD_REQUEST) if the request is malformed (e.g. invalid uuid or ['MediaLibrary'](crate::media::MediaLibrary) enum given).
+    pub struct Create;
+    impl ApiEndpoint for Create {
+        type Req = UserRecentImageCreateRequest;
+        type Res = UserRecentImageResponse;
+        type Err = EmptyError;
+        const PATH: &'static str = "/v1/user/me/recent/image";
+        const METHOD: Method = Method::Post;
+    }
+
+    /// Update an entry in the list of recent user images.
+    /// Invoking this bumps the entry to the top of the recent images list.
+    ///
+    /// # Errors
+    /// * [`Unauthorized`](http::StatusCode::UNAUTHORIZED) if authorization is not valid.
+    ///
+    /// * [`NotFound`](http::StatusCode::NOT_FOUND) if the image doesn't exist in the user's recent images list.
+    ///
+    /// * ['BadRequest'](http::StatusCode::BAD_REQUEST) if the request is malformed.
+    pub struct Update;
+    impl ApiEndpoint for Update {
+        type Req = ();
+        type Res = ();
+        type Err = EmptyError;
+        // uuid should be sufficient to identify an image, VERY unlikely to conflict across media libraries
+        const PATH: &'static str = "/v1/user/me/recent/image/{id}";
+        const METHOD: Method = Method::Patch;
+    }
+
+    /// Remove an entry from the list of recent user images.
+    ///
+    /// # Errors
+    /// * [`Unauthorized`](http::StatusCode::UNAUTHORIZED) if authorization is not valid.
+    ///
+    /// * ['BadRequest'](http::StatusCode::BAD_REQUEST) if the request is malformed.
+    pub struct Delete;
+    impl ApiEndpoint for Delete {
+        type Req = ();
+        type Res = ();
+        type Err = EmptyError;
+        // uuid should be sufficient to identify an image, VERY unlikely to conflict across media libraries
+        const PATH: &'static str = "/v1/user/me/recent/image/{id}";
+        const METHOD: Method = Method::Delete;
+    }
+}
+
 /// Get an image by ID.
 pub struct Get;
 impl ApiEndpoint for Get {

--- a/shared/rust/src/domain/image.rs
+++ b/shared/rust/src/domain/image.rs
@@ -99,6 +99,63 @@ pub mod tag {
     }
 }
 
+/// Types for a user's recent images list. Can be from any ['MediaLibrary'](crate::media::MediaLibrary).
+/// Does not verify entries for validity/existence.
+pub mod recent {
+    #[cfg(feature = "backend")]
+    use paperclip::actix::Apiv2Schema;
+    use serde::{Deserialize, Serialize};
+    use chrono::{DateTime, Utc};
+    use super::ImageId;
+    use crate::media::MediaLibrary;
+
+    /// Over-the-wire representation of a single recent image.
+    #[derive(Serialize, Deserialize, Debug)]
+    #[cfg_attr(feature = "backend", derive(Apiv2Schema))]
+    pub struct UserRecentImageResponse {
+        /// The image's ID.
+        pub id: ImageId,
+
+        /// The library that the image belongs to.
+        pub library: MediaLibrary,
+
+        /// When the image was last used.
+        pub last_used: DateTime<Utc>,
+    }
+
+    /// Request to add an entry to the recent user images list,
+    /// see ['recent::Create'](crate::endpoints::image::recent::Create).
+    #[derive(Serialize, Deserialize, Debug)]
+    #[cfg_attr(feature = "backend", derive(Apiv2Schema))]
+    pub struct UserRecentImageCreateRequest {
+        /// The image's ID.
+        pub id: ImageId,
+
+        /// The library that the image belongs to.
+        pub library: MediaLibrary,
+    }
+
+    /// Query to list a user's recent images,
+    /// see ['recent::List'](crate::endpoints::image::recent::List).
+    ///
+    /// This query is optional.
+    #[derive(Serialize, Deserialize, Debug)]
+    #[cfg_attr(feature = "backend", derive(Apiv2Schema))]
+    pub struct UserRecentImageListRequest {
+        /// Indicates how many recent items to retrieve.
+        pub limit: u16,
+    }
+
+    /// Response for listing a user's recent images,
+    /// see ['recent::List'](crate::endpoints::image::recent::List).
+    #[derive(Serialize, Deserialize, Debug)]
+    #[cfg_attr(feature = "backend", derive(Apiv2Schema))]
+    pub struct UserRecentImageListResponse {
+        /// The images returned.
+        pub images: Vec<UserRecentImageResponse>,
+    }
+}
+
 /// Represents different kinds of images (which affects how the size is stored in the db)
 #[derive(Serialize, Deserialize, Copy, Clone, Debug)]
 #[cfg_attr(feature = "backend", derive(sqlx::Type))]


### PR DESCRIPTION
closes #909 

`GET /v1/user/me/recent/image` with optional limit query field.
`POST /v1/user/me/recent/image` to push image .
`PATCH, DELETE /v1/user/me/recent/image/{id}` on image id to modify/delete.
