### PR TITLE
fix(fe/jig/edit): Fix regression so that final placeholder does not have a menu

### DIFF
--- a/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/module/dom.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/module/dom.rs
@@ -167,7 +167,12 @@ impl ModuleDom {
                 .after_removed(clone!(state => move |_dom| {
                     *state.elem.borrow_mut() = None;
                 }))
-                .child(MenuDom::render(&state))
+                // Add the menu only if the current module is not a placeholder or if it is, it is
+                // not the _last_ placeholder.
+                .apply_if(
+                    module.is_some() || (index <= total_len - 2 && module.is_none()),
+                    |dom| dom.child(MenuDom::render(&state))
+                )
                 .apply(Self::render_add_button(&state))
             }))
         })


### PR DESCRIPTION
Related to #1959, fixes regression introduced in 5701eeeb74914dd4d9d82612dd8642689a52e31f