### PR TITLE
feat(fe/module/card-quiz): Flip incorrect answers when correct answer is clicked

### DIFF
--- a/frontend/apps/crates/entry/module/card-quiz/play/src/base/game/dom.rs
+++ b/frontend/apps/crates/entry/module/card-quiz/play/src/base/game/dom.rs
@@ -45,7 +45,7 @@ impl Game {
                                         //should be some animation
                                         .property_signal("flipped", phase.signal().map(clone!(pair_id => move |phase| {
                                             match phase {
-                                                CurrentPhase::Correct(id) => id != pair_id,
+                                                CurrentPhase::Correct(id) => id == pair_id,
                                                 CurrentPhase::Wrong(id) => id != pair_id,
                                                 _ => true,
                                             }


### PR DESCRIPTION
Part of #1678

- When the correct card is selected, the incorrect cards are flipped;
- When an incorrect card is selected, that card is flipped (existing behavior).