### PR TITLE
fix(gcs): use `Origin` header for CORS w/ resumable uploads

### DIFF
--- a/backend/api/src/http/endpoints/animation.rs
+++ b/backend/api/src/http/endpoints/animation.rs
@@ -14,6 +14,7 @@ use shared::{
 };
 use sqlx::{postgres::PgDatabaseError, PgPool};
 
+use crate::extractor::RequestOrigin;
 use crate::service::storage;
 use crate::{
     db, error,
@@ -104,6 +105,7 @@ async fn upload(
     gcs: ServiceData<storage::Client>,
     _claims: TokenUserWithScope<ScopeManageAnimation>,
     Path(id): Path<AnimationId>,
+    origin: RequestOrigin,
     req: Json<<animation::Upload as ApiEndpoint>::Req>,
 ) -> Result<Json<<animation::Upload as ApiEndpoint>::Res>, error::Upload> {
     let mut txn = db.begin().await?;
@@ -133,6 +135,7 @@ async fn upload(
             MediaLibrary::Global,
             id.0,
             FileKind::AnimationGif,
+            origin,
         )
         .await?;
 

--- a/backend/api/src/http/endpoints/image.rs
+++ b/backend/api/src/http/endpoints/image.rs
@@ -18,7 +18,7 @@ use sqlx::{postgres::PgDatabaseError, PgPool};
 use crate::{
     db::{self, meta::handle_metadata_err, nul_if_empty},
     error::{self, ServiceKind},
-    extractor::{ScopeManageImage, TokenUser, TokenUserWithScope},
+    extractor::{RequestOrigin, ScopeManageImage, TokenUser, TokenUserWithScope},
     s3, service,
     service::ServiceData,
 };
@@ -72,6 +72,7 @@ async fn upload(
     gcs: ServiceData<service::storage::Client>,
     _claims: TokenUserWithScope<ScopeManageImage>,
     Path(id): Path<ImageId>,
+    origin: RequestOrigin,
     req: Json<<endpoints::image::Upload as ApiEndpoint>::Req>,
 ) -> Result<Json<<endpoints::image::Upload as ApiEndpoint>::Res>, error::Upload> {
     let mut txn = db.begin().await?;
@@ -101,6 +102,7 @@ async fn upload(
             MediaLibrary::Global,
             id.0,
             FileKind::ImagePng(PngImageFile::Original),
+            origin,
         )
         .await?;
 

--- a/backend/api/src/http/endpoints/image/user.rs
+++ b/backend/api/src/http/endpoints/image/user.rs
@@ -1,3 +1,4 @@
+use crate::extractor::RequestOrigin;
 use crate::service::storage;
 use crate::{db, error, extractor::TokenUser, s3, service::ServiceData};
 use futures::TryStreamExt;
@@ -37,6 +38,7 @@ pub(super) async fn upload(
     gcs: ServiceData<storage::Client>,
     _claims: TokenUser,
     Path(id): Path<ImageId>,
+    origin: RequestOrigin,
     req: Json<<endpoints::image::user::Upload as ApiEndpoint>::Req>,
 ) -> Result<Json<<endpoints::image::user::Upload as ApiEndpoint>::Res>, error::Upload> {
     let mut txn = db.begin().await?;
@@ -63,6 +65,7 @@ pub(super) async fn upload(
             MediaLibrary::User,
             id.0,
             FileKind::ImagePng(PngImageFile::Original),
+            origin,
         )
         .await?;
 

--- a/backend/api/tests/integration/image.rs
+++ b/backend/api/tests/integration/image.rs
@@ -343,10 +343,10 @@ async fn create_media_and_upload_with_url() -> anyhow::Result<()> {
 
     let resp: shared::domain::image::ImageUploadResponse = resp.json().await?;
 
-    let url = resp.session_uri;
+    let _url = resp.session_uri;
 
     // perform upload in single chunk
-    let resp = client;
+    let _resp = client;
 
     Ok(())
 }


### PR DESCRIPTION
resolves #1193

Optionally include a `Origin: {domain}` header in media upload requests for global images, user images, and animations. If this domain is one of the allowed (specified in `config::CORS_ORIGINS`), it is then passed to GCS during the upload session URI create request. 