### PR TITLE
fix(be/fk_constraint): fix for updating jigs

### DIFF
--- a/backend/api/src/db/jig.rs
+++ b/backend/api/src/db/jig.rs
@@ -601,25 +601,25 @@ where id = $1
     .await?;
 
     if let Some(goals) = goals {
-        super::recycle_metadata(&mut txn, "jig_data", id.0, goals)
+        super::recycle_metadata(&mut txn, "jig_data", draft_id, goals)
             .await
             .map_err(super::meta::handle_metadata_err)?;
     }
 
     if let Some(categories) = categories {
-        super::recycle_metadata(&mut txn, "jig_data", id.0, categories)
+        super::recycle_metadata(&mut txn, "jig_data", draft_id, categories)
             .await
             .map_err(super::meta::handle_metadata_err)?;
     }
 
     if let Some(affiliations) = affiliations {
-        super::recycle_metadata(&mut txn, "jig_data", id.0, affiliations)
+        super::recycle_metadata(&mut txn, "jig_data", draft_id, affiliations)
             .await
             .map_err(super::meta::handle_metadata_err)?;
     }
 
     if let Some(age_ranges) = age_ranges {
-        super::recycle_metadata(&mut txn, "jig_data", id.0, age_ranges)
+        super::recycle_metadata(&mut txn, "jig_data", draft_id, age_ranges)
             .await
             .map_err(super::meta::handle_metadata_err)?;
     }

--- a/backend/api/tests/integration/jig.rs
+++ b/backend/api/tests/integration/jig.rs
@@ -352,7 +352,11 @@ async fn count() -> anyhow::Result<()> {
 
 #[actix_rt::test]
 async fn update_and_publish() -> anyhow::Result<()> {
-    let app = initialize_server(&[Fixture::User, Fixture::Jig], &[]).await;
+    let app = initialize_server(
+        &[Fixture::User, Fixture::Jig, Fixture::CategoryOrdering],
+        &[],
+    )
+    .await;
 
     let port = app.port();
 
@@ -379,7 +383,8 @@ async fn update_and_publish() -> anyhow::Result<()> {
         ))
         .json(&json!({
             "description": "asdasdasd",
-            "language": "en-us"
+            "language": "en-us",
+            "categories":["7fe19326-e883-11ea-93f0-5343493c17c4", "81c4796a-e883-11ea-93f0-df2484ab6b11"]
         }))
         .login()
         .send()
@@ -422,7 +427,7 @@ async fn update_and_publish() -> anyhow::Result<()> {
         }
     );
 
-    let resp = client
+    let _resp = client
         .put(&format!(
             "http://0.0.0.0:{}/v1/jig/3a71522a-cd77-11eb-8dc1-af3e35f7c743/draft/publish",
             port

--- a/backend/api/tests/integration/snapshots/integration__jig__update_and_publish-2.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__update_and_publish-2.snap
@@ -17,7 +17,10 @@ expression: body
     "affiliations": [],
     "goals": [],
     "language": "en-us",
-    "categories": [],
+    "categories": [
+      "7fe19326-e883-11ea-93f0-5343493c17c4",
+      "81c4796a-e883-11ea-93f0-df2484ab6b11"
+    ],
     "additionalResources": [],
     "description": "asdasdasd",
     "lastEdited": "[timestamp]",

--- a/backend/api/tests/integration/snapshots/integration__jig__update_and_publish-4.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__update_and_publish-4.snap
@@ -17,7 +17,10 @@ expression: body
     "affiliations": [],
     "goals": [],
     "language": "en-us",
-    "categories": [],
+    "categories": [
+      "7fe19326-e883-11ea-93f0-5343493c17c4",
+      "81c4796a-e883-11ea-93f0-df2484ab6b11"
+    ],
     "additionalResources": [],
     "description": "asdasdasd",
     "lastEdited": "[last_edited]",


### PR DESCRIPTION
Following fields can now be updated: `categories`, `affiliations`, `goals`, and `age_range`.