### PR TITLE
refactor(be/get_module): omit stable id option and query parameter

### DIFF
--- a/backend/api/sqlx-data.json
+++ b/backend/api/sqlx-data.json
@@ -4702,13 +4702,13 @@
         ]
       },
       "nullable": [
+        false,
         true,
         true,
-        true,
-        true,
-        true,
-        true,
-        true,
+        null,
+        false,
+        false,
+        false,
         true
       ]
     }

--- a/backend/api/src/http/endpoints/jig/module.rs
+++ b/backend/api/src/http/endpoints/jig/module.rs
@@ -1,12 +1,12 @@
 use actix_web::{
-    web::{self, Data, Json, Path, Query, ServiceConfig},
+    web::{self, Data, Json, Path, ServiceConfig},
     HttpResponse,
 };
 use shared::{
     api::{endpoints::jig::module, ApiEndpoint},
     domain::{
         jig::{
-            module::{ModuleId, ModuleResponse, StableModuleId, StableOrUniqueId},
+            module::{ModuleId, ModuleResponse, StableOrUniqueId},
             JigId,
         },
         CreateResponse,
@@ -40,22 +40,10 @@ async fn create(
 async fn get_live(
     db: Data<PgPool>,
     path: web::Path<(JigId, String)>,
-    query: Query<<module::GetLive as ApiEndpoint>::Req>,
 ) -> Result<Json<<module::GetLive as ApiEndpoint>::Res>, error::NotFound> {
     let path = path.into_inner();
-    let query = query.into_inner();
 
-    let q: &str = &query.q;
-
-    let module_id = match q {
-        "stable" => StableOrUniqueId::Stable(StableModuleId(uuid::Uuid::parse_str(&path.1)?)),
-
-        "unique" => StableOrUniqueId::Unique(ModuleId(uuid::Uuid::parse_str(&path.1)?)),
-
-        _ => {
-            return Err(error::NotFound::ResourceNotFound);
-        }
-    };
+    let module_id = StableOrUniqueId::Unique(ModuleId(uuid::Uuid::parse_str(&path.1)?));
 
     let module = db::jig::module::get_live(&db, path.0, module_id)
         .await?
@@ -70,22 +58,10 @@ async fn get_live(
 async fn get_draft(
     db: Data<PgPool>,
     path: web::Path<(JigId, String)>,
-    query: Query<<module::GetLive as ApiEndpoint>::Req>,
 ) -> Result<Json<<module::GetDraft as ApiEndpoint>::Res>, error::NotFound> {
     let path = path.into_inner();
-    let query = query.into_inner();
 
-    let q: &str = &query.q;
-
-    let module_id = match q {
-        "stable" => StableOrUniqueId::Stable(StableModuleId(uuid::Uuid::parse_str(&path.1)?)),
-
-        "unique" => StableOrUniqueId::Unique(ModuleId(uuid::Uuid::parse_str(&path.1)?)),
-
-        _ => {
-            return Err(error::NotFound::ResourceNotFound);
-        }
-    };
+    let module_id = StableOrUniqueId::Unique(ModuleId(uuid::Uuid::parse_str(&path.1)?));
 
     let module = db::jig::module::get_draft(&db, path.0, module_id)
         .await?

--- a/backend/api/tests/integration/jig/module.rs
+++ b/backend/api/tests/integration/jig/module.rs
@@ -1,8 +1,7 @@
 use http::StatusCode;
 
 use shared::domain::jig::module::{
-    body::memory, ModuleBody, ModuleCreateRequest, ModuleId, ModuleUpdateRequest, StableModuleId,
-    StableOrUniqueId,
+    body::memory, ModuleBody, ModuleCreateRequest, ModuleId, ModuleUpdateRequest, StableOrUniqueId,
 };
 
 use crate::{
@@ -20,27 +19,9 @@ async fn get_live() -> anyhow::Result<()> {
 
     let resp = client
         .get(&format!(
-            "http://0.0.0.0:{}/v1/jig/0cc084bc-7c83-11eb-9f77-e3218dffb008/live/module/0cc03a02-7c83-11eb-9f77-f77f9ad65e9a",
+            "http://0.0.0.0:{}/v1/jig/0cc084bc-7c83-11eb-9f77-e3218dffb008/live/module/a6b24970-1dd7-11ec-8426-57136b411853",
             port
         ))
-        .query(&[("q", "stable")])
-        .login()
-        .send()
-        .await?
-        .error_for_status()?;
-
-    assert_eq!(resp.status(), StatusCode::OK);
-
-    let body: serde_json::Value = resp.json().await?;
-
-    insta::assert_json_snapshot!(body, {".**.updated_at" => "[timestamp]"});
-
-    let resp = client
-        .get(&format!(
-            "http://0.0.0.0:{}/v1/jig/0cc084bc-7c83-11eb-9f77-e3218dffb008/live/module/0cc03a02-7c83-11eb-9f77-f77f9ad65e9a",
-            port
-        ))
-        .query(&[("q", "stable")])
         .login()
         .send()
         .await?
@@ -146,24 +127,6 @@ async fn update_empty() -> anyhow::Result<()> {
             "http://0.0.0.0:{}/v1/jig/0cc084bc-7c83-11eb-9f77-e3218dffb008/draft/module/a6b24a42-1dd7-11ec-8426-a7165f9281a2",
             port
         ))
-        .query(&[("q", "unique")])
-        .login()
-        .send()
-        .await?
-        .error_for_status()?;
-
-    assert_eq!(resp.status(), StatusCode::OK);
-
-    let body: serde_json::Value = resp.json().await?;
-
-    insta::assert_json_snapshot!(body, {".**.updated_at" => "[timestamp]"});
-
-    let resp = client
-        .get(&format!(
-            "http://0.0.0.0:{}/v1/jig/0cc084bc-7c83-11eb-9f77-e3218dffb008/draft/module/0cc03a02-7c83-11eb-9f77-f77f9ad65e9a",
-            port
-        ))
-        .query(&[("q", "stable")])
         .login()
         .send()
         .await?
@@ -188,6 +151,8 @@ async fn update_contents() -> anyhow::Result<()> {
 
     let client = reqwest::Client::new();
 
+    println!("Before module");
+
     let resp = client
         .patch(&format!(
             "http://0.0.0.0:{}/v1/jig/0cc084bc-7c83-11eb-9f77-e3218dffb008/draft/module",
@@ -195,8 +160,8 @@ async fn update_contents() -> anyhow::Result<()> {
         ))
         .login()
         .json(&ModuleUpdateRequest {
-            id: StableOrUniqueId::Stable(StableModuleId(uuid::Uuid::parse_str(
-                "0cc03a02-7c83-11eb-9f77-f77f9ad65e9a",
+            id: StableOrUniqueId::Unique(ModuleId(uuid::Uuid::parse_str(
+                "a6b24970-1dd7-11ec-8426-57136b411853",
             )?)),
             body: Some(ModuleBody::MemoryGame(memory::ModuleData {
                 content: Some(memory::Content {
@@ -214,10 +179,9 @@ async fn update_contents() -> anyhow::Result<()> {
 
     let resp = client
         .get(&format!(
-            "http://0.0.0.0:{}/v1/jig/0cc084bc-7c83-11eb-9f77-e3218dffb008/draft/module/0cc03a02-7c83-11eb-9f77-f77f9ad65e9a",
+            "http://0.0.0.0:{}/v1/jig/0cc084bc-7c83-11eb-9f77-e3218dffb008/draft/module/a6b24970-1dd7-11ec-8426-57136b411853",
             port
         ))
-        .query(&[("q", "stable")])
         .login()
         .send()
         .await?
@@ -234,7 +198,6 @@ async fn update_contents() -> anyhow::Result<()> {
             "http://0.0.0.0:{}/v1/jig/0cc084bc-7c83-11eb-9f77-e3218dffb008/draft/module/a6b24a42-1dd7-11ec-8426-a7165f9281a2",
             port
         ))
-        .query(&[("q", "unique")])
         .login()
         .send()
         .await?

--- a/backend/api/tests/integration/jig/snapshots/integration__jig__module__update_contents.snap
+++ b/backend/api/tests/integration/jig/snapshots/integration__jig__module__update_contents.snap
@@ -5,32 +5,14 @@ expression: body
 ---
 {
   "module": {
-    "id": "a6b24a42-1dd7-11ec-8426-a7165f9281a2",
+    "id": "a6b24970-1dd7-11ec-8426-57136b411853",
     "stable_id": "0cc03a02-7c83-11eb-9f77-f77f9ad65e9a",
     "body": {
-      "memoryGame": {
-        "content": {
-          "base": {
-            "editor_state": {
-              "step": "One",
-              "steps_completed": []
-            },
-            "instructions": {
-              "text": null,
-              "audio": null
-            },
-            "mode": "Duplicate",
-            "pairs": [],
-            "theme": "Jig",
-            "background": null
-          },
-          "player_settings": {
-            "time_limit": null
-          }
-        }
+      "flashcards": {
+        "content": null
       }
     },
-    "is_complete": true,
+    "is_complete": false,
     "is_updated": true,
     "created_at": "2021-03-04T00:46:26.134651Z",
     "updated_at": "[timestamp]"

--- a/shared/rust/src/api/endpoints/jig/module.rs
+++ b/shared/rust/src/api/endpoints/jig/module.rs
@@ -2,8 +2,7 @@ use crate::{
     api::Method,
     domain::{
         jig::module::{
-            ModuleCreateRequest, ModuleDeleteRequest, ModuleGetQuery, ModuleId, ModuleResponse,
-            ModuleUpdateRequest,
+            ModuleCreateRequest, ModuleDeleteRequest, ModuleId, ModuleResponse, ModuleUpdateRequest,
         },
         CreateResponse,
     },
@@ -21,7 +20,7 @@ use super::ApiEndpoint;
 /// * [`NotFound`](http::StatusCode::NOT_FOUND) if the module does not exist, or the parent jig doesn't exist.
 pub struct GetLive;
 impl ApiEndpoint for GetLive {
-    type Req = ModuleGetQuery;
+    type Req = ();
     type Res = ModuleResponse;
     type Err = EmptyError;
     const PATH: &'static str = "/v1/jig/{id}/live/module/{module_id}";
@@ -38,7 +37,7 @@ impl ApiEndpoint for GetLive {
 /// * [`NotFound`](http::StatusCode::NOT_FOUND) if the module does not exist, or the parent jig doesn't exist.
 pub struct GetDraft;
 impl ApiEndpoint for GetDraft {
-    type Req = ModuleGetQuery;
+    type Req = ();
     type Res = ModuleResponse;
     type Err = EmptyError;
     const PATH: &'static str = "/v1/jig/{id}/draft/module/{module_id}";

--- a/shared/rust/src/domain/jig/module.rs
+++ b/shared/rust/src/domain/jig/module.rs
@@ -176,13 +176,6 @@ impl FromStr for ModuleKind {
     }
 }
 
-/// Request for fetching a module.
-#[derive(Clone, Serialize, Deserialize, Debug)]
-pub struct ModuleGetQuery {
-    /// The type of the ID.
-    pub q: String,
-}
-
 /// Minimal information about a module.
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct LiteModule {


### PR DESCRIPTION
closes issue #1928 

`GET Module` only requires path inputs
