### PR TITLE
refactor(be/resources): add 404 error messages

### DIFF
--- a/backend/api/sqlx-data.json
+++ b/backend/api/sqlx-data.json
@@ -4127,16 +4127,16 @@
         ]
       },
       "nullable": [
+        false,
         true,
         true,
+        null,
+        false,
+        false,
+        false,
         true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true
+        false,
+        null
       ]
     }
   },
@@ -4683,6 +4683,27 @@
         ]
       },
       "nullable": []
+    }
+  },
+  "c991e500948ede0aba8f2a8bd11f43aa266ae6c986cf0fa9ce1c48f64d4dde5c": {
+    "query": "\nselect exists(select 1 from jig_data_additional_resource \"jdar\" where jig_data_id = $1\n    and jdar.id = $2) as \"exists!\"\n    ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "exists!",
+          "type_info": "Bool"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Uuid"
+        ]
+      },
+      "nullable": [
+        null
+      ]
     }
   },
   "cd49cef54182b43dd7943bcd51fd3c535f4a8ec0dae95cbc8ceb39f7f757fe02": {

--- a/backend/api/src/error.rs
+++ b/backend/api/src/error.rs
@@ -35,7 +35,7 @@ pub type BasicError = ApiError<EmptyError>;
 pub enum Auth {
     InternalServerError(anyhow::Error),
     Forbidden,
-    BadRequest,
+    ResourceNotFound(String),
 }
 
 impl<T: Into<anyhow::Error>> From<T> for Auth {
@@ -49,9 +49,8 @@ impl Into<actix_web::Error> for Auth {
         match self {
             Self::Forbidden => BasicError::new(http::StatusCode::FORBIDDEN).into(),
             Self::InternalServerError(e) => ise(e),
-            Self::BadRequest => {
-                BasicError::with_message(http::StatusCode::BAD_REQUEST, "Invalid Input".to_owned())
-                    .into()
+            Self::ResourceNotFound(message) => {
+                BasicError::with_message(http::StatusCode::NOT_FOUND, message).into()
             }
         }
     }
@@ -73,7 +72,6 @@ pub enum Delete {
     Forbidden,
     ResourceNotFound,
     InternalServerError(anyhow::Error),
-    BadRequest,
 }
 
 impl<T: Into<anyhow::Error>> From<T> for Delete {
@@ -87,7 +85,7 @@ impl From<Auth> for Delete {
         match e {
             Auth::InternalServerError(e) => Self::InternalServerError(e),
             Auth::Forbidden => Self::Forbidden,
-            Auth::BadRequest => Self::BadRequest,
+            Auth::ResourceNotFound(_) => Self::ResourceNotFound,
         }
     }
 }
@@ -99,7 +97,6 @@ impl Into<actix_web::Error> for Delete {
             Self::Forbidden => BasicError::new(http::StatusCode::FORBIDDEN).into(),
             Self::ResourceNotFound => BasicError::new(http::StatusCode::NOT_FOUND).into(),
             Self::InternalServerError(e) => ise(e),
-            Self::BadRequest => BasicError::new(http::StatusCode::BAD_REQUEST).into(),
         }
     }
 }
@@ -234,7 +231,6 @@ pub enum NotFound {
     ResourceNotFound,
     Forbidden,
     InternalServerError(anyhow::Error),
-    BadRequest,
 }
 
 impl From<Auth> for NotFound {
@@ -242,7 +238,7 @@ impl From<Auth> for NotFound {
         match e {
             Auth::InternalServerError(e) => Self::InternalServerError(e),
             Auth::Forbidden => Self::Forbidden,
-            Auth::BadRequest => Self::BadRequest,
+            Auth::ResourceNotFound(_) => Self::ResourceNotFound,
         }
     }
 }
@@ -263,7 +259,6 @@ impl Into<actix_web::Error> for NotFound {
             .into(),
             Self::Forbidden => BasicError::new(http::StatusCode::FORBIDDEN).into(),
             Self::InternalServerError(e) => ise(e),
-            Self::BadRequest => BasicError::new(http::StatusCode::BAD_REQUEST).into(),
         }
     }
 }
