### PR TITLE
fix(fe/jig/edit): Duplicate modules are added before the final placeholder module

### DIFF
--- a/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/actions.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/actions.rs
@@ -70,7 +70,7 @@ pub fn update_display_name(state: Rc<State>, value: String) {
 pub fn duplicate_module(state: Rc<State>, module_id: &ModuleId) {
     state.loader.load(clone!(state, module_id => async move {
         let module = super::module_cloner::clone_module(&state.jig.id, &module_id, &state.jig.id).await.unwrap_ji();
-        state.modules.lock_mut().push_cloned(Rc::new(Some(module)));
+        populate_added_module(state.clone(), module);
     }));
 }
 
@@ -126,10 +126,12 @@ pub fn on_iframe_message(state: Rc<State>, message: ModuleToJigEditorMessage) {
 }
 
 fn populate_added_module(state: Rc<State>, module: LiteModule) {
+    let module_len = state.modules.lock_ref().len();
+
     state
         .modules
         .lock_mut()
-        .push_cloned(Rc::new(Some(module.clone())));
+        .insert_cloned(module_len - 1, Rc::new(Some(module.clone())));
     state
         .jig_edit_state
         .route

--- a/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/actions.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/actions.rs
@@ -126,12 +126,14 @@ pub fn on_iframe_message(state: Rc<State>, message: ModuleToJigEditorMessage) {
 }
 
 fn populate_added_module(state: Rc<State>, module: LiteModule) {
-    let module_len = state.modules.lock_ref().len();
+    // Assumes that the final module in the list is always the placeholder module.
+    let insert_at_idx = state.modules.lock_ref().len() - 1;
 
     state
         .modules
         .lock_mut()
-        .insert_cloned(module_len - 1, Rc::new(Some(module.clone())));
+        .insert_cloned(insert_at_idx, Rc::new(Some(module.clone())));
+
     state
         .jig_edit_state
         .route

--- a/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/menu/dom.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/menu/dom.rs
@@ -18,6 +18,13 @@ const STR_PASTE: &'static str = "Paste from another JIG";
 const STR_DUPLICATE_AS: &'static str = "Duplicate content as:";
 // const STR_EDIT_SETTINGS: &'static str = "Edit setting";
 
+const CARD_KINDS: [ModuleKind; 4] = [
+    ModuleKind::Memory,
+    ModuleKind::Flashcards,
+    ModuleKind::Matching,
+    ModuleKind::CardQuiz,
+];
+
 pub fn render(module_state: &Rc<ModuleState>) -> Dom {
     let state = Rc::new(State::new());
 
@@ -158,22 +165,14 @@ fn item_duplicate_as(
     sidebar_state: &Rc<SidebarState>,
     module: &LiteModule,
 ) -> Dom {
-    let card_kinds = vec![
-        ModuleKind::Memory,
-        ModuleKind::Flashcards,
-        ModuleKind::Matching,
-        ModuleKind::CardQuiz,
-    ];
-
-    let is_card = card_kinds.contains(&module.kind);
-
-    let card_kinds = card_kinds.into_iter().filter(|kind| &module.kind != kind);
-
-    let module_id = module.id;
+    let is_card = CARD_KINDS.contains(&module.kind);
 
     html!("empty-fragment", {
         .property("slot", "advanced")
         .apply_if(is_card, |dom| {
+            let card_kinds = CARD_KINDS.into_iter().filter(|kind| &module.kind != kind);
+            let module_id = module.id;
+
             dom.child(html!("menu-line", {
                 .property("customLabel", STR_DUPLICATE_AS)
                 .property("icon", "reuse")


### PR DESCRIPTION
Resolves #1960

- Duplicate and duplicate as functionality creates a new module which is added before the final placeholder module.