### PR TITLE
fix(fe/jig/edit): Prevent cover module being edited before having a cover dragged in

### DIFF
--- a/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/menu/dom.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/menu/dom.rs
@@ -18,199 +18,195 @@ const STR_PASTE: &'static str = "Paste from another JIG";
 const STR_DUPLICATE_AS: &'static str = "Duplicate content as:";
 // const STR_EDIT_SETTINGS: &'static str = "Edit setting";
 
-pub struct MenuDom;
+pub fn render(module_state: &Rc<ModuleState>) -> Dom {
+    let state = Rc::new(State::new());
 
-impl MenuDom {
-    pub fn render(module_state: &Rc<ModuleState>) -> Dom {
-        let state = Rc::new(State::new());
-
-        html!("menu-kebab", {
-            .property("slot", "menu")
-            .child(html!("jig-edit-sidebar-module-menu", {
-                .children(Self::children(&state, module_state))
-            }))
-            .event_with_options(&EventOptions::bubbles(), |e: events::Click| {
-                e.stop_propagation();
-            })
-            .after_inserted(move |elem| {
-                *state.menu_ref.borrow_mut() = Some(elem);
-            })
+    html!("menu-kebab", {
+        .property("slot", "menu")
+        .child(html!("jig-edit-sidebar-module-menu", {
+            .children(menu_items(&state, module_state))
+        }))
+        .event_with_options(&EventOptions::bubbles(), |e: events::Click| {
+            e.stop_propagation();
         })
-    }
+        .after_inserted(move |elem| {
+            *state.menu_ref.borrow_mut() = Some(elem);
+        })
+    })
+}
 
-    fn children(state: &Rc<State>, module_state: &Rc<ModuleState>) -> Vec<Dom> {
-        match module_state.index {
-            0 => {
-                vec![
-                    MenuDom::item_edit(state, module_state),
-                    // TODO:
-                    // MenuDom::item_copy(state.clone()),
-                    MenuDom::item_paste(state, &module_state.sidebar),
-                ]
-            },
-            _ => {
-                let mut v = vec![];
-                if let Some(module) = &*module_state.module {
-                    v.push(MenuDom::item_edit(state, module_state));
-                    if module_state.index > 1 {
-                        // We only want to be able to move up if there's somewhere
-                        // to move to. Index 0 is occupied by the Cover module, so
-                        // anything at 1 cannot go higher.
-                        v.push(MenuDom::item_move_up(state, module_state));
-                    }
-                    if module_state.is_last_module() {
-                        v.push(MenuDom::item_move_down(state, module_state));
-                    }
-                    v.push(MenuDom::item_duplicate(state, &module_state.sidebar, module.id));
+fn menu_items(state: &Rc<State>, module_state: &Rc<ModuleState>) -> Vec<Dom> {
+    match module_state.index {
+        0 => {
+            vec![
+                item_edit(state, module_state),
+                // TODO:
+                // item_copy(state.clone()),
+                item_paste(state, &module_state.sidebar),
+            ]
+        },
+        _ => {
+            let mut v = vec![];
+            if let Some(module) = &*module_state.module {
+                v.push(item_edit(state, module_state));
+                if module_state.index > 1 {
+                    // We only want to be able to move up if there's somewhere
+                    // to move to. Index 0 is occupied by the Cover module, so
+                    // anything at 1 cannot go higher.
+                    v.push(item_move_up(state, module_state));
                 }
-                v.push(MenuDom::item_delete(state, module_state));
-                if let Some(module) = &*module_state.module {
-                    v.push(MenuDom::item_copy(state, &module_state.sidebar, module.id));
-                    v.push(MenuDom::item_duplicate_as(state, &module_state.sidebar, module));
+                if module_state.is_last_module() {
+                    v.push(item_move_down(state, module_state));
                 }
-                v
+                v.push(item_duplicate(state, &module_state.sidebar, module.id));
             }
+            v.push(item_delete(state, module_state));
+            if let Some(module) = &*module_state.module {
+                v.push(item_copy(state, &module_state.sidebar, module.id));
+                v.push(item_duplicate_as(state, &module_state.sidebar, module));
+            }
+            v
         }
     }
-
-    fn item_edit(state: &Rc<State>, module: &Rc<ModuleState>) -> Dom {
-        html!("menu-line", {
-            .property("slot", "lines")
-            .property("icon", "edit")
-            .event(clone!(state, module => move |_:events::Click| {
-                state.close_menu();
-                actions::edit(module.clone());
-            }))
-        })
-    }
-
-    fn item_move_up(state: &Rc<State>, module: &Rc<ModuleState>) -> Dom {
-        html!("menu-line", {
-            .property("slot", "lines")
-            .property("icon", "move-up")
-            .event(clone!(state, module => move |_:events::Click| {
-                state.close_menu();
-                actions::move_index(module.clone(), MoveTarget::Up);
-            }))
-        })
-    }
-
-    fn item_move_down(state: &Rc<State>, module: &Rc<ModuleState>) -> Dom {
-        html!("menu-line", {
-            .property("slot", "lines")
-            .property("icon", "move-down")
-            .event(clone!(state, module => move |_:events::Click| {
-                state.close_menu();
-                actions::move_index(module.clone(), MoveTarget::Down);
-            }))
-        })
-    }
-
-    fn item_duplicate(
-        state: &Rc<State>,
-        sidebar_state: &Rc<SidebarState>,
-        module_id: ModuleId,
-    ) -> Dom {
-        html!("menu-line", {
-            .property("slot", "lines")
-            .property("icon", "duplicate")
-            .event(clone!(state, sidebar_state => move |_:events::Click| {
-                state.close_menu();
-                duplicate_module(sidebar_state.clone(), &module_id);
-            }))
-        })
-    }
-
-    fn item_delete(state: &Rc<State>, module: &Rc<ModuleState>) -> Dom {
-        html!("menu-line", {
-            .property("slot", "lines")
-            .property("icon", "delete")
-            .event(clone!(state, module => move |_:events::Click| {
-                state.close_menu();
-                actions::delete(module.clone());
-            }))
-        })
-    }
-
-    fn item_copy(state: &Rc<State>, sidebar_state: &Rc<SidebarState>, module_id: ModuleId) -> Dom {
-        html!("menu-line", {
-            .property("slot", "advanced")
-            .property("customLabel", STR_COPY)
-            .property("icon", "copy")
-            .event(clone!(state, sidebar_state => move |_:events::Click| {
-                state.close_menu();
-                copy_module(sidebar_state.clone(), &module_id);
-            }))
-        })
-    }
-
-    fn item_paste(state: &Rc<State>, sidebar_state: &Rc<SidebarState>) -> Dom {
-        html!("menu-line", {
-            .property("slot", "advanced")
-            .property("customLabel", STR_PASTE)
-            .property("icon", "copy")
-            .event(clone!(state, sidebar_state => move |_:events::Click| {
-                state.close_menu();
-                paste_module(sidebar_state.clone());
-            }))
-        })
-    }
-
-    fn item_duplicate_as(
-        state: &Rc<State>,
-        sidebar_state: &Rc<SidebarState>,
-        module: &LiteModule,
-    ) -> Dom {
-        let card_kinds = vec![
-            ModuleKind::Memory,
-            ModuleKind::Flashcards,
-            ModuleKind::Matching,
-            ModuleKind::CardQuiz,
-        ];
-
-        let is_card = card_kinds.contains(&module.kind);
-
-        let card_kinds = card_kinds.into_iter().filter(|kind| &module.kind != kind);
-
-        let module_id = module.id;
-
-        html!("empty-fragment", {
-            .property("slot", "advanced")
-            .apply_if(is_card, |dom| {
-                dom.child(html!("menu-line", {
-                    .property("customLabel", STR_DUPLICATE_AS)
-                    .property("icon", "reuse")
-                    .property_signal("active", state.dup_as_active.signal())
-                    .event(clone!(state => move |_:events::Click| {
-                        let mut dup_as_active = state.dup_as_active.lock_mut();
-                        *dup_as_active = !*dup_as_active;
-                    }))
-                }))
-                .children(card_kinds.map(|card_kind| {
-                    html!("menu-line", {
-                        .visible_signal(state.dup_as_active.signal())
-                        .property("customLabel", String::from("• ") + card_kind.as_str())
-                        .event(clone!(state, sidebar_state, module_id => move |_:events::Click| {
-                            use_module_as(Rc::clone(&sidebar_state), card_kind, module_id);
-                            state.close_menu();
-                        }))
-                    })
-                }))
-            })
-        })
-    }
-
-    // fn item_edit_settings(state: Rc<State>, sidebar_state: Rc<SidebarState>) -> Dom {
-    //     html!("menu-line", {
-    //         .property("slot", "lines")
-    //         .property("customLabel", STR_EDIT_SETTINGS)
-    //         .property("icon", "edit")
-    //         .event(clone!(state => move |_:events::Click| {
-    //             state.close_menu();
-    //             // sidebar_state.settings_shown.set(true);
-    //             sidebar_state.settings.active_popup.set(Some(ActiveSettingsPopup::Main))
-    //         }))
-    //     })
-    // }
 }
+
+fn item_edit(state: &Rc<State>, module: &Rc<ModuleState>) -> Dom {
+    html!("menu-line", {
+        .property("slot", "lines")
+        .property("icon", "edit")
+        .event(clone!(state, module => move |_:events::Click| {
+            state.close_menu();
+            actions::edit(module.clone());
+        }))
+    })
+}
+
+fn item_move_up(state: &Rc<State>, module: &Rc<ModuleState>) -> Dom {
+    html!("menu-line", {
+        .property("slot", "lines")
+        .property("icon", "move-up")
+        .event(clone!(state, module => move |_:events::Click| {
+            state.close_menu();
+            actions::move_index(module.clone(), MoveTarget::Up);
+        }))
+    })
+}
+
+fn item_move_down(state: &Rc<State>, module: &Rc<ModuleState>) -> Dom {
+    html!("menu-line", {
+        .property("slot", "lines")
+        .property("icon", "move-down")
+        .event(clone!(state, module => move |_:events::Click| {
+            state.close_menu();
+            actions::move_index(module.clone(), MoveTarget::Down);
+        }))
+    })
+}
+
+fn item_duplicate(
+    state: &Rc<State>,
+    sidebar_state: &Rc<SidebarState>,
+    module_id: ModuleId,
+) -> Dom {
+    html!("menu-line", {
+        .property("slot", "lines")
+        .property("icon", "duplicate")
+        .event(clone!(state, sidebar_state => move |_:events::Click| {
+            state.close_menu();
+            duplicate_module(sidebar_state.clone(), &module_id);
+        }))
+    })
+}
+
+fn item_delete(state: &Rc<State>, module: &Rc<ModuleState>) -> Dom {
+    html!("menu-line", {
+        .property("slot", "lines")
+        .property("icon", "delete")
+        .event(clone!(state, module => move |_:events::Click| {
+            state.close_menu();
+            actions::delete(module.clone());
+        }))
+    })
+}
+
+fn item_copy(state: &Rc<State>, sidebar_state: &Rc<SidebarState>, module_id: ModuleId) -> Dom {
+    html!("menu-line", {
+        .property("slot", "advanced")
+        .property("customLabel", STR_COPY)
+        .property("icon", "copy")
+        .event(clone!(state, sidebar_state => move |_:events::Click| {
+            state.close_menu();
+            copy_module(sidebar_state.clone(), &module_id);
+        }))
+    })
+}
+
+fn item_paste(state: &Rc<State>, sidebar_state: &Rc<SidebarState>) -> Dom {
+    html!("menu-line", {
+        .property("slot", "advanced")
+        .property("customLabel", STR_PASTE)
+        .property("icon", "copy")
+        .event(clone!(state, sidebar_state => move |_:events::Click| {
+            state.close_menu();
+            paste_module(sidebar_state.clone());
+        }))
+    })
+}
+
+fn item_duplicate_as(
+    state: &Rc<State>,
+    sidebar_state: &Rc<SidebarState>,
+    module: &LiteModule,
+) -> Dom {
+    let card_kinds = vec![
+        ModuleKind::Memory,
+        ModuleKind::Flashcards,
+        ModuleKind::Matching,
+        ModuleKind::CardQuiz,
+    ];
+
+    let is_card = card_kinds.contains(&module.kind);
+
+    let card_kinds = card_kinds.into_iter().filter(|kind| &module.kind != kind);
+
+    let module_id = module.id;
+
+    html!("empty-fragment", {
+        .property("slot", "advanced")
+        .apply_if(is_card, |dom| {
+            dom.child(html!("menu-line", {
+                .property("customLabel", STR_DUPLICATE_AS)
+                .property("icon", "reuse")
+                .property_signal("active", state.dup_as_active.signal())
+                .event(clone!(state => move |_:events::Click| {
+                    let mut dup_as_active = state.dup_as_active.lock_mut();
+                    *dup_as_active = !*dup_as_active;
+                }))
+            }))
+            .children(card_kinds.map(|card_kind| {
+                html!("menu-line", {
+                    .visible_signal(state.dup_as_active.signal())
+                    .property("customLabel", String::from("• ") + card_kind.as_str())
+                    .event(clone!(state, sidebar_state, module_id => move |_:events::Click| {
+                        use_module_as(Rc::clone(&sidebar_state), card_kind, module_id);
+                        state.close_menu();
+                    }))
+                })
+            }))
+        })
+    })
+}
+
+// fn item_edit_settings(state: Rc<State>, sidebar_state: Rc<SidebarState>) -> Dom {
+//     html!("menu-line", {
+//         .property("slot", "lines")
+//         .property("customLabel", STR_EDIT_SETTINGS)
+//         .property("icon", "edit")
+//         .event(clone!(state => move |_:events::Click| {
+//             state.close_menu();
+//             // sidebar_state.settings_shown.set(true);
+//             sidebar_state.settings.active_popup.set(Some(ActiveSettingsPopup::Main))
+//         }))
+//     })
+// }
 

--- a/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/menu/dom.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/menu/dom.rs
@@ -18,157 +18,199 @@ const STR_PASTE: &'static str = "Paste from another JIG";
 const STR_DUPLICATE_AS: &'static str = "Duplicate content as:";
 // const STR_EDIT_SETTINGS: &'static str = "Edit setting";
 
-pub fn render(state: Rc<State>, items: Vec<Dom>) -> Dom {
-    html!("menu-kebab", {
-        .property("slot", "menu")
-        .child(html!("jig-edit-sidebar-module-menu", {
-            .children(items)
-        }))
-        .event_with_options(&EventOptions::bubbles(), |e: events::Click| {
-            e.stop_propagation();
-        })
-        .after_inserted(clone!(state => move |elem| {
-            *state.menu_ref.borrow_mut() = Some(elem);
-        }))
-    })
-}
+pub struct MenuDom;
 
-pub fn item_edit(state: Rc<State>, module: Rc<ModuleState>) -> Dom {
-    html!("menu-line", {
-        .property("slot", "lines")
-        .property("icon", "edit")
-        .event(clone!(state => move |_:events::Click| {
-            actions::edit(module.clone());
-            state.close_menu();
-        }))
-    })
-}
+impl MenuDom {
+    pub fn render(module_state: Rc<ModuleState>) -> Dom {
+        let state = Rc::new(State::new());
 
-pub fn item_move_up(state: Rc<State>, module: Rc<ModuleState>) -> Dom {
-    html!("menu-line", {
-        .property("slot", "lines")
-        .property("icon", "move-up")
-        .event(clone!(state => move |_:events::Click| {
-            actions::move_index(module.clone(), MoveTarget::Up);
-            state.close_menu();
-        }))
-    })
-}
-
-pub fn item_move_down(state: Rc<State>, module: Rc<ModuleState>) -> Dom {
-    html!("menu-line", {
-        .property("slot", "lines")
-        .property("icon", "move-down")
-        .event(clone!(state => move |_:events::Click| {
-            actions::move_index(module.clone(), MoveTarget::Down);
-            state.close_menu();
-        }))
-    })
-}
-
-pub fn item_duplicate(
-    state: Rc<State>,
-    sidebar_state: Rc<SidebarState>,
-    module_id: ModuleId,
-) -> Dom {
-    html!("menu-line", {
-        .property("slot", "lines")
-        .property("icon", "duplicate")
-        .event(clone!(state, module_id => move |_:events::Click| {
-            state.close_menu();
-            duplicate_module(sidebar_state.clone(), &module_id);
-        }))
-    })
-}
-
-pub fn item_delete(state: Rc<State>, module: Rc<ModuleState>) -> Dom {
-    html!("menu-line", {
-        .property("slot", "lines")
-        .property("icon", "delete")
-        .event(clone!(state => move |_:events::Click| {
-            actions::delete(module.clone());
-            state.close_menu();
-        }))
-    })
-}
-
-pub fn item_copy(state: Rc<State>, sidebar_state: Rc<SidebarState>, module_id: ModuleId) -> Dom {
-    html!("menu-line", {
-        .property("slot", "advanced")
-        .property("customLabel", STR_COPY)
-        .property("icon", "copy")
-        .event(clone!(state => move |_:events::Click| {
-            state.close_menu();
-            copy_module(sidebar_state.clone(), &module_id);
-        }))
-    })
-}
-
-pub fn item_paste(state: Rc<State>, sidebar_state: Rc<SidebarState>) -> Dom {
-    html!("menu-line", {
-        .property("slot", "advanced")
-        .property("customLabel", STR_PASTE)
-        .property("icon", "copy")
-        .event(clone!(state => move |_:events::Click| {
-            state.close_menu();
-            paste_module(sidebar_state.clone());
-        }))
-    })
-}
-
-pub fn item_duplicate_as(
-    state: Rc<State>,
-    sidebar_state: Rc<SidebarState>,
-    module: &LiteModule,
-) -> Dom {
-    let card_kinds = vec![
-        ModuleKind::Memory,
-        ModuleKind::Flashcards,
-        ModuleKind::Matching,
-        ModuleKind::CardQuiz,
-    ];
-
-    let is_card = card_kinds.contains(&module.kind);
-
-    let card_kinds = card_kinds.into_iter().filter(|kind| &module.kind != kind);
-
-    let module_id = module.id;
-
-    html!("empty-fragment", {
-        .property("slot", "advanced")
-        .apply_if(is_card, |dom| {
-            dom.child(html!("menu-line", {
-                .property("customLabel", STR_DUPLICATE_AS)
-                .property("icon", "reuse")
-                .property_signal("active", state.dup_as_active.signal())
-                .event(clone!(state => move |_:events::Click| {
-                    let mut dup_as_active = state.dup_as_active.lock_mut();
-                    *dup_as_active = !*dup_as_active;
-                }))
+        html!("menu-kebab", {
+            .property("slot", "menu")
+            .child(html!("jig-edit-sidebar-module-menu", {
+                .children(Self::children(&state, &module_state))
             }))
-            .children(card_kinds.map(|card_kind| {
-                html!("menu-line", {
-                    .visible_signal(state.dup_as_active.signal())
-                    .property("customLabel", String::from("• ") + card_kind.as_str())
-                    .event(clone!(state, sidebar_state, module_id => move |_:events::Click| {
-                        use_module_as(Rc::clone(&sidebar_state), card_kind, module_id);
-                        state.close_menu();
+            .event_with_options(&EventOptions::bubbles(), |e: events::Click| {
+                e.stop_propagation();
+            })
+            .after_inserted(move |elem| {
+                *state.menu_ref.borrow_mut() = Some(elem);
+            })
+        })
+    }
+
+    fn children(state: &Rc<State>, module_state: &Rc<ModuleState>) -> Vec<Dom> {
+        match module_state.index {
+            0 => {
+                vec![
+                    MenuDom::item_edit(state, module_state),
+                    // TODO:
+                    // MenuDom::item_copy(state.clone()),
+                    MenuDom::item_paste(state, &module_state.sidebar),
+                ]
+            },
+            _ => {
+                let mut v = vec![];
+                if let Some(module) = &*module_state.module {
+                    v.push(MenuDom::item_edit(state, module_state));
+                    if module_state.index > 1 {
+                        // We only want to be able to move up if there's somewhere
+                        // to move to. Index 0 is occupied by the Cover module, so
+                        // anything at 1 cannot go higher.
+                        v.push(MenuDom::item_move_up(state, module_state));
+                    }
+                    if module_state.is_last_module() {
+                        v.push(MenuDom::item_move_down(state, module_state));
+                    }
+                    v.push(MenuDom::item_duplicate(state, &module_state.sidebar, module.id));
+                }
+                v.push(MenuDom::item_delete(state, module_state));
+                if let Some(module) = &*module_state.module {
+                    v.push(MenuDom::item_copy(state, &module_state.sidebar, module.id));
+                    v.push(MenuDom::item_duplicate_as(state, &module_state.sidebar, module));
+                }
+                v
+            }
+        }
+    }
+
+    fn item_edit(state: &Rc<State>, module: &Rc<ModuleState>) -> Dom {
+        html!("menu-line", {
+            .property("slot", "lines")
+            .property("icon", "edit")
+            .event(clone!(state, module => move |_:events::Click| {
+                state.close_menu();
+                actions::edit(module.clone());
+            }))
+        })
+    }
+
+    fn item_move_up(state: &Rc<State>, module: &Rc<ModuleState>) -> Dom {
+        html!("menu-line", {
+            .property("slot", "lines")
+            .property("icon", "move-up")
+            .event(clone!(state, module => move |_:events::Click| {
+                state.close_menu();
+                actions::move_index(module.clone(), MoveTarget::Up);
+            }))
+        })
+    }
+
+    fn item_move_down(state: &Rc<State>, module: &Rc<ModuleState>) -> Dom {
+        html!("menu-line", {
+            .property("slot", "lines")
+            .property("icon", "move-down")
+            .event(clone!(state, module => move |_:events::Click| {
+                state.close_menu();
+                actions::move_index(module.clone(), MoveTarget::Down);
+            }))
+        })
+    }
+
+    fn item_duplicate(
+        state: &Rc<State>,
+        sidebar_state: &Rc<SidebarState>,
+        module_id: ModuleId,
+    ) -> Dom {
+        html!("menu-line", {
+            .property("slot", "lines")
+            .property("icon", "duplicate")
+            .event(clone!(state, sidebar_state => move |_:events::Click| {
+                state.close_menu();
+                duplicate_module(sidebar_state.clone(), &module_id);
+            }))
+        })
+    }
+
+    fn item_delete(state: &Rc<State>, module: &Rc<ModuleState>) -> Dom {
+        html!("menu-line", {
+            .property("slot", "lines")
+            .property("icon", "delete")
+            .event(clone!(state, module => move |_:events::Click| {
+                state.close_menu();
+                actions::delete(module.clone());
+            }))
+        })
+    }
+
+    fn item_copy(state: &Rc<State>, sidebar_state: &Rc<SidebarState>, module_id: ModuleId) -> Dom {
+        html!("menu-line", {
+            .property("slot", "advanced")
+            .property("customLabel", STR_COPY)
+            .property("icon", "copy")
+            .event(clone!(state, sidebar_state => move |_:events::Click| {
+                state.close_menu();
+                copy_module(sidebar_state.clone(), &module_id);
+            }))
+        })
+    }
+
+    fn item_paste(state: &Rc<State>, sidebar_state: &Rc<SidebarState>) -> Dom {
+        html!("menu-line", {
+            .property("slot", "advanced")
+            .property("customLabel", STR_PASTE)
+            .property("icon", "copy")
+            .event(clone!(state, sidebar_state => move |_:events::Click| {
+                state.close_menu();
+                paste_module(sidebar_state.clone());
+            }))
+        })
+    }
+
+    fn item_duplicate_as(
+        state: &Rc<State>,
+        sidebar_state: &Rc<SidebarState>,
+        module: &LiteModule,
+    ) -> Dom {
+        let card_kinds = vec![
+            ModuleKind::Memory,
+            ModuleKind::Flashcards,
+            ModuleKind::Matching,
+            ModuleKind::CardQuiz,
+        ];
+
+        let is_card = card_kinds.contains(&module.kind);
+
+        let card_kinds = card_kinds.into_iter().filter(|kind| &module.kind != kind);
+
+        let module_id = module.id;
+
+        html!("empty-fragment", {
+            .property("slot", "advanced")
+            .apply_if(is_card, |dom| {
+                dom.child(html!("menu-line", {
+                    .property("customLabel", STR_DUPLICATE_AS)
+                    .property("icon", "reuse")
+                    .property_signal("active", state.dup_as_active.signal())
+                    .event(clone!(state => move |_:events::Click| {
+                        let mut dup_as_active = state.dup_as_active.lock_mut();
+                        *dup_as_active = !*dup_as_active;
                     }))
-                })
-            }))
+                }))
+                .children(card_kinds.map(|card_kind| {
+                    html!("menu-line", {
+                        .visible_signal(state.dup_as_active.signal())
+                        .property("customLabel", String::from("• ") + card_kind.as_str())
+                        .event(clone!(state, sidebar_state, module_id => move |_:events::Click| {
+                            use_module_as(Rc::clone(&sidebar_state), card_kind, module_id);
+                            state.close_menu();
+                        }))
+                    })
+                }))
+            })
         })
-    })
+    }
+
+    // fn item_edit_settings(state: Rc<State>, sidebar_state: Rc<SidebarState>) -> Dom {
+    //     html!("menu-line", {
+    //         .property("slot", "lines")
+    //         .property("customLabel", STR_EDIT_SETTINGS)
+    //         .property("icon", "edit")
+    //         .event(clone!(state => move |_:events::Click| {
+    //             state.close_menu();
+    //             // sidebar_state.settings_shown.set(true);
+    //             sidebar_state.settings.active_popup.set(Some(ActiveSettingsPopup::Main))
+    //         }))
+    //     })
+    // }
 }
 
-// pub fn item_edit_settings(state: Rc<State>, sidebar_state: Rc<SidebarState>) -> Dom {
-//     html!("menu-line", {
-//         .property("slot", "lines")
-//         .property("customLabel", STR_EDIT_SETTINGS)
-//         .property("icon", "edit")
-//         .event(clone!(state => move |_:events::Click| {
-//             state.close_menu();
-//             // sidebar_state.settings_shown.set(true);
-//             sidebar_state.settings.active_popup.set(Some(ActiveSettingsPopup::Main))
-//         }))
-//     })
-// }

--- a/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/menu/dom.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/menu/dom.rs
@@ -21,13 +21,13 @@ const STR_DUPLICATE_AS: &'static str = "Duplicate content as:";
 pub struct MenuDom;
 
 impl MenuDom {
-    pub fn render(module_state: Rc<ModuleState>) -> Dom {
+    pub fn render(module_state: &Rc<ModuleState>) -> Dom {
         let state = Rc::new(State::new());
 
         html!("menu-kebab", {
             .property("slot", "menu")
             .child(html!("jig-edit-sidebar-module-menu", {
-                .children(Self::children(&state, &module_state))
+                .children(Self::children(&state, module_state))
             }))
             .event_with_options(&EventOptions::bubbles(), |e: events::Click| {
                 e.stop_propagation();

--- a/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/module/dom.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/module/dom.rs
@@ -167,7 +167,7 @@ impl ModuleDom {
                 .after_removed(clone!(state => move |_dom| {
                     *state.elem.borrow_mut() = None;
                 }))
-                .child(MenuDom::render(state.clone()))
+                .child(MenuDom::render(&state))
                 .apply(Self::render_add_button(&state))
             }))
         })

--- a/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/module/dom.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/module/dom.rs
@@ -1,8 +1,8 @@
 use components::overlay::handle::OverlayHandle;
-use dominator::{Dom, EventOptions, clone, html, with_node};
-use web_sys::HtmlElement;
+use dominator::{Dom, EventOptions, clone, html, with_node, DomBuilder};
+use web_sys::{HtmlElement, Node};
 
-use super::super::menu::{dom as MenuDom, state::State as MenuState};
+use super::super::menu::{dom::MenuDom, state::State as MenuState};
 use super::{actions, state::*};
 use crate::edit::sidebar::state::State as SidebarState;
 use components::module::_common::thumbnail::ModuleThumbnail;
@@ -62,21 +62,35 @@ impl ModuleDom {
                     }
                 })))
                 .property("lastBottomDecoration", index == total_len-1)
-                .event(|_evt:events::MouseDown| {
-                    // TODO:
-                    // actions::mouse_down(state.clone(), evt.x(), evt.y());
-                })
+                // TODO:
+                // .event(|_evt:events::MouseDown| {
+                //     actions::mouse_down(state.clone(), evt.x(), evt.y());
+                // })
                 .event_with_options(
                     &EventOptions::bubbles(),
                     clone!(state => move |_evt:events::Click| {
-                        match &*state.module {
+                        let can_edit = match &*state.module {
                             Some(_) => {
-                                actions::edit(state.clone())
+                                if state.index == 0 {
+                                    // If the cover is clicked, but the cover module hasn't yet
+                                    // been dragged onto it, then it should navigate to the landing
+                                    // screen.
+                                    state.sidebar.first_cover_assigned.get()
+                                } else {
+                                    true
+                                }
                             },
-                            None =>  {
-                                state.sidebar.jig_edit_state.route.set_neq(JigEditRoute::Landing);
-                            },
+                            None => false,
                         };
+
+                        if can_edit {
+                            actions::edit(state.clone())
+                        } else {
+                            // Anything that cannot be edited should navigate the user to the
+                            // landing screen.
+                            state.sidebar.jig_edit_state.route.set_neq(JigEditRoute::Landing);
+                        }
+
                     })
                 )
                 .child(html!("jig-edit-sidebar-module-window" => HtmlElement, {
@@ -153,59 +167,43 @@ impl ModuleDom {
                 .after_removed(clone!(state => move |_dom| {
                     *state.elem.borrow_mut() = None;
                 }))
-                .apply(clone!(state, sidebar_state, module => move |dom| {
-                    // If the module is anything other than a placeholder, otherwise if it is not the
-                    // last module in the list.
-                    if (&*module).is_some() || (index <= total_len - 2 && (&*module).is_none()) {
-                        let menu_state = Rc::new(MenuState::new());
-                        let menu_items = match index {
-                            0 => {
-                                vec![
-                                    MenuDom::item_edit(menu_state.clone(), state.clone()),
-                                    // TODO:
-                                    // MenuDom::item_copy(menu_state.clone()),
-                                    MenuDom::item_paste(menu_state.clone(), sidebar_state.clone()),
-                                ]
-                            },
-                            _ => {
-                                let mut v = vec![];
-                                if let Some(module) = &*module {
-                                    v.push(MenuDom::item_edit(menu_state.clone(), state.clone()));
-                                    v.push(MenuDom::item_move_up(menu_state.clone(), state.clone()));
-                                    v.push(MenuDom::item_move_down(menu_state.clone(), state.clone()));
-                                    v.push(MenuDom::item_duplicate(menu_state.clone(), sidebar_state.clone(), module.id));
-                                }
-                                v.push(MenuDom::item_delete(menu_state.clone(), state.clone()));
-                                if let Some(module) = &*module {
-                                    v.push(MenuDom::item_copy(menu_state.clone(), sidebar_state.clone(), module.id));
-                                    v.push(MenuDom::item_duplicate_as(menu_state.clone(), sidebar_state.clone(), module));
-                                }
-                                v
-                            }
-                        };
-
-                        dom.child(MenuDom::render(
-                            menu_state.clone(),
-                            menu_items
-                        ))
-                    } else {
-                        dom
-                    }
-                }))
-                .apply(clone!(state => move |dom| {
-                    if state.can_add() {
-                        dom.child(html!("button-icon", {
-                            .property("icon", "gears")
-                            .property("slot", "add")
-                            .event(clone!(state => move |_evt:events::Click| {
-                                actions::add_empty_module_after(state.clone())
-                            }))
-                        }))
-                    } else {
-                        dom
-                    }
-                }))
+                .child(MenuDom::render(state.clone()))
+                .apply(Self::render_add_button(&state))
             }))
         })
+    }
+
+    pub fn render_add_button<A>(state: &Rc<State>) -> impl FnOnce(DomBuilder<A>) -> DomBuilder<A> + '_
+    where
+        A: AsRef<Node>,
+    {
+        move |dom: DomBuilder<A>| {
+            // If this module is anything other than a placeholder, the add button could be displayed.
+            let current_module_should_add = state.module.is_some();
+            let next_module_should_show_add = {
+                match state.sidebar.modules.lock_ref().to_vec().get(state.index + 1) {
+                    // If the next module is anything other than a placeholder, then this module can
+                    // potentially display the the add button.
+                    Some(module) => module.is_some(),
+                    // If there is no next module, then this module can potentially display the add
+                    // button.
+                    None => true,
+                }
+            };
+
+            let should_add = current_module_should_add && next_module_should_show_add;
+
+            if should_add {
+                dom.child(html!("button-icon", {
+                    .property("icon", "gears")
+                    .property("slot", "add")
+                    .event(clone!(state => move |_evt:events::Click| {
+                        actions::add_empty_module_after(state.clone())
+                    }))
+                }))
+            } else {
+                dom
+            }
+        }
     }
 }

--- a/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/module/dom.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/module/dom.rs
@@ -2,7 +2,7 @@ use components::overlay::handle::OverlayHandle;
 use dominator::{Dom, EventOptions, clone, html, with_node, DomBuilder};
 use web_sys::{HtmlElement, Node};
 
-use super::super::menu::{dom::MenuDom, state::State as MenuState};
+use super::super::menu::{dom as MenuDom, state::State as MenuState};
 use super::{actions, state::*};
 use crate::edit::sidebar::state::State as SidebarState;
 use components::module::_common::thumbnail::ModuleThumbnail;

--- a/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/module/state.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/module/state.rs
@@ -4,7 +4,7 @@ use futures_signals::{
     map_ref,
     signal::{Mutable, Signal, SignalExt},
 };
-use shared::domain::jig::{LiteModule, ModuleKind};
+use shared::domain::jig::LiteModule;
 use std::cell::RefCell;
 use std::rc::Rc;
 use utils::drag::Drag;
@@ -46,23 +46,8 @@ impl State {
         }
     }
 
-    pub fn can_add(&self) -> bool {
-        // If this module is anything other than a placeholder, the add button could be displayed.
-        let current_module_should_add = if let Some(_) = &*self.module { true } else { false };
-        let next_module_should_show_add = {
-            match self.sidebar.modules.lock_ref().to_vec().get(self.index + 1) {
-                Some(module) => {
-                    // If the next module is anything other than a placeholder, then this module can
-                    // potentially display the the add button.
-                    if let Some(_) = &**module { true } else { false }
-                }
-                // If there is no next module, then this module can potentially display the add
-                // button.
-                None => true
-            }
-        };
-
-        current_module_should_add && next_module_should_show_add
+    pub fn is_last_module(&self) -> bool {
+        self.index < self.total_len - 2 && (&*self.module).is_some()
     }
 
     pub fn window_state_signal(state: Rc<State>) -> impl Signal<Item = &'static str> {


### PR DESCRIPTION
Resolves #1961

Other changes included:

- Fixes some syntax noted in #1967;
- Refactors MenuDom so that children are constructed by that component instead;
- Add a render function for rendering the modules "add" button.