### PR TITLE
Refactor publish

### DIFF
--- a/frontend/apps/crates/components/src/module/_common/mod.rs
+++ b/frontend/apps/crates/components/src/module/_common/mod.rs
@@ -4,3 +4,5 @@ pub mod page_kind;
 #[cfg(feature = "module_play")]
 pub mod play;
 pub mod prelude;
+
+pub mod thumbnail;

--- a/frontend/apps/crates/components/src/module/_common/thumbnail/dom.rs
+++ b/frontend/apps/crates/components/src/module/_common/thumbnail/dom.rs
@@ -1,0 +1,30 @@
+use dominator::{Dom, html};
+use std::rc::Rc;
+use utils::prelude::*;
+use super::state::*;
+use futures_signals::signal::{Signal, SignalExt};
+use dominator_helpers::signals::RcSignalFn;
+
+impl ModuleThumbnail {
+    pub fn render(state: Rc<Self>, slot: Option<&str>) -> Dom {
+        html!("img-module-screenshot", {
+            .apply_if(slot.is_some(), |dom| {
+                dom.property("slot", slot.unwrap_ji())
+            })
+            .property("jigId", state.jig_id.0.to_string())
+            .property("moduleId", state.module.id.0.to_string())
+            .property("fallbackKind", state.module.kind.as_str())
+        })
+    }
+
+    pub fn render_signal_fn(state_signal_fn: RcSignalFn<Self>, slot: Option<&str>) -> Dom {
+        html!("img-module-screenshot", {
+            .apply_if(slot.is_some(), |dom| {
+                dom.property("slot", slot.unwrap_ji())
+            })
+            .property_signal("jigId", state_signal_fn().map(|state| state.jig_id.0.to_string()))
+            .property_signal("moduleId", state_signal_fn().map(|state| state.module.id.0.to_string()))
+            .property_signal("fallbackKind", state_signal_fn().map(|state| state.module.kind.as_str()))
+        })
+    }
+}

--- a/frontend/apps/crates/components/src/module/_common/thumbnail/mod.rs
+++ b/frontend/apps/crates/components/src/module/_common/thumbnail/mod.rs
@@ -1,0 +1,5 @@
+mod dom;
+mod state;
+
+pub use dom::*;
+pub use state::*;

--- a/frontend/apps/crates/components/src/module/_common/thumbnail/state.rs
+++ b/frontend/apps/crates/components/src/module/_common/thumbnail/state.rs
@@ -1,0 +1,6 @@
+use shared::domain::jig::{JigId, module::{LiteModule}};
+
+pub struct ModuleThumbnail {
+    pub jig_id: JigId,
+    pub module: LiteModule,
+}

--- a/frontend/apps/crates/entry/jig/edit/src/edit/publish/components/age.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/publish/components/age.rs
@@ -30,15 +30,9 @@ pub fn render(state: Rc<State>) -> Dom {
                 })
         })
         .children_signal_vec(state.ages.signal_cloned().map(clone!(state => move |ages| {
-            match ages {
-                None => vec![],
-                Some(ages) => {
-                    ages.iter().map(|age| {
-                        render_age(&age, state.clone())
-                    }).collect()
-                },
-            }
-
+            ages.iter().map(|age| {
+                render_age(&age, state.clone())
+            }).collect()
         })).to_signal_vec())
     })
 }
@@ -66,12 +60,10 @@ fn age_value_signal(state: Rc<State>) -> impl Signal<Item = String> {
         let selected_ages = state.jig.age_ranges.signal_cloned(),
         let available_ages = state.ages.signal_cloned() => {
             let mut output = vec![];
-            if let Some(available_ages) = available_ages {
-                selected_ages.iter().for_each(|age_id| {
-                    let age = available_ages.iter().find(|age| age.id == *age_id).unwrap_ji();
-                    output.push(age.display_name.clone());
-                })
-            }
+            selected_ages.iter().for_each(|age_id| {
+                let age = available_ages.iter().find(|age| age.id == *age_id).unwrap_ji();
+                output.push(age.display_name.clone());
+            });
             output.join(", ")
         }
 

--- a/frontend/apps/crates/entry/jig/edit/src/edit/publish/components/categories_pills.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/publish/components/categories_pills.rs
@@ -20,13 +20,9 @@ pub fn render(state: Rc<State>) -> Dom {
 fn render_pill(state: Rc<State>, category_id: CategoryId) -> Dom {
     html!("pill-close", {
         .property_signal("label", state.category_label_lookup.signal_cloned().map(move |category_label_lookup| {
-            match category_label_lookup {
-                None => String::new(),
-                Some(category_label_lookup) => {
-                    log::info!("{:?}", category_label_lookup.get(&category_id));
-                    category_label_lookup.get(&category_id).unwrap_ji().clone()
-                }
-            }
+
+            log::info!("{:?}", category_label_lookup.get(&category_id));
+            category_label_lookup.get(&category_id).unwrap_ji().clone()
         }))
     })
 }

--- a/frontend/apps/crates/entry/jig/edit/src/edit/publish/components/categories_select.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/publish/components/categories_select.rs
@@ -30,10 +30,7 @@ pub fn render(state: Rc<State>) -> Dom {
                 })
         })
         .children_signal_vec(state.categories.signal_cloned().map(clone!(state => move |categories| {
-            match categories {
-                None => vec![],
-                Some(categories) => render_categories(state.clone(), &categories),
-            }
+            render_categories(state.clone(), &categories)
         })).to_signal_vec())
     })
 }
