### PR TITLE
fix(backend/api): remove extra scope in default and create module

### DIFF
--- a/backend/api/src/db/jig.rs
+++ b/backend/api/src/db/jig.rs
@@ -6,7 +6,7 @@ use shared::domain::{
         additional_resource::AdditionalResourceId,
         module::{
             body::{cover, ThemeId},
-            ModuleBody, ModuleId,
+            ModuleId,
         },
         AudioBackground, AudioEffects, AudioFeedbackNegative, AudioFeedbackPositive, Jig, JigId,
         JigPlayerSettings, LiteModule, ModuleKind, TextDirection,
@@ -64,7 +64,7 @@ returning id
 
     let default_modules = [(
         ModuleKind::Cover,
-        serde_json::to_value(ModuleBody::Cover(cover::ModuleData::default()))
+        serde_json::to_value(cover::ModuleData::default())
             .expect("default cover module failed to serialize while creating jig"),
     )];
 

--- a/backend/api/src/db/module.rs
+++ b/backend/api/src/db/module.rs
@@ -11,8 +11,7 @@ pub async fn create(
     parent: JigId,
     body: ModuleBody,
 ) -> anyhow::Result<(ModuleId, u16)> {
-    let kind = body.kind();
-    let body = serde_json::to_value(body)?;
+    let (kind, body) = map_module_contents(&body)?;
 
     sqlx::query!(
         r#"

--- a/backend/api/src/http/endpoints/module.rs
+++ b/backend/api/src/http/endpoints/module.rs
@@ -1,7 +1,7 @@
 use paperclip::actix::{
     api_v2_operation,
     web::{self, Data, Json, Path, ServiceConfig},
-    NoContent,
+    CreatedJson, NoContent,
 };
 use shared::{
     api::{endpoints::jig::module, ApiEndpoint},
@@ -24,15 +24,16 @@ async fn create(
     auth: TokenUser,
     parent: Path<JigId>,
     req: Json<<module::Create as ApiEndpoint>::Req>,
-) -> Result<Json<<module::Create as ApiEndpoint>::Res>, error::Auth> {
+) -> Result<CreatedJson<<module::Create as ApiEndpoint>::Res>, error::Auth> {
     let parent_id = parent.into_inner();
 
     db::jig::authz(&*db, auth.0.user_id, Some(parent_id)).await?;
 
     let req = req.into_inner();
+
     let (id, _index) = db::module::create(&*db, parent_id, req.body).await?;
 
-    Ok(Json(CreateResponse { id }))
+    Ok(CreatedJson(CreateResponse { id }))
 }
 
 /// Delete a module.

--- a/backend/api/tests/integration/jig/snapshots/integration__jig__module__create_default-2.snap
+++ b/backend/api/tests/integration/jig/snapshots/integration__jig__module__create_default-2.snap
@@ -1,0 +1,33 @@
+---
+source: tests/integration/jig/module.rs
+expression: body
+
+---
+{
+  "module": {
+    "id": "[id]",
+    "body": {
+      "cover": {
+        "content": {
+          "editor_state": {
+            "step": "One",
+            "steps_completed": []
+          },
+          "base": {
+            "instructions": {
+              "text": null,
+              "audio": null
+            },
+            "theme": "Jig",
+            "backgrounds": {
+              "layer_1": null,
+              "layer_2": null
+            },
+            "stickers": []
+          }
+        }
+      }
+    },
+    "is_complete": false
+  }
+}

--- a/backend/api/tests/integration/jig/snapshots/integration__jig__module__create_default.snap
+++ b/backend/api/tests/integration/jig/snapshots/integration__jig__module__create_default.snap
@@ -1,0 +1,8 @@
+---
+source: tests/integration/jig/module.rs
+expression: body
+
+---
+{
+  "id": "[id]"
+}


### PR DESCRIPTION
resolves #1266
resolves #1257

## Changes:
* The extra most outer scope with the module type name as json key is no longer used as expected, matching the result of module update requests (see #1266 for reference)
* `POST /v1/jig/{id}/module` returns with `201 - CREATED` instead of `200 - NO_CONTENT` as expected of POST resouce requests.