### PR TITLE
algolia tag prioritization

### DIFF
--- a/backend/api/Cargo.lock
+++ b/backend/api/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
 [[package]]
 name = "algolia"
 version = "0.1.0"
-source = "git+https://gitlab.com/izik1/algolia-rs.git?rev=f5ab9b32121f51f0ff8b0a5cef0656ada0f477e4#f5ab9b32121f51f0ff8b0a5cef0656ada0f477e4"
+source = "git+https://gitlab.com/rrcwang/algolia-rs.git?rev=b976ec28366eca22c56cf28c5c54a42833e4a988#b976ec28366eca22c56cf28c5c54a42833e4a988"
 dependencies = [
  "base64 0.13.0",
  "chrono",

--- a/backend/api/Cargo.toml
+++ b/backend/api/Cargo.toml
@@ -14,7 +14,8 @@ actix-http = "2.1.0"
 actix-rt = "1.0.0"
 actix-service = "1.0.5"
 actix-web = "3.0.0"
-algolia = { git = "https://gitlab.com/izik1/algolia-rs.git", rev = "f5ab9b32121f51f0ff8b0a5cef0656ada0f477e4" }
+# temp algolia = { git = "https://gitlab.com/izik1/algolia-rs.git", rev = "f5ab9b32121f51f0ff8b0a5cef0656ada0f477e4" }
+algolia = { git = "https://gitlab.com/rrcwang/algolia-rs.git", rev = "b976ec28366eca22c56cf28c5c54a42833e4a988" }
 anyhow = "1.0.32"
 chrono = "0.4.13"
 chrono-tz = "0.5.3"

--- a/backend/api/fixtures/2_meta_kinds.sql
+++ b/backend/api/fixtures/2_meta_kinds.sql
@@ -23,10 +23,10 @@ values ('533898ea-3367-11eb-a473-8f2df3b13671', 'Lesson Component', 0, '2020-11-
        ('533899b2-3367-11eb-a473-ef2577a4de84', 'Full Lesson', 1, '2020-11-30 23:54:39.198381+00'),
        ('53389a20-3367-11eb-a473-bbdc8773362a', 'Assessment', 2, '2020-11-30 23:54:39.198381+00');
 
-insert into "image_tag" (id, display_name, index, created_at)
-values ('591a2a64-a3a4-11eb-96e7-6bc0e819bc5f', 'A', 0, '2021-04-22 19:53:37.997394+00'),
-       ('5b032222-a3a4-11eb-96e7-dbc5742f1640', 'B', 1, '2021-04-22 19:53:37.997394+00'),
-       ('5e72c62e-a3a4-11eb-96e7-c78c34eb32ee', 'C', 2, '2021-04-22 19:53:37.997394+00');
+insert into "image_tag" (index, display_name, created_at)
+values (0, 'A', '2021-04-22 19:53:37.997394+00'),
+       (1, 'B', '2021-04-22 19:53:37.997394+00'),
+       (2, 'C', '2021-04-22 19:53:37.997394+00');
 
 insert into "animation_tag" (id, display_name, index, created_at)
 values ('73f5daac-adec-11eb-ab06-5b9996c1d1a8', 'A', 0, '2021-05-05 21:45:56.665492+00'),

--- a/backend/api/migrations/20210809192407_tag-replace-id-with-index.sql
+++ b/backend/api/migrations/20210809192407_tag-replace-id-with-index.sql
@@ -1,0 +1,29 @@
+-- removes all references to `id` image tags, moving to using index::smallint entirely
+--
+
+alter table if exists image_tag_join
+    rename to old_image_tag_join;
+
+alter table old_image_tag_join
+    drop constraint image_tag_join_tag_id_fkey;
+
+alter table image_tag
+    drop constraint if exists image_tag_pkey,
+    drop constraint if exists image_tag_index_key,
+    add constraint image_tag_index_pkey primary key (index);
+
+create table image_tag_join
+(
+    image_id  uuid     not null references image_metadata (id) on delete cascade,
+    tag_index smallint not null references image_tag (index) on delete cascade
+);
+
+insert into image_tag_join (image_id, tag_index)
+select image_id, index
+from old_image_tag_join
+         left join image_tag on old_image_tag_join.tag_id = image_tag.id;
+
+drop table old_image_tag_join;
+
+alter table image_tag
+    drop column id;

--- a/backend/api/sqlx-data.json
+++ b/backend/api/sqlx-data.json
@@ -637,6 +637,114 @@
       ]
     }
   },
