### PR TITLE
feat(be/cover): add initial cover set in response and patch endpoint

### DIFF
--- a/backend/api/migrations/20211103181137_jig_module_cover.sql
+++ b/backend/api/migrations/20211103181137_jig_module_cover.sql
@@ -1,0 +1,5 @@
+alter table jig 
+    add column initial_cover_set boolean not null default true;
+
+alter table jig
+    alter initial_cover_set set default false;

--- a/backend/api/sqlx-data.json
+++ b/backend/api/sqlx-data.json
@@ -484,165 +484,6 @@
       ]
     }
   },
-  "0c1d0c95806bd5aba157081c5055edeeab5f4e19f4d525daf7cb1452f7ce66a4": {
-    "query": "\nselect jig.id                                              as \"jig_id: JigId\",\n       privacy_level                                       as \"privacy_level: PrivacyLevel\",\n       creator_id,\n       author_id,\n       (select given_name || ' '::text || family_name\n        from user_profile\n        where user_profile.user_id = author_id)            as \"author_name\",\n       published_at,\n       display_name                                        as \"display_name!\",\n       updated_at,\n       language                                            as \"language!\",\n       description                                         as \"description!\",\n       direction                                           as \"direction!: TextDirection\",\n       display_score                                       as \"display_score!\",\n       track_assessments                                   as \"track_assessments!\",\n       drag_assist                                         as \"drag_assist!\",\n       theme                                               as \"theme!: ThemeId\",\n       audio_background                                    as \"audio_background!: Option<AudioBackground>\",\n       array(select row (unnest(audio_feedback_positive))) as \"audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>\",\n       array(select row (unnest(audio_feedback_negative))) as \"audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>\",\n       array(\n               select row (jig_data_module.id, kind)\n               from jig_data_module\n               where jig_data_id = jig_data.id\n               order by \"index\"\n           )                                               as \"modules!: Vec<(ModuleId, ModuleKind)>\",\n       array(select row (goal_id)\n             from jig_data_goal\n             where jig_data_id = jig_data.id)              as \"goals!: Vec<(GoalId,)>\",\n       array(select row (category_id)\n             from jig_data_category\n             where jig_data_id = jig_data.id)              as \"categories!: Vec<(CategoryId,)>\",\n       array(select row (affiliation_id)\n             from jig_data_affiliation\n             where jig_data_id = jig_data.id)              as \"affiliations!: Vec<(AffiliationId,)>\",\n       array(select row (age_range_id)\n             from jig_data_age_range\n             where jig_data_id = jig_data.id)              as \"age_ranges!: Vec<(AgeRangeId,)>\",\n       array(select row (jig_data_additional_resource.id)\n             from jig_data_additional_resource\n             where jig_data_id = jig_data.id)              as \"additional_resources!: Vec<(AdditionalResourceId,)>\"\nfrom jig_data\n         inner join jig on jig_data.id = jig.draft_id\nwhere (author_id is not distinct from $2 or $2 is null)\norder by coalesce(updated_at, created_at) desc\nlimit 20 offset 20 * $1\n",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "jig_id: JigId",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 1,
-          "name": "privacy_level: PrivacyLevel",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 2,
-          "name": "creator_id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 3,
-          "name": "author_id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 4,
-          "name": "author_name",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 5,
-          "name": "published_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 6,
-          "name": "display_name!",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 7,
-          "name": "updated_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 8,
-          "name": "language!",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 9,
-          "name": "description!",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 10,
-          "name": "direction!: TextDirection",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 11,
-          "name": "display_score!",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 12,
-          "name": "track_assessments!",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 13,
-          "name": "drag_assist!",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 14,
-          "name": "theme!: ThemeId",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 15,
-          "name": "audio_background!: Option<AudioBackground>",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 16,
-          "name": "audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 17,
-          "name": "audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 18,
-          "name": "modules!: Vec<(ModuleId, ModuleKind)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 19,
-          "name": "goals!: Vec<(GoalId,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 20,
-          "name": "categories!: Vec<(CategoryId,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 21,
-          "name": "affiliations!: Vec<(AffiliationId,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 22,
-          "name": "age_ranges!: Vec<(AgeRangeId,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 23,
-          "name": "additional_resources!: Vec<(AdditionalResourceId,)>",
-          "type_info": "RecordArray"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Int4",
-          "Uuid"
-        ]
-      },
-      "nullable": [
-        false,
-        false,
-        true,
-        true,
-        null,
-        true,
-        false,
-        true,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        true,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-      ]
-    }
-  },
   "0ca2ee29314d9dd79d7eab236d935ac40f4699104a8e32d4fedda568c67d9ab5": {
     "query": "\ninsert into jig_data_module (jig_data_id, \"index\", kind, contents)\nvalues ($1, $2, $3, $4)\nreturning stable_id as \"stable_id: StableModuleId\"\n",
     "describe": {
@@ -1242,6 +1083,68 @@
       ]
     }
   },
