### PR TITLE
feat(pages): change home route to use `spa` template 

### DIFF
--- a/backend/pages/src/server/routes.rs
+++ b/backend/pages/src/server/routes.rs
@@ -1,8 +1,5 @@
 use crate::templates::{
-    direct::{direct_template_home, direct_template_no_auth},
-    epoch::epoch_page,
-    info::info_template,
-    spa,
+    direct::direct_template_no_auth, epoch::epoch_page, info::info_template, spa,
 };
 use actix_web::web::{self, ServiceConfig};
 
@@ -30,7 +27,7 @@ pub fn configure(config: &mut ServiceConfig) {
             web::get().to(spa::module_template),
         )
         .route("/dev/{path:.*}", web::get().to(spa::dev_template))
-        .route("/", web::get().to(direct_template_home))
+        .route("/", web::get().to(spa::home_template))
         .route("/no-auth", web::get().to(direct_template_no_auth))
         .route("/info", web::get().to(info_template))
         .route("/epoch", web::get().to(epoch_page));

--- a/backend/pages/src/templates/direct.rs
+++ b/backend/pages/src/templates/direct.rs
@@ -10,6 +10,8 @@ struct TitlePage<'a> {
     title: &'a str,
 }
 
+#[deprecated]
+#[allow(dead_code)]
 pub async fn direct_template_home(
     settings: Data<RuntimeSettings>,
 ) -> actix_web::Result<HttpResponse> {

--- a/backend/pages/src/templates/spa.rs
+++ b/backend/pages/src/templates/spa.rs
@@ -26,6 +26,7 @@ impl ModuleJigPageKind {
 
 #[derive(Eq, PartialEq, Clone)]
 pub enum SpaPage {
+    Home,
     User,
     Admin,
     Jig(ModuleJigPageKind),
@@ -37,6 +38,7 @@ pub enum SpaPage {
 impl SpaPage {
     pub fn as_str(&self) -> Cow<'static, str> {
         match self {
+            Self::Home => Cow::Borrowed("home"),
             Self::User => Cow::Borrowed("user"),
             Self::Admin => Cow::Borrowed("admin"),
             Self::Jig(page_kind) => Cow::Owned(format!("jig/{}", page_kind.as_str())),
@@ -83,6 +85,10 @@ fn spa_template(settings: &RuntimeSettings, spa: SpaPage) -> actix_web::Result<H
     let info = info.render().map_err(ErrorInternalServerError)?;
 
     Ok(actix_web::HttpResponse::Ok().body(info))
+}
+
+pub async fn home_template(settings: Data<RuntimeSettings>) -> actix_web::Result<HttpResponse> {
+    spa_template(&settings, SpaPage::Home)
 }
 
 pub async fn user_template(settings: Data<RuntimeSettings>) -> actix_web::Result<HttpResponse> {


### PR DESCRIPTION
closes #1087 

Points to `spa` template with `/home` path.