@@ -73,12 +70,10 @@ fn category_value_signal(state: Rc<State>) -> impl Signal<Item = String> {
         let selected_categories = state.jig.categories.signal_cloned(),
         let category_label_lookup = state.category_label_lookup.signal_cloned() => {
             let mut output = vec![];
-            if let Some(category_label_lookup) = category_label_lookup {
-                selected_categories.iter().for_each(|category_id| {
-                    let category_name = category_label_lookup.get(category_id).unwrap_ji();
-                    output.push(category_name.clone());
-                })
-            }
+            selected_categories.iter().for_each(|category_id| {
+                let category_name = category_label_lookup.get(category_id).unwrap_ji();
+                output.push(category_name.clone());
+            });
             output.join(", ")
         }
     }

--- a/frontend/apps/crates/entry/jig/edit/src/edit/publish/components/goal.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/publish/components/goal.rs
@@ -30,15 +30,9 @@ pub fn render(state: Rc<State>) -> Dom {
                 })
         })
         .children_signal_vec(state.goals.signal_cloned().map(clone!(state => move |goals| {
-            match goals {
-                None => vec![],
-                Some(goals) => {
-                    goals.iter().map(|goal| {
-                        render_goal(&goal, state.clone())
-                    }).collect()
-                },
-            }
-
+            goals.iter().map(|goal| {
+                render_goal(&goal, state.clone())
+            }).collect()
         })).to_signal_vec())
     })
 }