+  "2da550cd367fdf35b43f66e29864d35cd65fc8bcf2e06043cb4e8c8322f66db7": {
+    "query": "\nselect jig.id                                       as \"id!: JigId\",\n       creator_id,\n       author_id                                as \"author_id\",\n       (select given_name || ' '::text || family_name\n        from user_profile\n        where user_profile.user_id = author_id) as \"author_name\",\n       initial_cover_set                        as \"initial_cover_set!\",\n       live_id                                  as \"live_id!\",\n       draft_id                                 as \"draft_id!\",\n       published_at\n\nfrom jig \n         inner join unnest($1::uuid[])\n    with ordinality t(id, ord) using (id)\norder by t.ord\n    ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id!: JigId",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 1,
+          "name": "creator_id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 2,
+          "name": "author_id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 3,
+          "name": "author_name",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 4,
+          "name": "initial_cover_set!",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 5,
+          "name": "live_id!",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 6,
+          "name": "draft_id!",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 7,
+          "name": "published_at",
+          "type_info": "Timestamptz"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "UuidArray"
+        ]
+      },
+      "nullable": [
+        false,
+        true,
+        true,
+        null,
+        false,
+        false,
+        false,
+        true
+      ]
+    }
+  },
   "2de098c6b9ee0874cf91614aff351a1538ddf0dbb477225708b253948abd264d": {
     "query": "\n            select uploaded_at\n            from web_media_upload wmu\n            inner join web_media_library wml on wml.kind = $1 \n            where wmu.media_id = $2 for update",
     "describe": {
@@ -1407,6 +1310,171 @@
         ]
       },
       "nullable": []