+  "196981a36982a10e68661c8f04cdf39471687a1f2a3c9d92601aad9eee65d74e": {
+    "query": "\nselect id,\n    name,\n    kind as \"kind: ImageKind\",\n    description,\n    array((select affiliation_id from image_affiliation where image_id = image_metadata.id)) as \"affiliations!\",\n    array((select affiliation.display_name\n           from affiliation\n                    inner join image_affiliation on affiliation.id = image_affiliation.affiliation_id\n           where image_affiliation.image_id = image_metadata.id))                            as \"affiliation_names!\",\n           array((select style_id from image_style where image_id = image_metadata.id))             as \"styles!\",\n           array((select style.display_name\n                  from style\n                           inner join image_style on style.id = image_style.style_id\n           where image_style.image_id = image_metadata.id))                                  as \"style_names!\",\n    array((select age_range_id from image_age_range where image_id = image_metadata.id))     as \"age_ranges!\",\n    array((select age_range.display_name\n           from age_range\n                    inner join image_age_range on age_range.id = image_age_range.age_range_id\n           where image_age_range.image_id = image_metadata.id))                              as \"age_range_names!\",\n    array((select category_id from image_category where image_id = image_metadata.id))       as \"categories!\",\n    array((select name\n           from category\n                    inner join image_category on category.id = image_category.category_id\n           where image_category.image_id = image_metadata.id))                               as \"category_names!\",\n    array((select index \n           from image_tag \n               inner join image_tag_join on image_tag.index = image_tag_join.tag_index\n           where image_tag_join.image_id = image_metadata.id))                               as \"tags!\",\n    array((select display_name\n           from image_tag\n                    inner join image_tag_join on image_tag.index = image_tag_join.tag_index\n           where image_tag_join.image_id = image_metadata.id))                               as \"tag_names!\",\n    (publish_at < now() is true) as \"is_published!\",\n    is_premium\nfrom image_metadata\nwhere \n    last_synced_at is null or\n    (updated_at is not null and last_synced_at < updated_at) or\n    (publish_at < now() is true and last_synced_at < publish_at)\nlimit 100\nfor no key update skip locked;\n     ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 1,
+          "name": "name",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 2,
+          "name": "kind: ImageKind",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 3,
+          "name": "description",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 4,
+          "name": "affiliations!",
+          "type_info": "UuidArray"
+        },
+        {
+          "ordinal": 5,
+          "name": "affiliation_names!",
+          "type_info": "TextArray"
+        },
+        {
+          "ordinal": 6,
+          "name": "styles!",
+          "type_info": "UuidArray"
+        },
+        {
+          "ordinal": 7,
+          "name": "style_names!",
+          "type_info": "TextArray"
+        },
+        {
+          "ordinal": 8,
+          "name": "age_ranges!",
+          "type_info": "UuidArray"
+        },
+        {
+          "ordinal": 9,
+          "name": "age_range_names!",
+          "type_info": "TextArray"
+        },
+        {
+          "ordinal": 10,
+          "name": "categories!",
+          "type_info": "UuidArray"
+        },
+        {
+          "ordinal": 11,
+          "name": "category_names!",
+          "type_info": "TextArray"
+        },
+        {
+          "ordinal": 12,
+          "name": "tags!",
+          "type_info": "Int2Array"
+        },
+        {
+          "ordinal": 13,
+          "name": "tag_names!",
+          "type_info": "TextArray"
+        },
+        {
+          "ordinal": 14,
+          "name": "is_published!",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 15,
+          "name": "is_premium",
+          "type_info": "Bool"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        false
+      ]
+    }
+  },
   "19e13d35722d768bfabd2104aaabd88c7c6b7436ac230485dfe370a6b4609aee": {
     "query": "insert into user_auth_google (user_id, google_id) values ($1, $2)",
     "describe": {
@@ -2323,6 +2431,42 @@
       ]
     }
   },
+  "758bee136eaae799c8beef0e069597d0f67cfc590d5ecc6a4353d24b3474e39b": {
+    "query": "\n        select index as \"index: ImageTagIndex\", display_name, created_at, updated_at from \"image_tag\"\n        order by index\n    ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "index: ImageTagIndex",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 1,
+          "name": "display_name",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 2,
+          "name": "created_at",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 3,
+          "name": "updated_at",
+          "type_info": "Timestamptz"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        true
+      ]
+    }
+  },
   "760185608bd03a9a30aba9100ecc18e170aed0b1008c5f51ad0c7c6f564b090e": {
     "query": "select user_id from user_auth_google where google_id = $1",
     "describe": {
@@ -2343,31 +2487,28 @@
       ]
     }
   },
-  "7f13eff963b91007e55a4a80fc4e32b866781dab9548bb01db0d20a12cb664ed": {
-    "query": "\nselect id as \"id: TagId\", display_name, index from \"image_tag\"\norder by index\n            ",
+  "76f5138776b2544741d5bd7a20298dd4309fa398f23fac98b74873899a0f88b3": {
+    "query": "\ninsert into image_tag (index, display_name)\nvalues ($1, $2)\nreturning index as \"index: ImageTagIndex\", display_name\n            ",
     "describe": {
       "columns": [
         {
           "ordinal": 0,
-          "name": "id: TagId",
-          "type_info": "Uuid"
+          "name": "index: ImageTagIndex",
+          "type_info": "Int2"
         },
         {
           "ordinal": 1,
           "name": "display_name",
           "type_info": "Text"
-        },
-        {
-          "ordinal": 2,
-          "name": "index",
-          "type_info": "Int2"
         }
       ],
       "parameters": {
-        "Left": []
+        "Left": [
+          "Int2",
+          "Text"
+        ]
       },
       "nullable": [
-        false,
         false,
         false
       ]
@@ -3242,6 +3383,30 @@
       ]
     }
   },
+  "a85530d1d83a7f3cd3786da68f5b489fbddbf411d735cf114817e4417768520b": {
+    "query": "\nselect index as \"index: ImageTagIndex\", display_name from \"image_tag\"\norder by index\n            ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "index: ImageTagIndex",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 1,
+          "name": "display_name",
+          "type_info": "Text"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        false
+      ]
+    }
+  },
   "a87ea4169f26518cbf7f88c1777bd15bbf72f938d6352567cd549bbe970db5f2": {
     "query": "\nupdate user_color\nset index = index - 1\nwhere index > $2 and user_id = $1\n",
     "describe": {
@@ -3533,114 +3698,6 @@
       "nullable": []
     }
   },
