### PR TITLE
fix(fe/user): Remove email placeholders on login/register

### DIFF
--- a/frontend/apps/crates/entry/user/src/login/dom.rs
+++ b/frontend/apps/crates/entry/user/src/login/dom.rs
@@ -29,7 +29,6 @@ impl LoginPage {
                         .child(html!("input" => HtmlInputElement, {
                             .with_node!(elem => {
                                 .property("type", "email")
-                                .property("placeholder", crate::strings::STR_EMAIL_PLACEHOLDER)
                                 .attribute("autocomplete", "email")
                                 .event(clone!(state => move |_:events::Input| {
                                     state.clear_email_status();

--- a/frontend/apps/crates/entry/user/src/register/pages/start/dom.rs
+++ b/frontend/apps/crates/entry/user/src/register/pages/start/dom.rs
@@ -36,7 +36,6 @@ impl StartPage {
                             .with_node!(elem => {
                                 .property("type", "email")
                                 .attribute("autocomplete", "email")
-                                .property("placeholder", strings::STR_EMAIL_PLACEHOLDER)
                                 .event(clone!(state => move |_:events::Input| {
                                     state.clear_email_status();
                                     *state.email.borrow_mut() = elem.value();

--- a/frontend/apps/crates/entry/user/src/strings.rs
+++ b/frontend/apps/crates/entry/user/src/strings.rs
@@ -4,16 +4,15 @@ pub const STR_AUTH_OAUTH_LOGIN_FAIL: &str = "Create an account first :)";
 pub const STR_CHANGE_EMAIL: &str = "Change email account";
 pub const STR_SUBMIT: &str = "Submit";
 pub const STR_CONTINUE: &str = "Continue";
-pub const STR_EMAIL_LABEL: &str = "Email*";
-pub const STR_EMAIL_PLACEHOLDER: &str = "Type or paste your email";
-pub const STR_PASSWORD_CREATE_LABEL: &str = "Create password*";
+pub const STR_EMAIL_LABEL: &str = "Email *";
+pub const STR_PASSWORD_CREATE_LABEL: &str = "Create password *";
 pub const STR_PASSWORD_PLACEHOLDER: &str = "********";
 
 pub const STR_NOT_AUTHORIZED: &str = "Not authorized!";
 pub const STR_USER_EXISTS: &str = "User already exists!";
 pub const STR_EMPTY_USERNAME: &str = "Empty username!";
 
-pub const STR_PASSWORD_LABEL: &str = "Password*";
+pub const STR_PASSWORD_LABEL: &str = "Password *";
 pub const STR_PASSWORD_FORGOTTEN: &str = "Forgot your password?";
 
 pub mod profile {

--- a/frontend/storybook/src/components/entry/user/register/pages/start.ts
+++ b/frontend/storybook/src/components/entry/user/register/pages/start.ts
@@ -12,7 +12,6 @@ export default {
 
 const STR_SUBMIT = "Submit";
 const STR_EMAIL_LABEL = "Email";
-const STR_EMAIL_PLACEHOLDER = "Type or paste your email";
 const STR_PASSWORD_LABEL = "Create Password";
 const STR_PASSWORD_PLACEHOLDER = "********";
 const STR_CONTINUE = "Continue";
@@ -34,10 +33,10 @@ export const Start = (props?: Partial<Args>) => {
         <page-register-start passwordStrength="${passwordStrength}">
             <button-google slot="google"></button-google>
             <input-wrapper slot="email" label="${STR_EMAIL_LABEL}">
-                <input placeholder="${STR_EMAIL_PLACEHOLDER}">
+                <input>
             </input-wrapper>
             <input-password slot="password" label="${STR_PASSWORD_LABEL}" placeholder="${STR_PASSWORD_PLACEHOLDER}"></input-password>
-            <button-rect slot="submit" color="red" size="medium" IconAfter="arrow">${STR_CONTINUE}</button-rect> 
+            <button-rect slot="submit" color="red" size="medium" IconAfter="arrow">${STR_CONTINUE}</button-rect>
             <footer-register-login slot="footer"></footer-register-login>
         </page-register-start>
     `;


### PR DESCRIPTION
Closes #1919

Includes the same changes for the login screen.