+    }
+  },
+  "3439eef5b2d442aaf1f06cd113c1710f591cadcaae25195a181f58766525d1d4": {
+    "query": "\nwith cte as (\n    select id      as \"jig_id\",\n           creator_id,\n           author_id,\n           case\n               when $2 = 0 then jig.draft_id\n               when $2 = 1 then jig.live_id\n               end as \"draft_or_live_id\",\n           initial_cover_set,\n           published_at\n    from jig\n    where id = $1\n)\nselect cte.jig_id                                          as \"jig_id: JigId\",\n       display_name,\n       creator_id,\n       author_id,\n       (select given_name || ' '::text || family_name\n        from user_profile\n        where user_profile.user_id = author_id)            as \"author_name\",\n       initial_cover_set,\n       published_at,\n       updated_at,\n       privacy_level                                       as \"privacy_level!: PrivacyLevel\",\n       language,\n       description,\n       direction                                           as \"direction: TextDirection\",\n       display_score,\n       track_assessments,\n       drag_assist,\n       theme                                               as \"theme: ThemeId\",\n       audio_background                                    as \"audio_background: AudioBackground\",\n       array(select row (unnest(audio_feedback_positive))) as \"audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>\",\n       array(select row (unnest(audio_feedback_negative))) as \"audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>\",\n       array(\n               select row (jig_data_module.id, kind)\n               from jig_data_module\n               where jig_data_id = cte.draft_or_live_id\n               order by \"index\"\n           )                                               as \"modules!: Vec<(ModuleId, ModuleKind)>\",\n       array(select row (goal_id)\n             from jig_data_goal\n             where jig_data_id = cte.draft_or_live_id)     as \"goals!: Vec<(GoalId,)>\",\n       array(select row (category_id)\n             from jig_data_category\n             where jig_data_id = cte.draft_or_live_id)     as \"categories!: Vec<(CategoryId,)>\",\n       array(select row (affiliation_id)\n             from jig_data_affiliation\n             where jig_data_id = cte.draft_or_live_id)     as \"affiliations!: Vec<(AffiliationId,)>\",\n       array(select row (age_range_id)\n             from jig_data_age_range\n             where jig_data_id = cte.draft_or_live_id)     as \"age_ranges!: Vec<(AgeRangeId,)>\",\n       array(select row (jig_data_additional_resource.id)\n             from jig_data_additional_resource\n             where jig_data_id = cte.draft_or_live_id)     as \"additional_resources!: Vec<(AdditionalResourceId,)>\"\nfrom jig_data\n         inner join cte on cte.draft_or_live_id = jig_data.id\n",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "jig_id: JigId",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 1,
+          "name": "display_name",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 2,
+          "name": "creator_id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 3,
+          "name": "author_id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 4,
+          "name": "author_name",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 5,
+          "name": "initial_cover_set",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 6,
+          "name": "published_at",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 7,
+          "name": "updated_at",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 8,
+          "name": "privacy_level!: PrivacyLevel",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 9,
+          "name": "language",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 10,
+          "name": "description",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 11,
+          "name": "direction: TextDirection",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 12,
+          "name": "display_score",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 13,
+          "name": "track_assessments",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 14,
+          "name": "drag_assist",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 15,
+          "name": "theme: ThemeId",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 16,
+          "name": "audio_background: AudioBackground",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 17,
+          "name": "audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 18,
+          "name": "audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 19,
+          "name": "modules!: Vec<(ModuleId, ModuleKind)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 20,
+          "name": "goals!: Vec<(GoalId,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 21,
+          "name": "categories!: Vec<(CategoryId,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 22,
+          "name": "affiliations!: Vec<(AffiliationId,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 23,
+          "name": "age_ranges!: Vec<(AgeRangeId,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 24,
+          "name": "additional_resources!: Vec<(AdditionalResourceId,)>",
+          "type_info": "RecordArray"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Int4"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
+        true,
+        true,
+        null,
+        false,
+        true,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ]
     }
   },
   "386d90ebabd3f05484bdba519793fa2cbc67c804a185216c3f58be42f0269ef6": {
@@ -2651,6 +2719,18 @@
       ]
     }
   },
+  "7c1ad2c8495aeac1a2597d5502aa6acf305599365be84d4314c7631f2e748eb7": {
+    "query": "\nupdate jig\nset initial_cover_set = true\nwhere id = $1\n",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      },
+      "nullable": []
+    }
+  },
   "7de388b21267e45c30f82ed5f18a433423d535b7e22a752bcd95c82fc050190e": {
     "query": "select count(*) - 1 as \"max_index!\" from jig_data_module where jig_data_id = $1",
     "describe": {
@@ -3214,62 +3294,6 @@
       "nullable": [
         true,
         false
-      ]
-    }
-  },
-  "910c085a55b0bd0eb5dea8be2c96acfe43560e1e300952fae14d8672bedc7953": {
-    "query": "\nselect jig.id                                       as \"id!: JigId\",\n       creator_id,\n       author_id                                as \"author_id\",\n       (select given_name || ' '::text || family_name\n        from user_profile\n        where user_profile.user_id = author_id) as \"author_name\",\n       live_id                                  as \"live_id!\",\n       draft_id                                 as \"draft_id!\",\n       published_at\nfrom jig \n         inner join unnest($1::uuid[])\n    with ordinality t(id, ord) using (id)\norder by t.ord\n    ",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id!: JigId",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 1,
-          "name": "creator_id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 2,
-          "name": "author_id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 3,
-          "name": "author_name",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 4,
-          "name": "live_id!",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 5,
-          "name": "draft_id!",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 6,
-          "name": "published_at",
-          "type_info": "Timestamptz"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "UuidArray"
-        ]
-      },
-      "nullable": [
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true
       ]
     }
   },