-  "bc780ffba7cd48b5c9b829c87ef663b4dc398986888f9f5285b413b1563db729": {
-    "query": "\nselect id,\n    name,\n    kind as \"kind: ImageKind\",\n    description,\n    array((select affiliation_id from image_affiliation where image_id = image_metadata.id)) as \"affiliations!\",\n    array((select affiliation.display_name\n           from affiliation\n                    inner join image_affiliation on affiliation.id = image_affiliation.affiliation_id\n           where image_affiliation.image_id = image_metadata.id))                            as \"affiliation_names!\",\n           array((select style_id from image_style where image_id = image_metadata.id))             as \"styles!\",\n           array((select style.display_name\n                  from style\n                           inner join image_style on style.id = image_style.style_id\n           where image_style.image_id = image_metadata.id))                                  as \"style_names!\",\n    array((select age_range_id from image_age_range where image_id = image_metadata.id))     as \"age_ranges!\",\n    array((select age_range.display_name\n           from age_range\n                    inner join image_age_range on age_range.id = image_age_range.age_range_id\n           where image_age_range.image_id = image_metadata.id))                              as \"age_range_names!\",\n    array((select category_id from image_category where image_id = image_metadata.id))       as \"categories!\",\n    array((select name\n           from category\n                    inner join image_category on category.id = image_category.category_id\n           where image_category.image_id = image_metadata.id))                               as \"category_names!\",\n    array((select tag_id from image_tag_join where image_id = image_metadata.id))       as \"tags!\",\n    array((select name\n           from image_tag\n                    inner join image_tag_join on image_tag.id = image_tag_join.tag_id\n           where image_tag_join.image_id = image_metadata.id))                               as \"tag_names!\",\n    (publish_at < now() is true) as \"is_published!\",\n    is_premium\nfrom image_metadata\nwhere \n    last_synced_at is null or\n    (updated_at is not null and last_synced_at < updated_at) or\n    (publish_at < now() is true and last_synced_at < publish_at)\nlimit 100\nfor no key update skip locked;\n     ",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 1,
-          "name": "name",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 2,
-          "name": "kind: ImageKind",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 3,
-          "name": "description",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 4,
-          "name": "affiliations!",
-          "type_info": "UuidArray"
-        },
-        {
-          "ordinal": 5,
-          "name": "affiliation_names!",
-          "type_info": "TextArray"
-        },
-        {
-          "ordinal": 6,
-          "name": "styles!",
-          "type_info": "UuidArray"
-        },
-        {
-          "ordinal": 7,
-          "name": "style_names!",
-          "type_info": "TextArray"
-        },
-        {
-          "ordinal": 8,
-          "name": "age_ranges!",
-          "type_info": "UuidArray"
-        },
-        {
-          "ordinal": 9,
-          "name": "age_range_names!",
-          "type_info": "TextArray"
-        },
-        {
-          "ordinal": 10,
-          "name": "categories!",
-          "type_info": "UuidArray"
-        },
-        {
-          "ordinal": 11,
-          "name": "category_names!",
-          "type_info": "TextArray"
-        },
-        {
-          "ordinal": 12,
-          "name": "tags!",
-          "type_info": "UuidArray"
-        },
-        {
-          "ordinal": 13,
-          "name": "tag_names!",
-          "type_info": "TextArray"
-        },
-        {
-          "ordinal": 14,
-          "name": "is_published!",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 15,
-          "name": "is_premium",
-          "type_info": "Bool"
-        }
-      ],
-      "parameters": {
-        "Left": []
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        false
-      ]
-    }
-  },
   "bdedb2c9dea3363859d3dbe22b6665efda3bf686a9c1eca1ffc9fb298de68d6f": {
     "query": "\n            select id as \"id: AgeRangeId\", display_name, created_at, updated_at from age_range\n            order by index\n        ",
     "describe": {
@@ -3765,48 +3822,6 @@
         ]
       },
       "nullable": [
-        false
-      ]
-    }
-  },
-  "d24c286c6094e2009d400e4f366ffb3ba255c34bf4848598a30a63c2f1106889": {
-    "query": "\n        select id as \"id: TagId\", display_name, created_at, updated_at, index from \"image_tag\"\n        order by index\n    ",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id: TagId",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 1,
-          "name": "display_name",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 2,
-          "name": "created_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 3,
-          "name": "updated_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 4,
-          "name": "index",
-          "type_info": "Int2"
-        }
-      ],
-      "parameters": {
-        "Left": []
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        true,
         false
       ]
     }
@@ -4584,39 +4599,6 @@
         true,
         null,
         null
-      ]
-    }
-  },
-  "f952ba3dea24e228c56c46db14e1db511e5325d96026dfe1ba8cd06cb2864e62": {
-    "query": "\ninsert into image_tag (index, display_name)\nvalues ($1, $2)\nreturning id as \"id: TagId\", index as \"index: i16\", display_name\n            ",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id: TagId",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 1,
-          "name": "index: i16",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 2,
-          "name": "display_name",
-          "type_info": "Text"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Int2",
-          "Text"
-        ]
-      },
-      "nullable": [
-        false,
-        false,
-        false
       ]
     }
   },

