### PR TITLE
feat(fe/module/card-quiz): Fade out incorrect answers when correct answer clicked

### DIFF
--- a/frontend/apps/crates/entry/jig/play/src/player/sidebar/dom/mod.rs
+++ b/frontend/apps/crates/entry/jig/play/src/player/sidebar/dom/mod.rs
@@ -49,12 +49,8 @@ pub fn render(state: Rc<State>) -> Dom {
         }))
         .child_signal(state.player_state.jig.signal_ref(clone!(state => move |jig| {
             match jig {
-                Some(jig) => {
-                    if can_load_liked_status(jig) {
-                        Some(like::render(Rc::clone(&state), jig))
-                    } else {
-                        None
-                    }
+                Some(jig) if can_load_liked_status(jig) => {
+                    Some(like::render(Rc::clone(&state), jig))
                 },
                 _ => None,
             }

--- a/frontend/apps/crates/entry/module/card-quiz/play/src/base/game/dom.rs
+++ b/frontend/apps/crates/entry/module/card-quiz/play/src/base/game/dom.rs
@@ -43,9 +43,14 @@ impl Game {
                                 children.push(render_card_mixin(options, |dom| {
                                     dom
                                         //should be some animation
-                                        .property_signal("flipped", phase.signal().map(clone!(pair_id => move |phase| {
+                                        .property_signal("faded", phase.signal().map(clone!(pair_id => move |phase| {
                                             match phase {
                                                 CurrentPhase::Correct(id) => id != pair_id,
+                                                _ => false,
+                                            }
+                                        })))
+                                        .property_signal("flipped", phase.signal().map(clone!(pair_id => move |phase| {
+                                            match phase {
                                                 CurrentPhase::Wrong(id) => id != pair_id,
                                                 _ => true,
                                             }

--- a/frontend/elements/src/module/_groups/cards/play/card/card.ts
+++ b/frontend/elements/src/module/_groups/cards/play/card/card.ts
@@ -35,7 +35,7 @@ export class _ extends LitElement {
                 }
 
                 section {
-                    transition: transform 0.8s;
+                    transition: transform 0.8s, opacity 0.8s;
                     transform-style: preserve-3d;
                     transform: rotateY(180deg);
                 }
@@ -84,6 +84,10 @@ export class _ extends LitElement {
                     transform: rotateY(0deg);
                 }
 
+                :host([faded]) > section {
+                    opacity: 0.5;
+                }
+
                 :host * {
                     pointer-events: none;
                 }
@@ -94,6 +98,10 @@ export class _ extends LitElement {
     // whether or not showing front vs. back
     @property({ type: Boolean, reflect: true })
     flipped: boolean = false;
+
+    // Whether or not the card is faded out
+    @property({ type: Boolean, reflect: true })
+    faded: boolean = false;
 
     // required for styling
     @property()


### PR DESCRIPTION
Resolves #1678 

- Adds a new property to `play-card` which can set whether the card is to be faded out or not;
- Correct answers will fade out the incorrect cards;
- Wrong answers will flip the clicked card which is existing logic.