### PR TITLE
fix(fe/home): Active content header for search mode

### DIFF
--- a/frontend/apps/crates/entry/home/src/home/dom/mod.rs
+++ b/frontend/apps/crates/entry/home/src/home/dom/mod.rs
@@ -18,7 +18,9 @@ mod search_section;
 
 pub fn render(state: Rc<State>, auto_search: bool) -> Dom {
     html!("home-full", {
-        .child(page_header::dom::render(Rc::new(page_header::state::State::new()), None, Some(PageLinks::Home)))
+        .child_signal(state.mode.signal_ref(|mode| {
+            Some(page_header::dom::render(Rc::new(page_header::state::State::new()), None, Some(PageLinks::from(mode))))
+        }))
         .children(&mut [
             search_section::render(state.clone(), auto_search),
             html!("empty-fragment", {

--- a/frontend/apps/crates/entry/home/src/home/state/mod.rs
+++ b/frontend/apps/crates/entry/home/src/home/state/mod.rs
@@ -5,6 +5,8 @@ use futures_signals::{signal::Mutable, signal_vec::MutableVec};
 use search_state::{SearchOptions, SearchSelected};
 use shared::domain::jig::{JigId, JigResponse, JigSearchQuery};
 
+use components::page_header::state::PageLinks;
+
 mod search_state;
 
 pub struct State {
@@ -138,6 +140,15 @@ impl State {
 pub enum HomePageMode {
     Home,
     Search(String, Rc<MutableVec<JigResponse>>),
+}
+
+impl From<&HomePageMode> for PageLinks {
+    fn from(mode: &HomePageMode) -> PageLinks {
+        match mode {
+            &HomePageMode::Home => PageLinks::Home,
+            &HomePageMode::Search(..) => PageLinks::Content,
+        }
+    }
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
- Possibly related to https://github.com/ji-devs/ji-cloud/issues/1372#issuecomment-905301246
- Implement `From<>` for `PageLinks` so that when navigating to the search page, the Content header is marked as active;
- **Note** I'm assuming that we would want the header to be marked active, but this may not be the case.

![image](https://user-images.githubusercontent.com/4161106/144570667-42beb837-6f1c-420c-81de-bde5f7f4e5b6.png)