@@ -66,12 +60,10 @@ fn goal_value_signal(state: Rc<State>) -> impl Signal<Item = String> {
         let selected_goals = state.jig.goals.signal_cloned(),
         let available_goals = state.goals.signal_cloned() => {
             let mut output = vec![];
-            if let Some(available_goals) = available_goals {
-                selected_goals.iter().for_each(|goal_id| {
-                    let goal = available_goals.iter().find(|goal| goal.id == *goal_id).unwrap_ji();
-                    output.push(goal.display_name.clone());
-                })
-            }
+            selected_goals.iter().for_each(|goal_id| {
+                let goal = available_goals.iter().find(|goal| goal.id == *goal_id).unwrap_ji();
+                output.push(goal.display_name.clone());
+            });
             output.join(", ")
         }
 

--- a/frontend/apps/crates/entry/jig/edit/src/edit/publish/dom.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/publish/dom.rs
@@ -3,6 +3,7 @@ use futures_signals::{map_ref, signal::SignalExt};
 use shared::domain::jig::JigId;
 use utils::events;
 use web_sys::{HtmlElement, HtmlInputElement, HtmlTextAreaElement};
+use components::module::_common::thumbnail::ModuleThumbnail;
 
 use super::{
     actions,
@@ -45,17 +46,14 @@ pub fn render(jig_id: JigId) -> Dom {
 fn render_page(state: Rc<State>) -> Dom {
     html!("jig-edit-publish", {
         .children(&mut [
-            html!("img-module-screenshot", {
-                .property("slot", "thumbnail")
-                .property("slot", "img")
-                .property("jigId", state.jig.id.0.to_string())
-                .property_signal("moduleId", state.jig.modules.signal_ref(|modules| {
-                    match modules.len() {
-                        0 => String::new(),
-                        _ => modules[0].id.0.to_string()
-                    }
-                }))
-            }),
+            ModuleThumbnail::render(
+                Rc::new(ModuleThumbnail {
+                    jig_id: state.jig.id.clone(),
+                    //Cover module (first module) is guaranteed to exist
+                    module: state.jig.modules.lock_ref()[0].clone()
+                }),
+                Some("img")
+            ),
             html!("label", {
                 .property("slot", "public")
                 .text(STR_PUBLIC_LABEL)

--- a/frontend/apps/crates/entry/jig/edit/src/edit/publish/publish_jig.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/publish/publish_jig.rs
@@ -10,6 +10,7 @@ use shared::domain::{
     meta::{AgeRangeId, GoalId},
 };
 
+#[derive(Clone)]
 pub struct PublishJig {
     pub id: JigId,
     // modules only for read
@@ -41,29 +42,18 @@ impl From<Jig> for PublishJig {
 }
 
 impl PublishJig {
-    pub fn new_empty(jig_id: JigId) -> Self {
+    pub fn new(jig: Jig) -> Self {
         Self {
-            id: jig_id,
-            modules: Mutable::new(vec![]),
-            display_name: Mutable::new(String::new()),
-            description: Mutable::new(String::new()),
-            age_ranges: Mutable::new(HashSet::new()),
-            goals: Mutable::new(HashSet::new()),
-            language: Mutable::new(String::new()),
-            categories: Mutable::new(HashSet::new()),
-            is_public: Mutable::new(false),
+            id: jig.id,
+            display_name: Mutable::new(jig.display_name),
+            modules: Mutable::new(jig.modules),
+            description: Mutable::new(jig.description),
+            age_ranges: Mutable::new(HashSet::from_iter(jig.age_ranges)),
+            goals: Mutable::new(HashSet::from_iter(jig.goals)),
+            language: Mutable::new(jig.language),
+            categories: Mutable::new(HashSet::from_iter(jig.categories)),
+            is_public: Mutable::new(jig.is_public),
         }
-    }
-
-    pub fn fill_from_jig(&self, jig: Jig) {
-        self.display_name.set(jig.display_name);
-        self.modules.set(jig.modules);
-        self.description.set(jig.description);
-        self.age_ranges.set(HashSet::from_iter(jig.age_ranges));
-        self.goals.set(HashSet::from_iter(jig.goals));
-        self.language.set(jig.language);
-        self.categories.set(HashSet::from_iter(jig.categories));
-        self.is_public.set(jig.is_public);
     }
 
     pub fn to_jig_update_request(&self) -> JigUpdateRequest {

--- a/frontend/apps/crates/entry/jig/edit/src/edit/publish/state.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/publish/state.rs
@@ -13,25 +13,31 @@ use super::publish_jig::PublishJig;
 
 pub struct State {
     pub loader: AsyncLoader,
-    pub categories: Mutable<Option<Vec<Category>>>,
+    pub categories: Mutable<Vec<Category>>,
     // categories has label lookup since it's both more complex to lookup and used more then others (pills)
-    pub category_label_lookup: Mutable<Option<HashMap<CategoryId, String>>>,
-    pub goals: Mutable<Option<Vec<Goal>>>,
-    pub ages: Mutable<Option<Vec<AgeRange>>>,
+    pub category_label_lookup: Mutable<HashMap<CategoryId, String>>,
+    pub goals: Mutable<Vec<Goal>>,
+    pub ages: Mutable<Vec<AgeRange>>,
     pub jig: PublishJig,
     pub submission_tried: Mutable<bool>,
     pub languages: Vec<Language>,
 }
 
 impl State {
-    pub fn new(jig_id: JigId) -> Self {
+    pub fn new(
+        jig: PublishJig, 
+        categories: Vec<Category>,
+        category_label_lookup: HashMap<CategoryId, String>,
+        goals: Vec<Goal>,
+        ages: Vec<AgeRange>,
+    ) -> Self {
         Self {
             loader: AsyncLoader::new(),
-            categories: Mutable::new(None),
-            category_label_lookup: Mutable::new(None),
-            goals: Mutable::new(None),
-            ages: Mutable::new(None),
-            jig: PublishJig::new_empty(jig_id),
+            jig,
+            categories: Mutable::new(categories),
+            category_label_lookup: Mutable::new(category_label_lookup),
+            goals: Mutable::new(goals),
+            ages: Mutable::new(ages),
             submission_tried: Mutable::new(false),
             languages: LANGUAGES.clone(),
         }

--- a/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/module/dom.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/module/dom.rs
@@ -9,6 +9,7 @@ use std::rc::Rc;
 use std::str::FromStr;
 use utils::prelude::*;
 use wasm_bindgen::prelude::*;
+use components::module::_common::thumbnail::ModuleThumbnail;
 pub struct ModuleDom {}
 
 impl ModuleDom {
@@ -92,12 +93,13 @@ impl ModuleDom {
                         match (&*module, route) {
                             (Some(module), JigEditRoute::Module(module_id)) if module_id == &module.id => None,
                             (Some(module), _) => {
-                                Some(html!("img-module-screenshot", {
-                                    .property("slot", "thumbnail")
-                                    .property("jigId", state.sidebar.jig.id.0.to_string())
-                                    .property("moduleId", module.id.0.to_string())
-                                    .property("fallbackKind", state.kind_str())
-                                }))
+                                Some(ModuleThumbnail::render(
+                                        Rc::new(ModuleThumbnail {
+                                            jig_id: state.sidebar.jig.id.clone(),
+                                            module: module.clone(), 
+                                        }),
+                                        Some("thumbnail")
+                                ))
                             },
                             _ => None,
                         }


### PR DESCRIPTION
This changes the jig publish flow from:

1. Create State with placeholders
2. Render it / load it (async race)
3. Inside the render logic, deal with placeholders

To:

1. Load the State
2. Render it

It required changing several lines of code. It was almost entirely about _removing_ the nesting, and it was pretty much a repeatable, smooth process - but I still think it's worth it for @MendyBerger to review before merging, in case I didn't see some original intent somewhere.

Note that I believe we can _also_ remove the `Mutable` wrapper for goals / ages, but I didn't do that here.