### PR TITLE
fix(fe/jig/play): Start background audio once the user has started the jig

### DIFF
--- a/frontend/apps/crates/components/src/input/simple_select/dom.rs
+++ b/frontend/apps/crates/components/src/input/simple_select/dom.rs
@@ -2,7 +2,7 @@ use super::{state::*, SimpleSelectItem};
 use dominator::{clone, html, Dom, DomBuilder};
 use futures_signals::signal::SignalExt;
 use std::rc::Rc;
-use utils::{prelude::*, languages::Language};
+use utils::prelude::*;
 use wasm_bindgen::prelude::*;
 use web_sys::HtmlElement;
 

--- a/frontend/apps/crates/entry/jig/play/src/player/actions.rs
+++ b/frontend/apps/crates/entry/jig/play/src/player/actions.rs
@@ -187,37 +187,41 @@ pub fn on_iframe_message(state: Rc<State>, message: ModuleToJigPlayerMessage) {
             *points += amount;
         }
         ModuleToJigPlayerMessage::Start(time) => {
-            // Initialize the audio once the jig is started
-            if let Some(jig) = state.jig.get_cloned() {
-                if let Some(audio_background) = jig.jig_data.audio_background {
-                    init_audio(&state, audio_background);
-                }
-            }
-
-            // If the background audio is set to play, then start the audio
-            if state.bg_audio_playing.get() {
-                if let Some(bg_audio_handle) = &*state.bg_audio_handle.borrow() {
-                    play_background_audio(&state, bg_audio_handle);
-                }
-            }
-
-            if let Some(time) = time {
-                start_timer(Rc::clone(&state), time);
-            }
+            start_player(state, time);
         }
         ModuleToJigPlayerMessage::Next => {
-            navigate_forward(Rc::clone(&state));
+            navigate_forward(state);
         }
         ModuleToJigPlayerMessage::Stop => {
             state.timer.set(None);
         }
         ModuleToJigPlayerMessage::JumpToIndex(index) => {
-            navigate_to_index(Rc::clone(&state), index);
+            navigate_to_index(state, index);
         }
         ModuleToJigPlayerMessage::JumpToId(module_id) => {
-            navigate_to_module(Rc::clone(&state), &module_id);
+            navigate_to_module(state, &module_id);
         }
     };
+}
+
+fn start_player(state: Rc<State>, time: Option<u32>) {
+    // Initialize the audio once the jig is started
+    if let Some(jig) = state.jig.get_cloned() {
+        if let Some(audio_background) = jig.jig_data.audio_background {
+            init_audio(&state, audio_background);
+        }
+    }
+
+    // If the background audio is set to play, then start the audio
+    if state.bg_audio_playing.get() {
+        if let Some(bg_audio_handle) = &*state.bg_audio_handle.borrow() {
+            play_background_audio(&state, bg_audio_handle);
+        }
+    }
+
+    if let Some(time) = time {
+        start_timer(Rc::clone(&state), time);
+    }
 }
 
 pub fn reload_iframe(state: Rc<State>) {

--- a/frontend/apps/crates/entry/jig/play/src/player/dom.rs
+++ b/frontend/apps/crates/entry/jig/play/src/player/dom.rs
@@ -57,13 +57,8 @@ pub fn render(state: Rc<State>) -> Dom {
                     Some(html!("jig-play-background-music", {
                         .property("slot", "background")
                         .property_signal("playing", state.bg_audio_playing.signal())
-                        .event(clone!(state, jig => move|_: events::Click| {
-                            actions::toggle_background_audio(
-                                Rc::clone(&state),
-                                // `unwrap` is safe here because we are checking that it is Some in
-                                // the match branch above.
-                                jig.jig_data.audio_background.unwrap()
-                            );
+                        .event(clone!(state => move|_: events::Click| {
+                            actions::toggle_background_audio(Rc::clone(&state));
                         }))
                     }))
                 },


### PR DESCRIPTION
Properly resolves #1668

- Background audio starts automatically when the user clicks the start button on a jig