### PR TITLE
feat!(backend/search): image tags filtering and prioritization

### DIFF
--- a/backend/api/Cargo.lock
+++ b/backend/api/Cargo.lock
@@ -283,7 +283,7 @@ dependencies = [
 [[package]]
 name = "algolia"
 version = "0.1.0"
-source = "git+https://github.com/rrcwang/algolia-rs?rev=b4441a8cab5963d5a11eeb54fee128f5c73d6a1a#b4441a8cab5963d5a11eeb54fee128f5c73d6a1a"
+source = "git+https://github.com/rrcwang/algolia-rs?rev=dadfc5ddac19a58c3cd01a91b271d311b08af823#dadfc5ddac19a58c3cd01a91b271d311b08af823"
 dependencies = [
  "base64 0.13.0",
  "chrono",

--- a/backend/api/Cargo.toml
+++ b/backend/api/Cargo.toml
@@ -16,7 +16,7 @@ actix-service = "2.0.0"
 actix-web = "4.0.0-beta.8"
 actix-web-httpauth = "0.6.0-beta.2"
 
-algolia = { git = "https://github.com/rrcwang/algolia-rs", rev = "b4441a8cab5963d5a11eeb54fee128f5c73d6a1a" }
+algolia = { git = "https://github.com/rrcwang/algolia-rs", rev = "dadfc5ddac19a58c3cd01a91b271d311b08af823" }
 anyhow = "1.0.43"
 argon2 = "0.2.3"
 base64 = "0.13.0"
@@ -90,5 +90,4 @@ yup-oauth2 = "5.1.0"
 
 # temp for actix4 support, until it comes out of beta: https://github.com/cloudevents/sdk-rust/pull/147
 [patch.crates-io]
-
 cloudevents-sdk = { git = "https://github.com/cloudevents/sdk-rust", branch = "actix-web-4.0.0-beta.8" }

--- a/backend/api/src/http/endpoints/image.rs
+++ b/backend/api/src/http/endpoints/image.rs
@@ -152,6 +152,7 @@ async fn search(
             &query.affiliations,
             &query.categories,
             &query.tags,
+            &query.tags_priority,
         )
         .await?
         .ok_or_else(|| error::Service::DisabledService(ServiceKind::Algolia))?;

--- a/shared/rust/src/domain/image.rs
+++ b/shared/rust/src/domain/image.rs
@@ -196,6 +196,13 @@ pub struct ImageSearchQuery {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub categories: Vec<CategoryId>,
 
+    /// Optionally filter by `tags`
+    #[serde(default)]
+    #[serde(serialize_with = "super::csv_encode_i16_indices")]
+    #[serde(deserialize_with = "super::from_csv")]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<ImageTagIndex>,
+
     /// Optionally order by `tags`, given in decreasing priority.
     ///
     /// # Notes on priority
@@ -238,7 +245,7 @@ pub struct ImageSearchQuery {
     #[serde(serialize_with = "super::csv_encode_i16_indices")]
     #[serde(deserialize_with = "super::from_csv")]
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub tags: Vec<ImageTagIndex>,
+    pub tags_priority: Vec<ImageTagIndex>,
 
     /// Optionally filter by `is_premium`
     #[serde(default)]

--- a/shared/rust/src/domain/meta.rs
+++ b/shared/rust/src/domain/meta.rs
@@ -70,6 +70,12 @@ impl From<ImageTagIndex> for i16 {
     }
 }
 
+impl From<ImageTagIndex> for i64 {
+    fn from(value: ImageTagIndex) -> Self {
+        value.0 as i64
+    }
+}
+
 /// Represents an image style.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ImageStyle {


### PR DESCRIPTION
resolves #1391 : filtering with [tags](https://docs.sandbox.jicloud.org/crate/shared/domain/image/struct.ImageSearchQuery.html#structfield.tags)

resolves #1086: Prioritisation can now be called with: [tags_priority](https://docs.sandbox.jicloud.org/crate/shared/domain/image/struct.ImageSearchQuery.html#structfield.tags_priority)