### PR TITLE
fix(fe/register): Send correct location and language data during registration

### DIFF
--- a/frontend/apps/crates/components/src/input/simple_select/dom.rs
+++ b/frontend/apps/crates/components/src/input/simple_select/dom.rs
@@ -1,4 +1,4 @@
-use super::{state::*, Item};
+use super::{state::*, SimpleSelectItem};
 use dominator::{clone, html, Dom, DomBuilder};
 use futures_signals::signal::SignalExt;
 use std::rc::Rc;
@@ -6,7 +6,7 @@ use utils::{prelude::*, languages::Language};
 use wasm_bindgen::prelude::*;
 use web_sys::HtmlElement;
 
-impl<T: Item + 'static, P: ToString + 'static, L: ToString + 'static>
+impl<T: SimpleSelectItem + 'static, P: ToString + 'static, L: ToString + 'static>
     SimpleSelect<T, P, L>
 {
     pub fn render(self: Rc<Self>, slot: Option<&str>) -> Dom {

--- a/frontend/apps/crates/components/src/input/simple_select/dom.rs
+++ b/frontend/apps/crates/components/src/input/simple_select/dom.rs
@@ -1,12 +1,12 @@
-use super::state::*;
+use super::{state::*, Item};
 use dominator::{clone, html, Dom, DomBuilder};
 use futures_signals::signal::SignalExt;
 use std::rc::Rc;
-use utils::prelude::*;
+use utils::{prelude::*, languages::Language};
 use wasm_bindgen::prelude::*;
 use web_sys::HtmlElement;
 
-impl<T: ToString + Clone + 'static, P: ToString + 'static, L: ToString + 'static>
+impl<T: Item + 'static, P: ToString + 'static, L: ToString + 'static>
     SimpleSelect<T, P, L>
 {
     pub fn render(self: Rc<Self>, slot: Option<&str>) -> Dom {
@@ -35,7 +35,9 @@ impl<T: ToString + Clone + 'static, P: ToString + 'static, L: ToString + 'static
             .property_signal("value", state.value.signal_cloned().map(|value| {
                 match value {
                     None => JsValue::NULL,
-                    Some(value) => JsValue::from_str(&value.to_string())
+                    // Use the label here because the input-select element uses the value as the
+                    // display value for rendering the selected item in the placeholder field.
+                    Some(value) => JsValue::from_str(&value.label())
                 }
             }))
             .apply_if(state.label.is_some(), |dom| {
@@ -46,12 +48,12 @@ impl<T: ToString + Clone + 'static, P: ToString + 'static, L: ToString + 'static
             })
             .children(state.values.iter().map(clone!(state => move |value| {
                 html!("input-select-option", {
-                    .text(&value.to_string())
+                    .text(&value.label())
                     .event(clone!(state, value => move |evt:events::CustomSelectedChange| {
                         if evt.selected() {
                             state.value.set(Some(value.clone()));
                             if let Some(on_change) = state.on_change.as_ref() {
-                                (on_change) (Some(&value.to_string()));
+                                (on_change) (Some(value.clone()));
                             }
                         }
                     }))

--- a/frontend/apps/crates/components/src/input/simple_select/mod.rs
+++ b/frontend/apps/crates/components/src/input/simple_select/mod.rs
@@ -3,3 +3,18 @@ mod state;
 
 pub use dom::*;
 pub use state::*;
+
+pub trait Item: Clone {
+    fn value(&self) -> &str;
+    fn label(&self) -> &str;
+}
+
+impl Item for &str {
+    fn value(&self) -> &str {
+        self
+    }
+
+    fn label(&self) -> &str {
+        self
+    }
+}

--- a/frontend/apps/crates/components/src/input/simple_select/mod.rs
+++ b/frontend/apps/crates/components/src/input/simple_select/mod.rs
@@ -4,12 +4,12 @@ mod state;
 pub use dom::*;
 pub use state::*;
 
-pub trait Item: Clone {
+pub trait SimpleSelectItem: Clone {
     fn value(&self) -> &str;
     fn label(&self) -> &str;
 }
 
-impl Item for &str {
+impl SimpleSelectItem for &str {
     fn value(&self) -> &str {
         self
     }

--- a/frontend/apps/crates/components/src/input/simple_select/state.rs
+++ b/frontend/apps/crates/components/src/input/simple_select/state.rs
@@ -2,9 +2,9 @@ use std::rc::Rc;
 
 use futures_signals::signal::Mutable;
 
-use super::Item;
+use super::SimpleSelectItem;
 
-pub struct SimpleSelect<T: Item, P, L> {
+pub struct SimpleSelect<T: SimpleSelectItem, P, L> {
     pub(super) label: Option<L>,
     pub(super) placeholder: Option<P>,
     pub(super) value: Mutable<Option<T>>,
@@ -12,7 +12,7 @@ pub struct SimpleSelect<T: Item, P, L> {
     pub(super) on_change: Option<Box<dyn Fn(Option<T>)>>,
 }
 
-impl<T:Item + 'static, P, L> SimpleSelect<T, P, L> {
+impl<T:SimpleSelectItem + 'static, P, L> SimpleSelect<T, P, L> {
     pub fn new(
         label: Option<L>,
         placeholder: Option<P>,
@@ -55,7 +55,7 @@ impl<T:Item + 'static, P, L> SimpleSelect<T, P, L> {
     }
 }
 
-impl<T: Item, P, L> SimpleSelect<T, P, L> {
+impl<T: SimpleSelectItem, P, L> SimpleSelect<T, P, L> {
     pub fn get_value(&self) -> Option<T> {
         self.value.get_cloned()
     }

--- a/frontend/apps/crates/components/src/input/simple_select/state.rs
+++ b/frontend/apps/crates/components/src/input/simple_select/state.rs
@@ -2,21 +2,23 @@ use std::rc::Rc;
 
 use futures_signals::signal::Mutable;
 
-pub struct SimpleSelect<T, P, L> {
+use super::Item;
+
+pub struct SimpleSelect<T: Item, P, L> {
     pub(super) label: Option<L>,
     pub(super) placeholder: Option<P>,
     pub(super) value: Mutable<Option<T>>,
     pub(super) values: Vec<T>,
-    pub(super) on_change: Option<Box<dyn Fn(Option<&str>)>>,
+    pub(super) on_change: Option<Box<dyn Fn(Option<T>)>>,
 }
 
-impl<T, P, L> SimpleSelect<T, P, L> {
+impl<T:Item + 'static, P, L> SimpleSelect<T, P, L> {
     pub fn new(
         label: Option<L>,
         placeholder: Option<P>,
         init_value: Option<T>,
         values: Vec<T>,
-        on_change: impl Fn(Option<&str>) + 'static,
+        on_change: impl Fn(Option<T>) + 'static,
     ) -> Rc<Self> {
         Self::_new(label, placeholder, init_value, values, Some(on_change))
     }
@@ -32,7 +34,7 @@ impl<T, P, L> SimpleSelect<T, P, L> {
             placeholder,
             init_value,
             values,
-            None::<fn(Option<&str>)>,
+            None::<fn(Option<_>)>,
         )
     }
 
@@ -41,7 +43,7 @@ impl<T, P, L> SimpleSelect<T, P, L> {
         placeholder: Option<P>,
         init_value: Option<T>,
         values: Vec<T>,
-        on_change: Option<impl Fn(Option<&str>) + 'static>,
+        on_change: Option<impl Fn(Option<T>) + 'static>,
     ) -> Rc<Self> {
         Rc::new(Self {
             label,
@@ -53,7 +55,7 @@ impl<T, P, L> SimpleSelect<T, P, L> {
     }
 }
 
-impl<T: Clone, P, L> SimpleSelect<T, P, L> {
+impl<T: Item, P, L> SimpleSelect<T, P, L> {
     pub fn get_value(&self) -> Option<T> {
         self.value.get_cloned()
     }

--- a/frontend/apps/crates/entry/user/src/register/pages/step_2/dom.rs
+++ b/frontend/apps/crates/entry/user/src/register/pages/step_2/dom.rs
@@ -15,7 +15,7 @@ use utils::{events, languages};
 
 use super::Language;
 
-use components::input::simple_select::{SimpleSelect, Item};
+use components::input::simple_select::{SimpleSelect, SimpleSelectItem};
 
 pub struct Step2Page {}
 

--- a/frontend/apps/crates/entry/user/src/register/pages/step_2/dom.rs
+++ b/frontend/apps/crates/entry/user/src/register/pages/step_2/dom.rs
@@ -11,9 +11,11 @@ use crate::{
     },
     strings::register::step_2::*,
 };
-use utils::events;
+use utils::{events, languages};
 
-use components::input::simple_select::SimpleSelect;
+use super::Language;
+
+use components::input::simple_select::{SimpleSelect, Item};
 
 pub struct Step2Page {}
 
@@ -38,9 +40,9 @@ impl Step2Page {
                         Some(STR_LANGUAGE_LABEL),
                         Some(STR_LANGUAGE_PLACEHOLDER),
                         None,
-                        STR_LANGUAGE_OPTIONS.to_vec(),
+                        languages::EMAIL_LANGUAGES.iter().map(|l| Language::from(l.clone())).collect(),
                         clone!(state => move |value| {
-                            *state.language.borrow_mut() = value.map(|x| x.to_string());
+                            *state.language.borrow_mut() = value.map(|lang| lang.value().to_string());
                             state.evaluate_language_error();
                         })
                     ),

--- a/frontend/apps/crates/entry/user/src/register/pages/step_2/mod.rs
+++ b/frontend/apps/crates/entry/user/src/register/pages/step_2/mod.rs
@@ -1,15 +1,15 @@
-use components::input::simple_select::Item;
+use components::input::simple_select::SimpleSelectItem;
 
 pub(super) mod actions;
 pub mod dom;
 pub(super) mod state;
 
-/// Wrapper for [`utils::languages::Language`] so that we can implement SimpleSelect's [`Item`]
-/// trait.
+/// Wrapper for [`utils::languages::Language`] so that we can implement SimpleSelect's
+/// [`SimpleSelectItem`] trait.
 #[derive(Clone)]
 pub struct Language(utils::languages::Language);
 
-impl Item for Language {
+impl SimpleSelectItem for Language {
     fn value(&self) -> &str {
         self.0.0
     }

--- a/frontend/apps/crates/entry/user/src/register/pages/step_2/mod.rs
+++ b/frontend/apps/crates/entry/user/src/register/pages/step_2/mod.rs
@@ -1,3 +1,26 @@
+use components::input::simple_select::Item;
+
 pub(super) mod actions;
 pub mod dom;
 pub(super) mod state;
+
+/// Wrapper for [`utils::languages::Language`] so that we can implement SimpleSelect's [`Item`]
+/// trait.
+#[derive(Clone)]
+pub struct Language(utils::languages::Language);
+
+impl Item for Language {
+    fn value(&self) -> &str {
+        self.0.0
+    }
+
+    fn label(&self) -> &str {
+        self.0.1
+    }
+}
+
+impl From<utils::languages::Language> for Language {
+    fn from(language: utils::languages::Language) -> Self {
+        Language(language)
+    }
+}

--- a/frontend/apps/crates/entry/user/src/register/pages/step_3/actions.rs
+++ b/frontend/apps/crates/entry/user/src/register/pages/step_3/actions.rs
@@ -69,10 +69,8 @@ pub fn submit(state: Rc<State>) {
         affiliations,
         location: step_2
             .location_json
-            .map(|raw| serde_json::to_value(JsonRaw { raw }).unwrap_throw()),
+            .map(|raw| serde_json::to_value(raw).unwrap_throw()),
     };
-
-    log::info!("{:?}", req);
 
     state.register_loader.load(async {
         let (resp, status) = endpoints::user::CreateProfile::api_with_auth_status(Some(req)).await;

--- a/frontend/apps/crates/entry/user/src/strings.rs
+++ b/frontend/apps/crates/entry/user/src/strings.rs
@@ -49,13 +49,12 @@ pub mod register {
         pub const STR_TERMS_TERMS: &str = "terms & conditions";
         pub const STR_TERMS_LABEL_TWO: &str = " and ";
         pub const STR_TERMS_PRIVACY: &str = "privacy policy";
-        pub const STR_LANGUAGE_LABEL: &str = "Language of communication *";
         pub const STR_MARKETING_LABEL: &str = "I would like to receive educational resources.";
         pub const STR_PROTECTING_PRIVACY:&str = "Jewish Interactive (Ji) is committed to protecting and respecting your privacy. We will only use your personal information to administer your account and to provide the products and services you requested from us.";
 
+        pub const STR_LANGUAGE_LABEL: &str = "Language of communication *";
         pub const STR_LANGUAGE_PLACEHOLDER: &str = "Select from the list";
-        pub const STR_LANGUAGE_OPTIONS: &[&str] =
-            &["English", "Hebrew", "Spanish", "French", "Russian"];
+
         pub const STR_PERSONA_OPTIONS: &[&str] = &[
             "Teacher",
             "Parent",


### PR DESCRIPTION
Resolves #2030

- Adds a new trait, `Item` which exposes `value()` and `label()` methods;
- Updates `SimpleSelect` so that it can accept a list of a `Item` instead of types which impl `Display`
- Updates the registration process to send the language code which is expected by the profile page instead of the language string.
- Resolves the location not displaying in profile by sending the correct raw location data to the server.

*Note* that this also updates the the available languages in Step 2 to be English, Hebrew and French which is what is available on the profile page. Whereas originally there was English, Hebrew, Spanish, French and Russian. I wasn't sure which was correct so I used what was in use on the profile page.