### PR TITLE
feat(backend/api): make `GET /v1/jig/player/{index}` a public endpoint

### DIFF
--- a/backend/api/src/http/endpoints/jig/player.rs
+++ b/backend/api/src/http/endpoints/jig/player.rs
@@ -34,7 +34,6 @@ pub async fn create(
 #[api_v2_operation]
 pub async fn get(
     db: Data<PgPool>,
-    _claims: TokenUser,
     path: web::Path<i16>,
 ) -> Result<Json<<player::Get as ApiEndpoint>::Res>, error::JigCode> {
     let code = path.into_inner();


### PR DESCRIPTION
resolves #1285