@@ -4538,165 +4562,6 @@
       ]
     }
   },
-  "df06aa9229adc97aca259cbb6c8778a69c55d9dc4c48bf0267e0860b52cd3355": {
-    "query": "\nwith cte as (\n    select id      as \"jig_id\",\n           creator_id,\n           author_id,\n           case\n               when $2 = 0 then jig.draft_id\n               when $2 = 1 then jig.live_id\n               end as \"draft_or_live_id\",\n           published_at\n    from jig\n    where id = $1\n)\nselect cte.jig_id                                          as \"jig_id: JigId\",\n       display_name,\n       creator_id,\n       author_id,\n       (select given_name || ' '::text || family_name\n        from user_profile\n        where user_profile.user_id = author_id)            as \"author_name\",\n       published_at,\n       updated_at,\n       privacy_level                                       as \"privacy_level!: PrivacyLevel\",\n       language,\n       description,\n       direction                                           as \"direction: TextDirection\",\n       display_score,\n       track_assessments,\n       drag_assist,\n       theme                                               as \"theme: ThemeId\",\n       audio_background                                    as \"audio_background: AudioBackground\",\n       array(select row (unnest(audio_feedback_positive))) as \"audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>\",\n       array(select row (unnest(audio_feedback_negative))) as \"audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>\",\n       array(\n               select row (jig_data_module.id, kind)\n               from jig_data_module\n               where jig_data_id = cte.draft_or_live_id\n               order by \"index\"\n           )                                               as \"modules!: Vec<(ModuleId, ModuleKind)>\",\n       array(select row (goal_id)\n             from jig_data_goal\n             where jig_data_id = cte.draft_or_live_id)     as \"goals!: Vec<(GoalId,)>\",\n       array(select row (category_id)\n             from jig_data_category\n             where jig_data_id = cte.draft_or_live_id)     as \"categories!: Vec<(CategoryId,)>\",\n       array(select row (affiliation_id)\n             from jig_data_affiliation\n             where jig_data_id = cte.draft_or_live_id)     as \"affiliations!: Vec<(AffiliationId,)>\",\n       array(select row (age_range_id)\n             from jig_data_age_range\n             where jig_data_id = cte.draft_or_live_id)     as \"age_ranges!: Vec<(AgeRangeId,)>\",\n       array(select row (jig_data_additional_resource.id)\n             from jig_data_additional_resource\n             where jig_data_id = cte.draft_or_live_id)     as \"additional_resources!: Vec<(AdditionalResourceId,)>\"\nfrom jig_data\n         inner join cte on cte.draft_or_live_id = jig_data.id\n",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "jig_id: JigId",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 1,
-          "name": "display_name",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 2,
-          "name": "creator_id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 3,
-          "name": "author_id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 4,
-          "name": "author_name",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 5,
-          "name": "published_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 6,
-          "name": "updated_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 7,
-          "name": "privacy_level!: PrivacyLevel",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 8,
-          "name": "language",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 9,
-          "name": "description",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 10,
-          "name": "direction: TextDirection",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 11,
-          "name": "display_score",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 12,
-          "name": "track_assessments",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 13,
-          "name": "drag_assist",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 14,
-          "name": "theme: ThemeId",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 15,
-          "name": "audio_background: AudioBackground",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 16,
-          "name": "audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 17,
-          "name": "audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 18,
-          "name": "modules!: Vec<(ModuleId, ModuleKind)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 19,
-          "name": "goals!: Vec<(GoalId,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 20,
-          "name": "categories!: Vec<(CategoryId,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 21,
-          "name": "affiliations!: Vec<(AffiliationId,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 22,
-          "name": "age_ranges!: Vec<(AgeRangeId,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 23,
-          "name": "additional_resources!: Vec<(AdditionalResourceId,)>",
-          "type_info": "RecordArray"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Int4"
-        ]
-      },
-      "nullable": [
-        false,
-        false,
-        true,
-        true,
-        null,
-        true,
-        true,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        true,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-      ]
-    }
-  },
   "e14033c3f8bfad53554ff26c0c0d6f5910197db152016364df0c19b2e4665e42": {
     "query": "\ninsert into jig_data_additional_resource (jig_data_id, url)\nvalues ((select draft_id from jig where id = $1), $2)\nreturning id as \"id!: AdditionalResourceId\"\n        ",
     "describe": {
@@ -4815,6 +4680,171 @@
         ]
       },
       "nullable": []