--- a/backend/api/src/algolia.rs
+++ b/backend/api/src/algolia.rs
@@ -511,7 +511,9 @@ fn filters_for_ids<T: Into<Uuid> + Copy>(
 /// Filter with ordered priority.
 ///
 /// If using priority scoring, this can only rank the first 62 items.
-/// This is because scores are weighted exponentially and i64::MAX = 2^63-1.
+/// This is because scores are weighted exponentially and i64::MAX = 2^63-1. 63 less one so that
+/// it does not overflow when summed with lesser scores.
+///
 /// The remaining will be assigned a score of 1, which is the default score for all filters.
 fn filters_for_ints_with_scoring(
     filters: &mut Vec<Box<dyn AndFilterable>>,
@@ -520,7 +522,7 @@ fn filters_for_ints_with_scoring(
 ) {
     let count = ints.len() as u32;
 
-    // score for the highest priority tag
+    // start with the score for the highest priority tag
     let mut score = match count > i64::BITS - 1 {
         true => 1_i64 << (i64::BITS - 2), // 2_i64.pow(i64::BITS - 1),
         false if count == 0 => return,

--- a/backend/api/src/algolia.rs
+++ b/backend/api/src/algolia.rs
@@ -1,5 +1,5 @@
 use algolia::{
-    filter::{AndFilterable, CommonFilter, FacetFilter, TagFilter},
+    filter::{AndFilterable, CommonFilter, FacetFilter, ScoredFacetFilter, TagFilter},
     request::{BatchWriteRequests, SearchQuery, VirtualKeyRestrictions},
     response::SearchResponse,
     ApiKey, AppId, Client as Inner,
@@ -12,11 +12,9 @@ use serde::Serialize;
 use shared::{
     domain::{
         category::CategoryId,
-        image::{ImageId, ImageKind},
+        image::{ImageId, ImageKind, ImageTagIndex},
         jig::JigId,
-        meta::AffiliationId,
-        meta::AgeRangeId,
-        meta::{GoalId, ImageStyleId, TagId},
+        meta::{AffiliationId, AgeRangeId, GoalId, ImageStyleId},
     },
     media::MediaGroupKind,
 };
@@ -62,7 +60,7 @@ struct BatchImage<'a> {
     affiliation_names: &'a [String],
     categories: &'a [Uuid],
     category_names: &'a [String],
-    image_tags: &'a [Uuid],
+    image_tags: &'a [i16],
     image_tag_names: &'a [String],
     media_subkind: &'a str,
     #[serde(rename = "_tags")]
@@ -361,6 +359,7 @@ for no key update skip locked;
 
         // todo: allow for some way to do a partial update (for example, by having a channel for queueing partial updates)
         let requests: Vec<_> = sqlx::query!(
+            //language=SQL
             r#"
 select id,
     name,
@@ -386,7 +385,10 @@ select id,
            from category
                     inner join image_category on category.id = image_category.category_id
            where image_category.image_id = image_metadata.id))                               as "category_names!",
-    array((select tag_id from image_tag_join where image_id = image_metadata.id))       as "tags!",
+    array((select index 
+           from image_tag 
+               inner join image_tag_join on image_tag.id = image_tag_join.tag_id
+           where image_tag_join.image_id = image_metadata.id))                               as "tags!",
     array((select name
            from image_tag
                     inner join image_tag_join on image_tag.id = image_tag_join.tag_id
@@ -506,22 +508,44 @@ fn filters_for_ids<T: Into<Uuid> + Copy>(
     }
 }
 
-// fn fitlers_for_int_ids<T: Into<i64> + Copy>(
-//     filters: &mut Vec<Box<dyn AndFilterable>>,
-//     facet_name: &str,
-//     ids: &[T],
-// ) {
-//     for id in ids.iter().copied() {
-//         let id: i64 = id.into();
-//         filters.push(Box::new(CommonFilter {
-//             filter: FacetFilter {
-//                 facet_name: facet_name.to_owned(),
-//                 value: id.to_string(),
-//             },
-//             invert: false,
-//         }))
-//     }
-// }
+/// Filter with ordered priority.
+///
+/// If using priority scoring, this can only rank the first 62 items.
+/// This is because scores are weighted exponentially and i64::MAX = 2^63-1.
+/// The remaining will be assigned a score of 1, which is the default score for all filters.
+fn filters_for_ints_with_scoring(
+    filters: &mut Vec<Box<dyn AndFilterable>>,
+    facet_name: &str,
+    ints: &[i64],
+) {
+    let count = ints.len() as u32;
+
+    // score for the highest priority tag
+    let mut score = match count > i64::BITS - 1 {
+        true => 1_i64 << (i64::BITS - 2), // 2_i64.pow(i64::BITS - 1),
+        false if count == 0 => return,
+        false => 1_i64 << (count - 1),
+    };
+
+    // computes the score for the next lower priority tag
+    let next_score = |score: &mut i64| match *score > 1 {
+        true => *score = *score >> 1,
+        false => *score = 1,
+    };
+
+    for v in ints.iter() {
+        filters.push(Box::new(CommonFilter {
+            filter: ScoredFacetFilter {
+                facet_name: facet_name.to_owned(),
+                value: v.to_string(),
+                score,
+            },
+            invert: false,
+        }));
+
+        next_score(&mut score)
+    }
+}
 
 fn media_filter(kind: MediaGroupKind, invert: bool) -> CommonFilter<FacetFilter> {
     CommonFilter {
@@ -577,7 +601,7 @@ impl Client {
         age_ranges: &[AgeRangeId],
         affiliations: &[AffiliationId],
         categories: &[CategoryId],
-        tags: &[TagId],
+        tags: &[ImageTagIndex],
     ) -> anyhow::Result<Option<(Vec<Uuid>, u32, u64)>> {
         let mut filters = algolia::filter::AndFilter {
             filters: vec![Box::new(media_filter(MediaGroupKind::Image, false))],
@@ -601,7 +625,14 @@ impl Client {
         filters_for_ids(&mut filters.filters, "age_ranges", age_ranges);
         filters_for_ids(&mut filters.filters, "affiliations", affiliations);
         filters_for_ids(&mut filters.filters, "categories", categories);
-        filters_for_ids(&mut filters.filters, "image_tags", tags);
+        filters_for_ints_with_scoring(
+            &mut filters.filters,
+            "image_tags",
+            tags.iter()
+                .map(|it| it.0 as i64)
+                .collect::<Vec<i64>>()
+                .as_ref(),
+        );
 
         let results: SearchResponse = self
             .inner
@@ -613,6 +644,7 @@ impl Client {
                     get_ranking_info: true,
                     filters: Some(filters),
                     hits_per_page: None,
+                    sum_or_filters_scores: true,
                 },
             )
             .await?;
@@ -697,6 +729,7 @@ impl Client {
                     get_ranking_info: true,
                     filters: Some(filters),
                     hits_per_page: None,
+                    sum_or_filters_scores: false,
                 },
             )
             .await?;

--- a/backend/api/src/algolia.rs
+++ b/backend/api/src/algolia.rs
@@ -12,9 +12,9 @@ use serde::Serialize;
 use shared::{
     domain::{
         category::CategoryId,
-        image::{ImageId, ImageKind, ImageTagIndex},
+        image::{ImageId, ImageKind},
         jig::JigId,
-        meta::{AffiliationId, AgeRangeId, GoalId, ImageStyleId},
+        meta::{AffiliationId, AgeRangeId, GoalId, ImageStyleId, ImageTagIndex},
     },
     media::MediaGroupKind,
 };
@@ -387,11 +387,11 @@ select id,
            where image_category.image_id = image_metadata.id))                               as "category_names!",
     array((select index 
            from image_tag 
-               inner join image_tag_join on image_tag.id = image_tag_join.tag_id
+               inner join image_tag_join on image_tag.index = image_tag_join.tag_index
            where image_tag_join.image_id = image_metadata.id))                               as "tags!",
-    array((select name
+    array((select display_name
            from image_tag
-                    inner join image_tag_join on image_tag.id = image_tag_join.tag_id
+                    inner join image_tag_join on image_tag.index = image_tag_join.tag_index
            where image_tag_join.image_id = image_metadata.id))                               as "tag_names!",
     (publish_at < now() is true) as "is_published!",
     is_premium

--- a/backend/api/src/error.rs
+++ b/backend/api/src/error.rs
@@ -26,6 +26,7 @@ pub use user::{
 
 pub mod event_arc;
 pub use event_arc::EventArc;
+use shared::domain::meta::MetaKind;
 
 /// Represents an error returned by the api.
 // mostly used in this module
@@ -501,8 +502,22 @@ impl From<MetaWrapperError> for CreateWithMetadata {
         match e {
             MetaWrapperError::Sqlx(e) => Self::InternalServerError(e.into()),
             MetaWrapperError::MissingMetadata { id, kind } => {
-                Self::MissingMetadata(MetadataNotFound { id, kind })
+                Self::MissingMetadata(MetadataNotFound {
+                    id,
+                    index: None,
+                    kind,
+                    media_group_kind: None,
+                })
             }
+            MetaWrapperError::MissingTag {
+                index,
+                media_group_kind,
+            } => Self::MissingMetadata(MetadataNotFound {
+                id: None,
+                index,
+                kind: MetaKind::Tag,
+                media_group_kind: Some(media_group_kind),
+            }),
         }
     }
 }
@@ -512,8 +527,22 @@ impl From<MetaWrapperError> for UpdateWithMetadata {
         match e {
             MetaWrapperError::Sqlx(e) => Self::InternalServerError(e.into()),
             MetaWrapperError::MissingMetadata { id, kind } => {
-                Self::MissingMetadata(MetadataNotFound { id, kind })
+                Self::MissingMetadata(MetadataNotFound {
+                    id,
+                    index: None,
+                    kind,
+                    media_group_kind: None,
+                })
             }
+            MetaWrapperError::MissingTag {
+                index,
+                media_group_kind,
+            } => Self::MissingMetadata(MetadataNotFound {
+                id: None,
+                index,
+                kind: MetaKind::Tag,
+                media_group_kind: Some(media_group_kind),
+            }),
         }
     }
 }

--- a/backend/api/src/http/endpoints/image/tag.rs
+++ b/backend/api/src/http/endpoints/image/tag.rs
@@ -10,6 +10,7 @@ use paperclip::actix::{
     CreatedJson, NoContent,
 };
 use shared::domain::image::tag::ImageTagResponse;
+use shared::domain::meta::ImageTagIndex;
 use shared::{
     api::{endpoints, ApiEndpoint},
     domain::image::tag::ImageTagListResponse,
@@ -30,7 +31,7 @@ pub(super) async fn list(
 pub(super) async fn create(
     db: Data<PgPool>,
     _claims: TokenUserWithScope<ScopeAdmin>,
-    index: Path<i16>,
+    index: Path<ImageTagIndex>,
     req: Json<<endpoints::image::tag::Create as ApiEndpoint>::Req>,
 ) -> Result<CreatedJson<<endpoints::image::tag::Create as ApiEndpoint>::Res>, error::Tag> {
     let res =
@@ -39,7 +40,6 @@ pub(super) async fn create(
     Ok(CreatedJson(ImageTagResponse {
         index: res.0,
         display_name: res.1,
-        id: res.2,
     }))
 }
 
@@ -56,7 +56,7 @@ pub(super) async fn update(
         db.as_ref(),
         index.into_inner(),
         req.display_name.as_deref(),
-        req.index,
+        req.index.map(|it| it.0),
     )
     .await?;
 

--- a/backend/api/tests/integration/image/snapshots/integration__image__tag__create.snap
+++ b/backend/api/tests/integration/image/snapshots/integration__image__tag__create.snap
@@ -5,6 +5,5 @@ expression: body
 ---
 {
   "index": 3,
-  "display_name": "test name",
-  "id": "[id]"
+  "display_name": "test name"
 }

--- a/backend/api/tests/integration/image/snapshots/integration__image__tag__list.snap
+++ b/backend/api/tests/integration/image/snapshots/integration__image__tag__list.snap
@@ -7,18 +7,15 @@ expression: body
   "image_tags": [
     {
       "index": 0,
-      "display_name": "A",
-      "id": "[id]"
+      "display_name": "A"
     },
     {
       "index": 1,
-      "display_name": "B",
-      "id": "[id]"
+      "display_name": "B"
     },
     {
       "index": 2,
-      "display_name": "C",
-      "id": "[id]"
+      "display_name": "C"
     }
   ]
 }

--- a/backend/api/tests/integration/image/snapshots/integration__image__tag__update_conflict.snap
+++ b/backend/api/tests/integration/image/snapshots/integration__image__tag__update_conflict.snap
@@ -7,18 +7,15 @@ expression: body
   "image_tags": [
     {
       "index": 0,
-      "display_name": "A",
-      "id": "[id]"
+      "display_name": "A"
     },
     {
       "index": 1,
-      "display_name": "B",
-      "id": "[id]"
+      "display_name": "B"
     },
     {
       "index": 2,
-      "display_name": "C",
-      "id": "[id]"
+      "display_name": "C"
     }
   ]
 }

--- a/backend/api/tests/integration/image/snapshots/integration__image__tag__update_no_index.snap
+++ b/backend/api/tests/integration/image/snapshots/integration__image__tag__update_no_index.snap
@@ -7,18 +7,15 @@ expression: body
   "image_tags": [
     {
       "index": 0,
-      "display_name": "test",
-      "id": "[id]"
+      "display_name": "test"
     },
     {
       "index": 1,
-      "display_name": "B",
-      "id": "[id]"
+      "display_name": "B"
     },
     {
       "index": 2,
-      "display_name": "C",
-      "id": "[id]"
+      "display_name": "C"
     }
   ]
 }

--- a/backend/api/tests/integration/image/snapshots/integration__image__tag__update_none.snap
+++ b/backend/api/tests/integration/image/snapshots/integration__image__tag__update_none.snap
@@ -7,18 +7,15 @@ expression: body
   "image_tags": [
     {
       "index": 0,
-      "display_name": "A",
-      "id": "[id]"
+      "display_name": "A"
     },
     {
       "index": 1,
-      "display_name": "B",
-      "id": "[id]"
+      "display_name": "B"
     },
     {
       "index": 2,
-      "display_name": "C",
-      "id": "[id]"
+      "display_name": "C"
     }
   ]
 }

--- a/backend/api/tests/integration/image/snapshots/integration__image__tag__update_only_index.snap
+++ b/backend/api/tests/integration/image/snapshots/integration__image__tag__update_only_index.snap
@@ -7,18 +7,15 @@ expression: body
   "image_tags": [
     {
       "index": 0,
-      "display_name": "A",
-      "id": "[id]"
+      "display_name": "A"
     },
     {
       "index": 2,
-      "display_name": "C",
-      "id": "[id]"
+      "display_name": "C"
     },
     {
       "index": 3,
-      "display_name": "B",
-      "id": "[id]"
+      "display_name": "B"
     }
   ]
 }

--- a/backend/api/tests/integration/image/snapshots/integration__image__tag__update_with_index.snap
+++ b/backend/api/tests/integration/image/snapshots/integration__image__tag__update_with_index.snap
@@ -7,18 +7,15 @@ expression: body
   "image_tags": [
     {
       "index": 0,
-      "display_name": "A",
-      "id": "[id]"
+      "display_name": "A"
     },
     {
       "index": 2,
-      "display_name": "C",
-      "id": "[id]"
+      "display_name": "C"
     },
     {
       "index": 15,
-      "display_name": "test",
-      "id": "[id]"
+      "display_name": "test"
     }
   ]
 }

--- a/backend/api/tests/integration/image/tag.rs
+++ b/backend/api/tests/integration/image/tag.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use http::StatusCode;
 use shared::domain::image::tag::{ImageTagCreateRequest, ImageTagUpdateRequest};
+use shared::domain::meta::ImageTagIndex;
 
 #[actix_rt::test]
 async fn create() -> anyhow::Result<()> {
@@ -139,7 +140,7 @@ async fn update_with_index() -> anyhow::Result<()> {
         1,
         ImageTagUpdateRequest {
             display_name: Some("test".to_owned()),
-            index: Some(15),
+            index: Some(ImageTagIndex(15)),
         },
     )
     .await
@@ -163,7 +164,7 @@ async fn update_only_index() -> anyhow::Result<()> {
         1,
         ImageTagUpdateRequest {
             display_name: None,
-            index: Some(3),
+            index: Some(ImageTagIndex(3)),
         },
     )
     .await
@@ -181,7 +182,7 @@ async fn update_conflict() -> anyhow::Result<()> {
         .patch(&format!("http://0.0.0.0:{}/v1/image/tag/{}", port, 1))
         .json(&ImageTagUpdateRequest {
             display_name: None,
-            index: Some(0),
+            index: Some(ImageTagIndex(0)),
         })
         .login()
         .send()

--- a/backend/api/tests/integration/service.rs
+++ b/backend/api/tests/integration/service.rs
@@ -2,7 +2,6 @@ use core::{
     env::req_env,
     settings::{EmailClientSettings, GoogleCloudStorageSettings},
 };
-use futures::future::Remote;
 use ji_cloud_api::{
     s3,
     service::{mail, storage},

--- a/backend/api/tests/integration/snapshots/integration__image__create_with_affiliation_error.snap
+++ b/backend/api/tests/integration/snapshots/integration__image__create_with_affiliation_error.snap
@@ -7,5 +7,7 @@ expression: body
   "code": 422,
   "message": "Metadata not Found",
   "id": "6389eaa0-de76-11ea-b7ab-0399bcf84df2",
-  "kind": "Affiliation"
+  "index": null,
+  "kind": "Affiliation",
+  "media_group_kind": null
 }

--- a/backend/api/tests/integration/snapshots/integration__image__create_with_age_range_error.snap
+++ b/backend/api/tests/integration/snapshots/integration__image__create_with_age_range_error.snap
@@ -7,5 +7,7 @@ expression: body
   "code": 422,
   "message": "Metadata not Found",
   "id": "6389eaa0-de76-11ea-b7ab-0399bcf84df2",
-  "kind": "AgeRange"
+  "index": null,
+  "kind": "AgeRange",
+  "media_group_kind": null
 }

--- a/backend/api/tests/integration/snapshots/integration__image__create_with_category_error.snap
+++ b/backend/api/tests/integration/snapshots/integration__image__create_with_category_error.snap
@@ -7,5 +7,7 @@ expression: body
   "code": 422,
   "message": "Metadata not Found",
   "id": "6389eaa0-de76-11ea-b7ab-0399bcf84df2",
-  "kind": "Category"
+  "index": null,
+  "kind": "Category",
+  "media_group_kind": null
 }

--- a/backend/api/tests/integration/snapshots/integration__image__create_with_style_error.snap
+++ b/backend/api/tests/integration/snapshots/integration__image__create_with_style_error.snap
@@ -7,5 +7,7 @@ expression: body
   "code": 422,
   "message": "Metadata not Found",
   "id": "6389eaa0-de76-11ea-b7ab-0399bcf84df2",
-  "kind": "ImageStyle"
+  "index": null,
+  "kind": "ImageStyle",
+  "media_group_kind": null
 }

--- a/backend/api/tests/integration/snapshots/integration__image__create_with_tags_error.snap
+++ b/backend/api/tests/integration/snapshots/integration__image__create_with_tags_error.snap
@@ -6,6 +6,10 @@ expression: body
 {
   "code": 422,
   "message": "Metadata not Found",
-  "id": "6389eaa0-de76-11ea-b7ab-0399bcf84df2",
-  "kind": "Tag"
+  "id": null,
+  "index": 22,
+  "kind": "Tag",
+  "media_group_kind": {
+    "media_kind": "image"
+  }
 }

--- a/backend/api/tests/integration/snapshots/integration__image__update_tags.snap
+++ b/backend/api/tests/integration/snapshots/integration__image__update_tags.snap
@@ -13,8 +13,8 @@ expression: body
     "publish_at": null,
     "styles": [],
     "tags": [
-      "591a2a64-a3a4-11eb-96e7-6bc0e819bc5f",
-      "5b032222-a3a4-11eb-96e7-dbc5742f1640"
+      0,
+      2
     ],
     "age_ranges": [],
     "affiliations": [],

--- a/backend/api/tests/integration/snapshots/integration__meta__get.snap
+++ b/backend/api/tests/integration/snapshots/integration__meta__get.snap
@@ -103,21 +103,18 @@ expression: body
   "image_tags": [
     {
       "index": 0,
-      "id": "591a2a64-a3a4-11eb-96e7-6bc0e819bc5f",
       "display_name": "A",
       "created_at": "2021-04-22T19:53:37.997394Z",
       "updated_at": null
     },
     {
       "index": 1,
-      "id": "5b032222-a3a4-11eb-96e7-dbc5742f1640",
       "display_name": "B",
       "created_at": "2021-04-22T19:53:37.997394Z",
       "updated_at": null
     },
     {
       "index": 2,
-      "id": "5e72c62e-a3a4-11eb-96e7-c78c34eb32ee",
       "display_name": "C",
       "created_at": "2021-04-22T19:53:37.997394Z",
       "updated_at": null

--- a/shared/rust/src/api/endpoints/image.rs
+++ b/shared/rust/src/api/endpoints/image.rs
@@ -31,12 +31,13 @@ impl ApiEndpoint for Get {
 
 /// Search for images.
 ///
-/// # Request
-/// The request should be supplied as a URL query string.
-/// * `kind` field must match the case as represented in the returned json body (`PascalCase`?).
-/// * Vector fields, such as `age_ranges` should be given as a comma separated vector (CSV).
+/// The request should be supplied as a URL query string. This is handled by `serde` if using a `to_string` call.
+/// See [`ImageSearchQuery`](::domain::image::ImageSearchQuery) for more more usage details.
 ///
 /// Ex: `?age_ranges=b873b584-efd0-11eb-b4b7-b791fd521ed5,b8388824-efd0-11eb-b4b7-c335e6a1139f,b778a054-efd0-11eb-b4b7-6f7305d76205&page=0`
+///
+/// # Authorization
+/// Standard
 ///
 /// # Errors:
 ///

--- a/shared/rust/src/domain.rs
+++ b/shared/rust/src/domain.rs
@@ -43,7 +43,7 @@ pub mod auth {
 use chrono::Utc;
 #[cfg(feature = "backend")]
 use paperclip::actix::Apiv2Schema;
-use ser::{csv_encode_uuids, deserialize_optional_field, from_csv};
+use ser::{csv_encode_i16_indices, csv_encode_uuids, deserialize_optional_field, from_csv};
 use uuid::Uuid;
 
 /// Serialize/Deserialize wrapper for Base64 encoded content.
@@ -66,7 +66,7 @@ impl<'de, E: std::fmt::Debug, T: std::str::FromStr<Err = E>> serde::Deserialize<
     where
         D: serde::Deserializer<'de>,
     {
-        Ok(Self(deserializer.deserialize_str(ser::FromStrVisiter(
+        Ok(Self(deserializer.deserialize_str(ser::FromStrVisitor(
             std::marker::PhantomData,
         ))?))
     }

--- a/shared/rust/src/domain/image.rs
+++ b/shared/rust/src/domain/image.rs
@@ -215,7 +215,7 @@ pub struct ImageSearchQuery {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub categories: Vec<CategoryId>,
 
-    /// Optionally order by `tags`. `tags[0]` has the highest priority.
+    /// Optionally order by `tags`, given in decreasing priority.
     ///
     /// # Notes on priority:
     /// Consider a request with 4 tags, `[clothing, food, red, sports]`.
@@ -231,7 +231,7 @@ pub struct ImageSearchQuery {
     /// correct that we get the desired ranking.
     ///
     /// *NOTE*: this means that with `i64` range supported by Algolia, we can only assign priority for
-    /// the first 62 tags. The rest are all given a score of 1.  
+    /// the first 62 tags. The remaining are all given a score of 1.  
     ///
     /// ## Example
     /// For a example request `[clothing, food, red, sports]`, we assign the scores:
@@ -247,6 +247,7 @@ pub struct ImageSearchQuery {
     ///
     /// | position  | entry name | tag names    | score |
     /// |-----------|------------|--------------|-------|
+    /// | 0         | hat        | clothing     | 8     |
     /// | 1         | cherry     | red, food    | 6     |
     /// | 2         | cucumber   | green, food  | 4     |
     /// | 3         | stop sign  | red          | 2     |

--- a/shared/rust/src/domain/image/tag.rs
+++ b/shared/rust/src/domain/image/tag.rs
@@ -1,9 +1,10 @@
 //! Types to manage image tags.
 
-use crate::domain::meta::TagId;
 #[cfg(feature = "backend")]
 use paperclip::actix::Apiv2Schema;
 use serde::{Deserialize, Serialize};
+
+use crate::domain::meta::ImageTagIndex;
 
 /// Request to create an image tag.
 #[derive(Serialize, Deserialize, Debug)]
@@ -17,7 +18,7 @@ pub struct ImageTagCreateRequest {
 #[derive(Serialize, Deserialize)]
 #[cfg_attr(feature = "backend", derive(Apiv2Schema))]
 pub struct ImageTagListResponse {
-    /// Indexes and ids for all the image tags.
+    /// Indices for all the image tags.
     pub image_tags: Vec<ImageTagResponse>,
 }
 
@@ -26,13 +27,10 @@ pub struct ImageTagListResponse {
 #[cfg_attr(feature = "backend", derive(Apiv2Schema))]
 pub struct ImageTagResponse {
     /// The index of the image tag found.
-    pub index: i16,
+    pub index: ImageTagIndex,
 
     /// The display name of the image tag found.
     pub display_name: String,
-
-    /// The id of the image tag found.
-    pub id: TagId,
 }
 
 /// Request to update an image tag.
@@ -46,5 +44,5 @@ pub struct ImageTagUpdateRequest {
     /// change the indexing.
     ///
     /// If `index` is [`None`] then it will not be updated.
-    pub index: Option<i16>,
+    pub index: Option<ImageTagIndex>,
 }

--- a/shared/rust/src/domain/meta.rs
+++ b/shared/rust/src/domain/meta.rs
@@ -56,22 +56,30 @@ pub struct SubjectId(pub Uuid);
 #[cfg_attr(feature = "backend", derive(Apiv2Schema))]
 pub struct GoalId(pub Uuid);
 
-/// Wrapper type around [`Uuid`], represents [`Tag::id`].
-#[derive(Hash, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
-#[cfg_attr(feature = "backend", derive(sqlx::Type))]
-#[cfg_attr(feature = "backend", sqlx(transparent))]
-#[cfg_attr(feature = "backend", derive(Apiv2Schema))]
-pub struct TagId(pub Uuid);
-
 into_uuid!(
     ImageStyleId,
     AnimationStyleId,
     AffiliationId,
     AgeRangeId,
     SubjectId,
-    GoalId,
-    TagId
+    GoalId
 );
+
+/// Wrapper type around [`i16`](std::i16), represents the index of an image tag.
+///
+/// This is used instead of UUIDs for image tags as they aren't created dynamically and
+/// a simple and consistent way to identify them is desired.
+#[derive(Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "backend", derive(sqlx::Type))]
+#[cfg_attr(feature = "backend", sqlx(transparent))]
+#[cfg_attr(feature = "backend", derive(Apiv2Schema))]
+pub struct ImageTagIndex(pub i16);
+
+impl From<ImageTagIndex> for i16 {
+    fn from(value: ImageTagIndex) -> Self {
+        value.0
+    }
+}
 
 /// Represents an image style.
 #[derive(Serialize, Deserialize, Debug)]
@@ -178,12 +186,9 @@ pub struct Goal {
 /// Represents a tag.
 #[derive(Serialize, Deserialize, Debug)]
 #[cfg_attr(feature = "backend", derive(Apiv2Schema))]
-pub struct Tag {
+pub struct ImageTag {
     /// Index of the tag.
-    pub index: i16,
-
-    /// The id of the tag.
-    pub id: TagId,
+    pub index: ImageTagIndex,
 
     /// The tag's name.
     pub display_name: String,
@@ -221,7 +226,7 @@ pub struct MetadataResponse {
     pub goals: Vec<Goal>,
 
     /// All tags for images.
-    pub image_tags: Vec<Tag>,
+    pub image_tags: Vec<ImageTag>,
 }
 
 /// Metadata kinds.

--- a/shared/rust/src/error.rs
+++ b/shared/rust/src/error.rs
@@ -70,8 +70,7 @@ pub struct EmptyError {}
 /// Metadata associated with this operation could not be found.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct MetadataNotFound {
-    /// The (Optional) id of the item. This can be either a Uuid or an index as required by the
-    /// metadata type.
+    /// The (Optional) id of the item.
     pub id: Option<uuid::Uuid>,
     /// The (Optional) index of the item.
     pub index: Option<i16>,

--- a/shared/rust/src/error.rs
+++ b/shared/rust/src/error.rs
@@ -3,6 +3,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::domain::meta::MetaKind;
+use crate::media::MediaGroupKind;
 
 /// auth errors
 #[deprecated]
@@ -67,10 +68,16 @@ impl<T> ApiError<T> {}
 pub struct EmptyError {}
 
 /// Metadata associated with this operation could not be found.
-#[derive(serde::Serialize, serde::Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct MetadataNotFound {
-    /// The (Optional) id of the item.
+    /// The (Optional) id of the item. This can be either a Uuid or an index as required by the
+    /// metadata type.
     pub id: Option<uuid::Uuid>,
+    /// The (Optional) index of the item.
+    pub index: Option<i16>,
     /// The item's kind.
     pub kind: MetaKind,
+    /// The (Optional) media group of the item where the error originated, for metadata types that
+    /// are split per media group kind.
+    pub media_group_kind: Option<MediaGroupKind>,
 }


### PR DESCRIPTION
resolves #1086
resolves #1254

# Overview of Changes
* `ImageSearchQuery.tags` now provides a prioritization in 
* Any existing bare `i16`s used to identify an image tag have been replaced with `ImageTagIndex(i16)`. This helps give safer typing for image tag indicies and any future tag index types.
* All references to `TagId(Uuid)`, the wrapper around `Uuid`, have either been removed, or been replaced with `ImageTagIndex(i16)`.


## API
| `shared` crate item                         | old                  | new                            | notes                                |
|---------------------------------------------|----------------------|--------------------------------|--------------------------------------|
| `domain::image::ImageSearchQuery`           | `tags: Vec<TagId>`   | `tags: Vec<ImageTagIndex>`     |                                      |
| `domain::image::ImageCreateRequest`         | `tags: Vec<TagId>`   | `tags: Vec<ImageTagIndex>`     |                                      |
| `domain::image::ImageUpdateRequest`         | `tags: Vec<TagId>`   | `tags: Vec<ImageTagIndex>`     |                                      |
| `domain::image::ImageMetadata`              | `tags: Vec<TagId>`   | `tags: Vec<ImageTagIndex>`     |                                      |
| `domain::image::tag::ImageTagResponse`      | `index: i16`         | `index: ImageTagIndex`         | tag management API type  |
| `domain::image::tag::ImageTagResponse`      | `id: TagId`          | removed!                       |                                      |
| `domain::image::tag::ImageTagUpdateRequest` | `index: Option<i16>` | `index: Option<ImageTagIndex>` |                                      
| `meta::Tag`                                 | `index: i16`         | `index: ImageTagIndex`         | used as a part of `MetadataResponse` |
| `meta::Tag`                                 | `id: TagId`          | removed!                       |                                      |

## Error handling
Expanded `shared::error::MetadataNotFound` to optionally identify the index and specific media kind the metadata type is associated with.