### PR TITLE
fix(fe/jig/edit): Hide module buttons when they aren't required

### DIFF
--- a/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/module/actions.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/module/actions.rs
@@ -115,7 +115,7 @@ pub fn delete(state: Rc<State>) {
                 Err(_) => {}
             }
         } else {
-            // The module is DragDrop, it is not persisted so it can be removed from the list with
+            // The module is placeholder, it is not persisted so it can be removed from the list with
             // no extra work required.
             state.sidebar.modules.lock_mut().remove(index);
         }

--- a/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/module/dom.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/module/dom.rs
@@ -154,7 +154,7 @@ impl ModuleDom {
                     *state.elem.borrow_mut() = None;
                 }))
                 .apply(clone!(state, sidebar_state, module => move |dom| {
-                    // If the module is anything other than a DragDrop, otherwise if it is not the
+                    // If the module is anything other than a placeholder, otherwise if it is not the
                     // last module in the list.
                     if (&*module).is_some() || (index <= total_len - 2 && (&*module).is_none()) {
                         let menu_state = Rc::new(MenuState::new());

--- a/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/module/state.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/module/state.rs
@@ -47,12 +47,12 @@ impl State {
     }
 
     pub fn can_add(&self) -> bool {
-        // If this module is anything other than DragDrop, the add button could be displayed.
+        // If this module is anything other than a placeholder, the add button could be displayed.
         let current_module_should_add = if let Some(_) = &*self.module { true } else { false };
         let next_module_should_show_add = {
             match self.sidebar.modules.lock_ref().to_vec().get(self.index + 1) {
                 Some(module) => {
-                    // If the next module is anything other than DragDrop, then this module can
+                    // If the next module is anything other than a placeholder, then this module can
                     // potentially display the the add button.
                     if let Some(_) = &**module { true } else { false }
                 }

--- a/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/module/state.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/module/state.rs
@@ -4,7 +4,7 @@ use futures_signals::{
     map_ref,
     signal::{Mutable, Signal, SignalExt},
 };
-use shared::domain::jig::LiteModule;
+use shared::domain::jig::{LiteModule, ModuleKind};
 use std::cell::RefCell;
 use std::rc::Rc;
 use utils::drag::Drag;
@@ -45,6 +45,26 @@ impl State {
             Some(module) => module.kind.as_str(),
         }
     }
+
+    pub fn can_add(&self) -> bool {
+        // If this module is anything other than DragDrop, the add button could be displayed.
+        let current_module_should_add = if let Some(_) = &*self.module { true } else { false };
+        let next_module_should_show_add = {
+            match self.sidebar.modules.lock_ref().to_vec().get(self.index + 1) {
+                Some(module) => {
+                    // If the next module is anything other than DragDrop, then this module can
+                    // potentially display the the add button.
+                    if let Some(_) = &**module { true } else { false }
+                }
+                // If there is no next module, then this module can potentially display the add
+                // button.
+                None => true
+            }
+        };
+
+        current_module_should_add && next_module_should_show_add
+    }
+
     pub fn window_state_signal(state: Rc<State>) -> impl Signal<Item = &'static str> {
         clone!(state => map_ref! {
             let route = state.sidebar.jig_edit_state.route.signal_cloned(),


### PR DESCRIPTION
Resolves #1959 

This PR makes a few changes to how the kebab menu and add button are rendered in the edit jig sidebar:

- The kebab button is displayed for all modules _except_ for the last one **if** the last one is a placeholder;
- The add button is displayed for all modules _except_ if the module is a placeholder, or the module immediately after is a placeholder;
- The delete button works for placeholders that appear between other modules (#1856).

![image](https://user-images.githubusercontent.com/4161106/145017558-3e9d3cb1-baff-410a-92c3-c25a6adc9a0c.png)