@@ -367,7 +362,7 @@ pub enum CreateWithMetadata {
     InternalServerError(anyhow::Error),
     Forbidden,
     MissingMetadata(MetadataNotFound),
-    BadRequest,
+    ResourceNotFound,
 }
 
 impl From<Auth> for CreateWithMetadata {
@@ -375,7 +370,7 @@ impl From<Auth> for CreateWithMetadata {
         match e {
             Auth::InternalServerError(e) => Self::InternalServerError(e),
             Auth::Forbidden => Self::Forbidden,
-            Auth::BadRequest => Self::BadRequest,
+            Auth::ResourceNotFound(_) => Self::ResourceNotFound,
         }
     }
 }
@@ -397,7 +392,7 @@ impl Into<actix_web::Error> for CreateWithMetadata {
             .into(),
             Self::Forbidden => BasicError::new(http::StatusCode::FORBIDDEN).into(),
             Self::InternalServerError(e) => ise(e),
-            Self::BadRequest => BasicError::new(http::StatusCode::BAD_REQUEST).into(),
+            Self::ResourceNotFound => BasicError::new(http::StatusCode::BAD_REQUEST).into(),
         }
     }
 }
@@ -407,7 +402,6 @@ pub enum UpdateWithMetadata {
     InternalServerError(anyhow::Error),
     MissingMetadata(MetadataNotFound),
     Forbidden,
-    BadRequest,
 }
 
 impl From<Auth> for UpdateWithMetadata {
@@ -415,7 +409,7 @@ impl From<Auth> for UpdateWithMetadata {
         match e {
             Auth::InternalServerError(e) => Self::InternalServerError(e),
             Auth::Forbidden => Self::Forbidden,
-            Auth::BadRequest => Self::BadRequest,
+            Auth::ResourceNotFound(_) => Self::ResourceNotFound,
         }
     }
 }
@@ -445,8 +439,6 @@ impl Into<actix_web::Error> for UpdateWithMetadata {
             Self::Forbidden => BasicError::new(http::StatusCode::FORBIDDEN).into(),
 
             Self::InternalServerError(e) => ise(e),
-
-            Self::BadRequest => BasicError::new(http::StatusCode::BAD_REQUEST).into(),
         }
     }
 }
@@ -572,7 +564,6 @@ pub enum JigCloneDraft {
     Conflict,
     Forbidden,
     InternalServerError(anyhow::Error),
-    BadRequest,
 }
 
 impl<T: Into<anyhow::Error>> From<T> for JigCloneDraft {
@@ -586,7 +577,7 @@ impl From<Auth> for JigCloneDraft {
         match e {
             Auth::InternalServerError(e) => Self::InternalServerError(e),
             Auth::Forbidden => Self::Forbidden,
-            Auth::BadRequest => Self::BadRequest,
+            Auth::ResourceNotFound(_) => Self::ResourceNotFound,
         }
     }
 }
@@ -615,8 +606,6 @@ impl Into<actix_web::Error> for JigCloneDraft {
             Self::Forbidden => BasicError::new(http::StatusCode::FORBIDDEN).into(),
 
             Self::InternalServerError(e) => ise(e),
-
-            Self::BadRequest => BasicError::new(http::StatusCode::BAD_REQUEST).into(),
         }
     }
 }
@@ -655,7 +644,6 @@ pub enum JigCode {
     Conflict,
     AllCodesUsed,
     Forbidden,
-    BadRequest,
 }
 
 impl<T: Into<anyhow::Error>> From<T> for JigCode {
@@ -692,8 +680,6 @@ impl Into<actix_web::Error> for JigCode {
                 "User does not have permissions for this jig".to_owned(),
             )
             .into(),
-
-            Self::BadRequest => BasicError::new(http::StatusCode::BAD_REQUEST).into(),
         }
     }
 }
@@ -703,7 +689,7 @@ impl From<Auth> for JigCode {
         match err {
             Auth::InternalServerError(e) => Self::InternalServerError(e),
             Auth::Forbidden => Self::Forbidden,
-            Auth::BadRequest => Self::BadRequest,
+            Auth::ResourceNotFound(_) => Self::ResourceNotFound,
         }
     }
 }


### PR DESCRIPTION
closes issue #1952 

Additional resource `GET` endpoints have 404 error messages instead of 500.