### PR TITLE
Implement like action in JIG sidebar

### DIFF
--- a/frontend/apps/crates/entry/jig/play/src/player/actions.rs
+++ b/frontend/apps/crates/entry/jig/play/src/player/actions.rs
@@ -96,7 +96,8 @@ pub fn load_jig(state: Rc<State>) {
                 // Fetch whether the current user has liked this JIG.
                 let jig_liked = {
                     match &jig {
-                        // Only fetch liked status if the jig request didn't error and
+                        // Only fetch liked status if the jig request didn't error, the user is
+                        // logged in and the user is not the author of the JIG.
                         Ok(jig) if can_load_liked_status(&jig) => {
                             let path = jig::Liked::PATH.replace("{id}", &state.jig_id.0.to_string());
                             api_with_auth::<JigLikedResponse, EmptyError, ()>(&path, jig::Liked::METHOD, None)

--- a/frontend/apps/crates/entry/jig/play/src/player/sidebar/dom/like.rs
+++ b/frontend/apps/crates/entry/jig/play/src/player/sidebar/dom/like.rs
@@ -1,0 +1,40 @@
+use std::rc::Rc;
+
+use dominator::{clone, html, Dom};
+
+use shared::{
+    api::{endpoints::jig, ApiEndpoint},
+    error::EmptyError, domain::jig::JigResponse,
+};
+
+use utils::{
+    prelude::api_with_auth_empty,
+    events
+};
+
+use super::super::state::State;
+
+pub fn render(state: Rc<State>, jig: &JigResponse) -> Dom {
+    html!("jig-play-sidebar-action", {
+        .property("slot", "actions")
+        .property("kind", "like")
+        // TODO Render active or not active
+        .event(clone!(state, jig => move |_: events::Click| {
+            state.loader.load(async move {
+                let path = jig::Like::PATH.replace("{id}", &jig.id.0.to_string());
+                let response = api_with_auth_empty::<EmptyError, ()>(
+                    &path,
+                    jig::Like::METHOD,
+                    None
+                )
+                .await;
+
+                if response.is_ok() {
+                    // TODO Toggle active state
+                    // TODO Update like count or refetch jig data
+                }
+            })
+        }))
+    })
+}
+

--- a/frontend/apps/crates/entry/jig/play/src/player/sidebar/dom/like.rs
+++ b/frontend/apps/crates/entry/jig/play/src/player/sidebar/dom/like.rs
@@ -20,7 +20,11 @@ pub fn render(state: Rc<State>, jig: &JigResponse) -> Dom {
         .property("kind", "like")
         // TODO Render active or not active
         .event(clone!(state, jig => move |_: events::Click| {
-            state.loader.load(async move {
+            // TODO Return early to disable this feature until we are able to fetch whether the
+            // current user liked the jig or not.
+            return;
+
+            state.loader.load(async {
                 let path = jig::Like::PATH.replace("{id}", &jig.id.0.to_string());
                 let response = api_with_auth_empty::<EmptyError, ()>(
                     &path,

--- a/frontend/apps/crates/entry/jig/play/src/player/sidebar/dom/like.rs
+++ b/frontend/apps/crates/entry/jig/play/src/player/sidebar/dom/like.rs
@@ -18,26 +18,38 @@ pub fn render(state: Rc<State>, jig: &JigResponse) -> Dom {
     html!("jig-play-sidebar-action", {
         .property("slot", "actions")
         .property("kind", "like")
+        .property_signal("active", state.player_state.jig_liked.signal_ref(|jig_liked| jig_liked.unwrap_or(false)))
         // TODO Render active or not active
         .event(clone!(state, jig => move |_: events::Click| {
-            // TODO Return early to disable this feature until we are able to fetch whether the
-            // current user liked the jig or not.
-            return;
+            // If jig_liked is None, we don't want to do anything because the request to fetch
+            // whether the user liked this jig may not have resolved yet.
+            if let Some(jig_liked) = state.player_state.jig_liked.get() {
+                state.loader.load(clone!(state => async move {
+                    let response = if jig_liked {
+                        // Unlike the JIG
+                        let path = jig::Unlike::PATH.replace("{id}", &jig.id.0.to_string());
+                        api_with_auth_empty::<EmptyError, ()>(
+                            &path,
+                            jig::Unlike::METHOD,
+                            None
+                        )
+                        .await
+                    } else {
+                        // Like the JIG
+                        let path = jig::Like::PATH.replace("{id}", &jig.id.0.to_string());
+                        api_with_auth_empty::<EmptyError, ()>(
+                            &path,
+                            jig::Like::METHOD,
+                            None
+                        )
+                        .await
+                    };
 
-            state.loader.load(async {
-                let path = jig::Like::PATH.replace("{id}", &jig.id.0.to_string());
-                let response = api_with_auth_empty::<EmptyError, ()>(
-                    &path,
-                    jig::Like::METHOD,
-                    None
-                )
-                .await;
-
-                if response.is_ok() {
-                    // TODO Toggle active state
-                    // TODO Update like count or refetch jig data
-                }
-            })
+                    if response.is_ok() {
+                        state.player_state.jig_liked.set(Some(!jig_liked));
+                    }
+                }));
+            }
         }))
     })
 }

--- a/frontend/apps/crates/entry/jig/play/src/player/sidebar/dom/mod.rs
+++ b/frontend/apps/crates/entry/jig/play/src/player/sidebar/dom/mod.rs
@@ -49,7 +49,7 @@ pub fn render(state: Rc<State>) -> Dom {
         .child_signal(state.player_state.jig.signal_ref(clone!(state => move |jig| {
             // only show like if jig is published
             match jig {
-                Some(jig) if jig.published_at.is_some() => {
+                Some(jig) if jig.jig_data.draft_or_live.is_live() => {
                     Some(like::render(Rc::clone(&state), &jig))
                 },
                 _ => None,
@@ -58,7 +58,7 @@ pub fn render(state: Rc<State>) -> Dom {
         .child_signal(state.player_state.jig.signal_ref(clone!(state => move |jig| {
             // only show share options if jig is published
             match jig {
-                Some(jig) if jig.published_at.is_some() => {
+                Some(jig) if jig.jig_data.draft_or_live.is_live() => {
                     Some(share::render(Rc::clone(&state)))
                 },
                 _ => None,

--- a/frontend/apps/crates/entry/jig/play/src/player/sidebar/dom/mod.rs
+++ b/frontend/apps/crates/entry/jig/play/src/player/sidebar/dom/mod.rs
@@ -10,6 +10,7 @@ use crate::player::sidebar::actions::load_ages;
 use super::state::State;
 
 pub(super) mod info;
+pub(super) mod like;
 pub(super) mod report;
 pub(super) mod share;
 
@@ -45,10 +46,15 @@ pub fn render(state: Rc<State>) -> Dom {
                 state.sidebar_open.set(false);
             }))
         }))
-        .child(html!("jig-play-sidebar-action", {
-            .property("slot", "actions")
-            .property("kind", "like")
-        }))
+        .child_signal(state.player_state.jig.signal_ref(clone!(state => move |jig| {
+            // only show like if jig is published
+            match jig {
+                Some(jig) if jig.published_at.is_some() => {
+                    Some(like::render(Rc::clone(&state), &jig))
+                },
+                _ => None,
+            }
+        })))
         .child_signal(state.player_state.jig.signal_ref(clone!(state => move |jig| {
             // only show share options if jig is published
             match jig {

--- a/frontend/apps/crates/entry/jig/play/src/player/sidebar/dom/mod.rs
+++ b/frontend/apps/crates/entry/jig/play/src/player/sidebar/dom/mod.rs
@@ -8,6 +8,7 @@ use utils::events;
 use crate::player::sidebar::actions::load_ages;
 
 use super::state::State;
+use super::super::state::can_load_liked_status;
 
 pub(super) mod info;
 pub(super) mod like;
@@ -47,10 +48,13 @@ pub fn render(state: Rc<State>) -> Dom {
             }))
         }))
         .child_signal(state.player_state.jig.signal_ref(clone!(state => move |jig| {
-            // only show like if jig is published
             match jig {
-                Some(jig) if jig.jig_data.draft_or_live.is_live() => {
-                    Some(like::render(Rc::clone(&state), &jig))
+                Some(jig) => {
+                    if can_load_liked_status(jig) {
+                        Some(like::render(Rc::clone(&state), jig))
+                    } else {
+                        None
+                    }
                 },
                 _ => None,
             }

--- a/frontend/apps/crates/entry/jig/play/src/player/state.rs
+++ b/frontend/apps/crates/entry/jig/play/src/player/state.rs
@@ -3,7 +3,7 @@ use std::{cell::RefCell, rc::Rc};
 use awsm_web::{audio::AudioHandle, loaders::helpers::AsyncLoader};
 use futures_signals::signal::Mutable;
 use serde::{Deserialize, Serialize};
-use shared::domain::jig::{module::ModuleId, JigId, JigPlayerSettings, JigResponse};
+use shared::domain::{jig::{module::ModuleId, JigId, JigPlayerSettings, JigResponse}, user::UserProfile};
 use utils::jig::JigPlayerOptions;
 use web_sys::HtmlIFrameElement;
 
@@ -56,4 +56,20 @@ impl State {
 pub struct PlayerOptions {
     settings: JigPlayerSettings,
     is_student: bool,
+}
+
+/// Returns whether the liked status should be loaded for a JIG
+///
+/// Returns true only if there is a logged-in user who is **not** the author of the JIG, and the
+/// JIG is published.
+pub fn can_load_liked_status(jig: &JigResponse) -> bool {
+    match utils::init::user::get_user() {
+        Some(user) if jig.jig_data.draft_or_live.is_live() => {
+            match jig.author_id {
+                Some(author_id) => author_id != user.id,
+                None => true
+            }
+        },
+        _ => false, // No logged-in user
+    }
 }

--- a/frontend/apps/crates/entry/jig/play/src/player/state.rs
+++ b/frontend/apps/crates/entry/jig/play/src/player/state.rs
@@ -12,6 +12,8 @@ use super::timer::Timer;
 pub struct State {
     pub jig_id: JigId,
     pub jig: Mutable<Option<JigResponse>>,
+    /// Loaded after [`State`] is initialized necessitating an Option
+    pub jig_liked: Mutable<Option<bool>>,
     pub loader: AsyncLoader,
     pub active_module: Mutable<usize>,
     pub module_id: Mutable<Option<ModuleId>>, // needed?
@@ -34,6 +36,7 @@ impl State {
         Self {
             jig_id,
             jig: Mutable::new(None),
+            jig_liked: Mutable::new(None),
             loader: AsyncLoader::new(),
             active_module: Mutable::new(0),
             module_id: Mutable::new(None),

--- a/shared/rust/src/domain/jig.rs
+++ b/shared/rust/src/domain/jig.rs
@@ -171,6 +171,34 @@ pub enum DraftOrLive {
     Live = 1,
 }
 
+impl DraftOrLive {
+    /// Returns `true` for a [`Self::Live`] value.
+    ///
+    /// ```
+    /// let x = DraftOrLive::Live;
+    /// assert_eq!(x.is_live(), true);
+    ///
+    /// let x = DraftOrLive::Draft;
+    /// assert_eq!(x.is_live(), false);
+    /// ```
+    pub fn is_live(&self) -> bool {
+        matches!(*self, DraftOrLive::Live)
+    }
+
+    /// Returns `true` for a [`Draft`] value.
+    ///
+    /// ```
+    /// let x = DraftOrLive::Live;
+    /// assert_eq!(x.is_draft(), false);
+    ///
+    /// let x = DraftOrLive::Draft;
+    /// assert_eq!(x.is_draft(), true);
+    /// ```
+    pub fn is_draft(&self) -> bool {
+        !self.is_live()
+    }
+}
+
 impl From<DraftOrLive> for bool {
     fn from(draft_or_live: DraftOrLive) -> Self {
         match draft_or_live {


### PR DESCRIPTION
Resolves #1505

- [x] Only fetched liked status if user is logged in and not the author
- [x] Only render the like icon if the user is logged in