+    }
+  },
+  "e5cd5a1b42322bb8f7dfab60561f91027e3ef7268d39e3d954555e928a279fdc": {
+    "query": "\nselect jig.id                                              as \"jig_id: JigId\",\n       privacy_level                                       as \"privacy_level: PrivacyLevel\",\n       creator_id,\n       author_id,\n       (select given_name || ' '::text || family_name\n        from user_profile\n        where user_profile.user_id = author_id)            as \"author_name\",\n       initial_cover_set                                   as \"initial_cover_set!\",\n       published_at,\n       display_name                                        as \"display_name!\",\n       updated_at,\n       language                                            as \"language!\",\n       description                                         as \"description!\",\n       direction                                           as \"direction!: TextDirection\",\n       display_score                                       as \"display_score!\",\n       track_assessments                                   as \"track_assessments!\",\n       drag_assist                                         as \"drag_assist!\",\n       theme                                               as \"theme!: ThemeId\",\n       audio_background                                    as \"audio_background!: Option<AudioBackground>\",\n       array(select row (unnest(audio_feedback_positive))) as \"audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>\",\n       array(select row (unnest(audio_feedback_negative))) as \"audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>\",\n       array(\n               select row (jig_data_module.id, kind)\n               from jig_data_module\n               where jig_data_id = jig_data.id\n               order by \"index\"\n           )                                               as \"modules!: Vec<(ModuleId, ModuleKind)>\",\n       array(select row (goal_id)\n             from jig_data_goal\n             where jig_data_id = jig_data.id)              as \"goals!: Vec<(GoalId,)>\",\n       array(select row (category_id)\n             from jig_data_category\n             where jig_data_id = jig_data.id)              as \"categories!: Vec<(CategoryId,)>\",\n       array(select row (affiliation_id)\n             from jig_data_affiliation\n             where jig_data_id = jig_data.id)              as \"affiliations!: Vec<(AffiliationId,)>\",\n       array(select row (age_range_id)\n             from jig_data_age_range\n             where jig_data_id = jig_data.id)              as \"age_ranges!: Vec<(AgeRangeId,)>\",\n       array(select row (jig_data_additional_resource.id)\n             from jig_data_additional_resource\n             where jig_data_id = jig_data.id)              as \"additional_resources!: Vec<(AdditionalResourceId,)>\"\nfrom jig_data\n         inner join jig on jig_data.id = jig.draft_id\nwhere (author_id is not distinct from $2 or $2 is null)\norder by coalesce(updated_at, created_at) desc\nlimit 20 offset 20 * $1\n",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "jig_id: JigId",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 1,
+          "name": "privacy_level: PrivacyLevel",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 2,
+          "name": "creator_id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 3,
+          "name": "author_id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 4,
+          "name": "author_name",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 5,
+          "name": "initial_cover_set!",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 6,
+          "name": "published_at",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 7,
+          "name": "display_name!",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 8,
+          "name": "updated_at",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 9,
+          "name": "language!",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 10,
+          "name": "description!",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 11,
+          "name": "direction!: TextDirection",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 12,
+          "name": "display_score!",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 13,
+          "name": "track_assessments!",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 14,
+          "name": "drag_assist!",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 15,
+          "name": "theme!: ThemeId",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 16,
+          "name": "audio_background!: Option<AudioBackground>",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 17,
+          "name": "audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 18,
+          "name": "audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 19,
+          "name": "modules!: Vec<(ModuleId, ModuleKind)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 20,
+          "name": "goals!: Vec<(GoalId,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 21,
+          "name": "categories!: Vec<(CategoryId,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 22,
+          "name": "affiliations!: Vec<(AffiliationId,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 23,
+          "name": "age_ranges!: Vec<(AgeRangeId,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 24,
+          "name": "additional_resources!: Vec<(AdditionalResourceId,)>",
+          "type_info": "RecordArray"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int4",
+          "Uuid"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
+        true,
+        true,
+        null,
+        false,
+        true,
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ]
     }
   },
   "e799bf3796ba5e67d61e1914acbed273c38fe016c213c74f2acbe13071d3e81e": {

--- a/backend/api/src/http/endpoints/jig.rs
+++ b/backend/api/src/http/endpoints/jig.rs
@@ -156,6 +156,21 @@ async fn delete(
     Ok(HttpResponse::NoContent().finish())
 }
 
+/// Delete a jig.
+async fn cover(
+    db: Data<PgPool>,
+    claims: TokenUser,
+    path: web::Path<JigId>,
+) -> Result<HttpResponse, error::Delete> {
+    let id = path.into_inner();
+
+    db::jig::authz(&*db, claims.0.user_id, Some(id)).await?;
+
+    db::jig::cover_set(&*db, id).await?;
+
+    Ok(HttpResponse::NoContent().finish())
+}
+
 async fn browse(
     db: Data<PgPool>,
     claims: TokenUser,
@@ -303,6 +318,7 @@ pub fn configure(cfg: &mut ServiceConfig) {
             jig::UpdateDraftData::METHOD.route().to(update_draft),
         )
         .route(jig::Delete::PATH, jig::Delete::METHOD.route().to(delete))
+        .route(jig::Cover::PATH, jig::Cover::METHOD.route().to(cover))
         .route(
             jig::player::Create::PATH,
             jig::player::Create::METHOD.route().to(player::create),

--- a/backend/api/tests/integration/jig/snapshots/integration__jig__cover__update_no_modules_changes.snap
+++ b/backend/api/tests/integration/jig/snapshots/integration__jig__cover__update_no_modules_changes.snap
@@ -9,6 +9,7 @@ expression: body
   "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
   "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
   "authorName": "Bobby Tables",
+  "initialCoverSet": false,
   "jigData": {
     "draftOrLive": "Draft",
     "displayName": "test",

--- a/backend/api/tests/integration/snapshots/integration__jig__browse_own_simple.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__browse_own_simple.snap
@@ -11,6 +11,7 @@ expression: body
       "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
       "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
       "authorName": "Bobby Tables",
+      "initialCoverSet": false,
       "jigData": {
         "draftOrLive": "Draft",
         "displayName": "name",
@@ -60,6 +61,7 @@ expression: body
       "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
       "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
       "authorName": "Bobby Tables",
+      "initialCoverSet": false,
       "jigData": {
         "draftOrLive": "Draft",
         "displayName": "draft name",

--- a/backend/api/tests/integration/snapshots/integration__jig__browse_simple.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__browse_simple.snap
@@ -11,6 +11,7 @@ expression: body
       "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
       "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
       "authorName": "Bobby Tables",
+      "initialCoverSet": false,
       "jigData": {
         "draftOrLive": "Draft",
         "displayName": "name",
@@ -60,6 +61,7 @@ expression: body
       "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
       "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
       "authorName": "Bobby Tables",
+      "initialCoverSet": false,
       "jigData": {
         "draftOrLive": "Draft",
         "displayName": "draft name",

--- a/backend/api/tests/integration/snapshots/integration__jig__clone-2.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__clone-2.snap
@@ -9,6 +9,7 @@ expression: body
   "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
   "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
   "authorName": "Bobby Tables",
+  "initialCoverSet": false,
   "jigData": {
     "draftOrLive": "Live",
     "displayName": "name",

--- a/backend/api/tests/integration/snapshots/integration__jig__clone.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__clone.snap
@@ -9,6 +9,7 @@ expression: body
   "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
   "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
   "authorName": "Bobby Tables",
+  "initialCoverSet": false,
   "jigData": {
     "draftOrLive": "Draft",
     "displayName": "draft name",

--- a/backend/api/tests/integration/snapshots/integration__jig__create_default-2.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__create_default-2.snap
@@ -9,6 +9,7 @@ expression: body
   "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
   "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
   "authorName": "Bobby Tables",
+  "initialCoverSet": false,
   "jigData": {
     "draftOrLive": "Draft",
     "displayName": "",

--- a/backend/api/tests/integration/snapshots/integration__jig__create_default-3.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__create_default-3.snap
@@ -9,6 +9,7 @@ expression: body
   "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
   "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
   "authorName": "Bobby Tables",
+  "initialCoverSet": false,
   "jigData": {
     "draftOrLive": "Live",
     "displayName": "",

--- a/backend/api/tests/integration/snapshots/integration__jig__get-2.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__get-2.snap
@@ -9,6 +9,7 @@ expression: body
   "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
   "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
   "authorName": "Bobby Tables",
+  "initialCoverSet": false,
   "jigData": {
     "draftOrLive": "Live",
     "displayName": "name",

--- a/backend/api/tests/integration/snapshots/integration__jig__get.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__get.snap
@@ -9,6 +9,7 @@ expression: body
   "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
   "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
   "authorName": "Bobby Tables",
+  "initialCoverSet": false,
   "jigData": {
     "draftOrLive": "Draft",
     "displayName": "name",

--- a/backend/api/tests/integration/snapshots/integration__jig__update_and_publish-2.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__update_and_publish-2.snap
@@ -9,6 +9,7 @@ expression: body
   "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
   "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
   "authorName": "Bobby Tables",
+  "initialCoverSet": false,
   "jigData": {
     "draftOrLive": "Draft",
     "displayName": "draft name",

--- a/backend/api/tests/integration/snapshots/integration__jig__update_and_publish-3.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__update_and_publish-3.snap
@@ -9,6 +9,7 @@ expression: body
   "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
   "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
   "authorName": "Bobby Tables",
+  "initialCoverSet": false,
   "jigData": {
     "draftOrLive": "Live",
     "displayName": "name",

--- a/backend/api/tests/integration/snapshots/integration__jig__update_and_publish-4.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__update_and_publish-4.snap
@@ -9,6 +9,7 @@ expression: body
   "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
   "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
   "authorName": "Bobby Tables",
+  "initialCoverSet": false,
   "jigData": {
     "draftOrLive": "Live",
     "displayName": "draft name",

--- a/backend/api/tests/integration/snapshots/integration__jig__update_and_publish.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__update_and_publish.snap
@@ -9,6 +9,7 @@ expression: body
   "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
   "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
   "authorName": "Bobby Tables",
+  "initialCoverSet": false,
   "jigData": {
     "draftOrLive": "Draft",
     "displayName": "draft name",

--- a/shared/rust/src/api/endpoints/jig.rs
+++ b/shared/rust/src/api/endpoints/jig.rs
@@ -168,6 +168,19 @@ impl ApiEndpoint for Delete {
     const METHOD: Method = Method::Delete;
 }
 
+/// Indicates if a jig has a cover
+///
+/// # Authorization
+/// * One of `Admin`, `AdminJig`, or `ManageSelfJig` for owned JIGs
+pub struct Cover;
+impl ApiEndpoint for Cover {
+    type Req = ();
+    type Res = ();
+    type Err = EmptyError;
+    const PATH: &'static str = "/v1/jig/{id}/cover";
+    const METHOD: Method = Method::Patch;
+}
+
 /// Count of all public JIGs. See [`PrivacyLevel`](crate::domain::jig::PrivacyLevel).
 ///
 /// # Authorization

--- a/shared/rust/src/domain/jig.rs
+++ b/shared/rust/src/domain/jig.rs
@@ -407,6 +407,9 @@ pub struct JigResponse {
     /// The author's name, as "{given_name} {family_name}".
     pub author_name: Option<String>,
 
+    /// True if Jig cover is set
+    pub initial_cover_set: bool,
+
     /// The data of the requested JIG.
     pub jig_data: JigData,
 }


### PR DESCRIPTION
closes issue: #1795 

migrated new field to existing jigs, set to true, and defaulted new jigs to false until a cover is set

Added Endpoint: 

`PATCH ../v1/jig/{jigId}/cover` 
- inputs: Jig id in path