### PR TITLE
fix(fe/flashcards/edit): Show flashcard pair instead of duplicates

### DIFF
--- a/frontend/apps/crates/entry/module/flashcards/edit/src/settings/main/dom.rs
+++ b/frontend/apps/crates/entry/module/flashcards/edit/src/settings/main/dom.rs
@@ -44,7 +44,7 @@ pub fn render(state: Rc<MainSettings>) -> Dom {
 
                         children.push(render_card(options));
 
-                        let mut options = CardOptions::new(card, theme_id, mode, side, Size::Flashcards);
+                        let mut options = CardOptions::new(other, theme_id, mode, side, Size::Flashcards);
                         options.flip_on_hover = true;
 
                         children.push(render_card(options));


### PR DESCRIPTION
Resolves #1648 

![image](https://user-images.githubusercontent.com/4161106/145949560-7bf44ac1-22c0-44a3-a133-863276c017ed.png)
