### PR TITLE
chore: Include ALGOLIA_JIG_INDEX in .env.example

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -49,10 +49,11 @@ S3_PROCESSING_BUCKET=
 # all related routes will return "501 - Not Implemented" and a warning will be emitted.
 ALGOLIA_PROJECT_ID=<algolia_project_id>
 
-# The index to use for indexing and backend searches.
-# Is optional. If missing, indexing will be disabled,
+# The indices to use for indexing and backend searches.
+# Are optional. If missing, indexing will be disabled,
 # search related routes will return a "501 - Not Implemented" and a warning will be emitted.
 ALGOLIA_MEDIA_INDEX=<index_name>
+ALGOLIA_JIG_INDEX=<index_name>
 
 # The key the backend uses for managing- indexing- `MEDIA_INDEX`.
 # Needs the `addObject`, `deleteObject`, `settings`, and `editSettings` ACLs and access to `MEDIA_INDEX`.


### PR DESCRIPTION
Updates the .env.example to include ALGOLIA_JIG_INDEX which is required to enable Algolia indexing.