### PR TITLE
add legacy to map contents and kind

### DIFF
--- a/backend/api/src/db/jig/module.rs
+++ b/backend/api/src/db/jig/module.rs
@@ -19,6 +19,7 @@ fn map_module_contents(body: &ModuleBody) -> anyhow::Result<(ModuleKind, serde_j
         ModuleBody::Poster(body) => serde_json::to_value(body)?,
         ModuleBody::TappingBoard(body) => serde_json::to_value(body)?,
         ModuleBody::Video(body) => serde_json::to_value(body)?,
+        ModuleBody::Legacy(body) => serde_json::to_value(body)?,
 
         _ => anyhow::bail!("Unimplemented body kind: {}", kind.as_str()),
     };
@@ -40,6 +41,7 @@ fn transform_response_kind(
         ModuleKind::Poster => Ok(ModuleBody::Poster(serde_json::from_value(contents)?)),
         ModuleKind::TappingBoard => Ok(ModuleBody::TappingBoard(serde_json::from_value(contents)?)),
         ModuleKind::Video => Ok(ModuleBody::Video(serde_json::from_value(contents)?)),
+        ModuleKind::Legacy => Ok(ModuleBody::Legacy(serde_json::from_value(contents)?)),
 
         _ => anyhow::bail!("Unimplemented response kind"),
     }

--- a/backend/api/src/http/endpoints/search.rs
+++ b/backend/api/src/http/endpoints/search.rs
@@ -30,7 +30,7 @@ async fn create_key(
 /// Search for images over the web.
 pub async fn search_web_images(
     runtime_settings: Data<RuntimeSettings>,
-    // _claims: TokenUser,
+    _claims: TokenUser,
     query: Query<<search::WebImageSearch as ApiEndpoint>::Req>,
 ) -> Result<Json<<search::WebImageSearch as ApiEndpoint>::Res>, error::Server> {
     let query = query.into_inner();

--- a/shared/rust/src/domain/jig/module/body.rs
+++ b/shared/rust/src/domain/jig/module/body.rs
@@ -182,6 +182,7 @@ pub trait BodyExt<Mode: ModeExt, Step: StepExt>:
             ModuleKind::TappingBoard => Ok(Body::TappingBoard(self.convert_to_tapping_board()?)),
             ModuleKind::DragDrop => Ok(Body::DragDrop(self.convert_to_drag_drop()?)),
             ModuleKind::Cover => Ok(Body::Cover(self.convert_to_cover()?)),
+            ModuleKind::Legacy => Ok(Body::Legacy(self.convert_to_legacy()?)),
             _ => unimplemented!(
                 "cannot convert from {} to {}",
                 Self::kind().as_str(),
@@ -234,6 +235,10 @@ pub trait BodyConvert {
     /// Video
     fn convert_to_video(&self) -> Result<video::ModuleData, &'static str> {
         Err("cannot convert to video!")
+    }
+    /// Legacy
+    fn convert_to_legacy(&self) -> Result<legacy::ModuleData, &'static str> {
+        Err("cannot convert to legacy!")
     }
 }
 


### PR DESCRIPTION
issue #1722 

Added the following:

- `ModuleBody::Legacy(body)` for mapping module contents
- `ModuleKind::Legacy(body)` for transforming response kind
