### PR TITLE
fix: unnest Option for jig description, include field in requests

### DIFF
--- a/backend/api/migrations/20210608032633_jig-description-unnest-option.sql
+++ b/backend/api/migrations/20210608032633_jig-description-unnest-option.sql
@@ -1,0 +1,6 @@
+update jig
+    set description = ''
+where description is not distinct from null;
+
+alter table jig
+alter column description set not null;

--- a/backend/api/sqlx-data.json
+++ b/backend/api/sqlx-data.json
@@ -823,6 +823,30 @@
       "nullable": []
     }
   },
+  "2c5f9d004b784cbc4521f5a95c3ae2f2d42cc5d0517c78dec089cd7077e18d9c": {
+    "query": "\ninsert into jig\n    (display_name, creator_id, author_id, publish_at, language, description)\nvalues ($1, $2, $2, $3, $4, $5)\nreturning id\n",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Uuid"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Text",
+          "Uuid",
+          "Timestamptz",
+          "Text",
+          "Text"
+        ]
+      },
+      "nullable": [
+        false
+      ]
+    }
+  },
   "2fc15a774a3c774d8fbe0e1c9479a021c7491224421b3d51a739126b2f38a252": {
     "query": "\nupdate image_metadata\nset name        = coalesce($2, name),\n    description = coalesce($3, description),\n    is_premium  = coalesce($4, is_premium),\n    updated_at  = now()\nwhere id = $1\n  and (($2::text is not null and $2 is distinct from name) or\n       ($3::text is not null and $3 is distinct from description) or\n       ($4::boolean is not null and $4 is distinct from is_premium))",
     "describe": {
@@ -2098,7 +2122,7 @@
         true,
         true,
         false,
-        true,
+        false,
         false,
         null,
         null,
@@ -3053,29 +3077,6 @@
       "nullable": []
     }
   },
-  "c36ebb9a5396c74886fdb3fe7ed276d7398829b89a9c909f6a68de042a206aef": {
-    "query": "\ninsert into jig\n    (display_name, creator_id, author_id, publish_at, language)\nvalues ($1, $2, $2, $3, $4)\nreturning id\n",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id",
-          "type_info": "Uuid"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Text",
-          "Uuid",
-          "Timestamptz",
-          "Text"
-        ]
-      },
-      "nullable": [
-        false
-      ]
-    }
-  },
   "c5711732b2fcd0f1e9241eecd1714cd91d2de836d9bcb7561317e8fbca447b30": {
     "query": "update image_metadata set uploaded_at = now(), updated_at = now() where id = $1",
     "describe": {
@@ -3201,7 +3202,7 @@
         true,
         true,
         false,
-        true,
+        false,
         false,
         null,
         null,
@@ -3317,7 +3318,7 @@
         true,
         true,
         false,
-        true,
+        false,
         false,
         null,
         null,
@@ -3347,21 +3348,6 @@
       "nullable": [
         false
       ]
-    }
-  },
-  "cce3aeaccc695f530ff0fed6306b6e87acc581c6cbbc29aed40b62beda863a18": {
-    "query": "\nupdate jig\nset display_name  = coalesce($2, display_name),\n    author_id  = coalesce($3, author_id),\n    language  = coalesce($4, language),\n    updated_at  = now()\nwhere id = $1\n  and (($2::text is not null and $2 is distinct from display_name) or\n       ($3::uuid is not null and $3 is distinct from author_id) or\n       ($4::text is not null and $4 is distinct from language))",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Text",
-          "Uuid",
-          "Text"
-        ]
-      },
-      "nullable": []
     }
   },
   "cd49cef54182b43dd7943bcd51fd3c535f4a8ec0dae95cbc8ceb39f7f757fe02": {
@@ -3630,6 +3616,23 @@
       "nullable": [
         false
       ]
+    }
+  },
+  "e632f72e3856e06f121af5fe30045d3f17cd2e91bb1fdf9a798ea65c99b2f8b4": {
+    "query": "\nupdate jig\nset display_name    = coalesce($2, display_name),\n    author_id       = coalesce($3, author_id),\n    language        = coalesce($4, language),\n    description     = coalesce($5, description),\n    is_public       = coalesce($6, is_public),\n    updated_at      = now()\nwhere id = $1\n  and (($2::text is not null and $2 is distinct from display_name) or\n       ($3::uuid is not null and $3 is distinct from author_id) or\n       ($4::text is not null and $4 is distinct from language) or\n       ($5::text is not null and $5 is distinct from description) or\n       ($6::bool is not null and $6 is distinct from is_public))",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Text",
+          "Uuid",
+          "Text",
+          "Text",
+          "Bool"
+        ]
+      },
+      "nullable": []
     }
   },
   "e805579cae1a6b599640e1bedcc0aa45db9538e223ae3a572a2bbb7d85510cf2": {

--- a/backend/api/src/http/endpoints/jig.rs
+++ b/backend/api/src/http/endpoints/jig.rs
@@ -60,6 +60,7 @@ async fn create(
         creator_id,
         req.publish_at.map(DateTime::<Utc>::from),
         &language,
+        &req.description,
     )
     .await
     .map_err(db::meta::handle_metadata_err)?;
@@ -126,6 +127,8 @@ async fn update(
         req.affiliations.as_deref(),
         req.publish_at.map(|it| it.map(DateTime::<Utc>::from)),
         req.language.as_deref(),
+        req.description.as_deref(),
+        req.is_public,
     )
     .await?;
 

--- a/backend/api/tests/integration/jig.rs
+++ b/backend/api/tests/integration/jig.rs
@@ -71,6 +71,7 @@ async fn create_with_params() -> anyhow::Result<()> {
         .json(&json!({
             "modules": ["0cbfdd82-7c83-11eb-9f77-d7d86264c3bc"],
             "display_name": "test jig",
+            "description": "test description",
         }))
         .login()
         .send()

--- a/shared/rust/src/domain/jig.rs
+++ b/shared/rust/src/domain/jig.rs
@@ -124,8 +124,7 @@ pub struct JigCreateRequest {
     pub publish_at: Option<Publish>,
 
     /// Description of the jig. Defaults to empty string.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
+    pub description: String,
 }
 
 /// The over-the-wire representation of a JIG.
@@ -171,7 +170,7 @@ pub struct Jig {
     pub additional_resources: Vec<AdditionalResourceId>,
 
     /// Description of the jig.
-    pub description: Option<String>,
+    pub description: String,
 
     /// When the jig was last edited
     pub last_edited: Option<DateTime<Utc>>,


### PR DESCRIPTION
closes #1088

* `Jig.description` is now `String` instead of `Option<String>`
* `JigCreateRequest.description: String` is added
* `JigCreateRequest.is_public: bool` is added
* `JigUpdateRequest.description: String` is added
* `JigUpdateRequest.is_public: bool` is added