### PR TITLE
feat(fe/module/card-quiz): Keep incorrect choice card flipped when chosen

### DIFF
--- a/frontend/apps/crates/entry/module/card-quiz/play/src/base/game/actions.rs
+++ b/frontend/apps/crates/entry/module/card-quiz/play/src/base/game/actions.rs
@@ -84,8 +84,11 @@ impl Game {
                     TimeoutFuture::new(crate::config::SUCCESS_TIME).await;
                     Self::next(state);
                 } else {
-                    phase.set(CurrentPhase::Wrong(pair_id));
-                    TimeoutFuture::new(crate::config::WRONG_TIME).await;
+                    // We should be able to safely assume that current is Some(_), but
+                    // double-check here anyway because assumptions are bad.
+                    if let Some(current) = &*state.current.lock_ref() {
+                        current.incorrect_choices.borrow_mut().push(pair_id);
+                    }
                     phase.set(CurrentPhase::Waiting);
                 }
 

--- a/frontend/apps/crates/entry/module/card-quiz/play/src/base/game/dom.rs
+++ b/frontend/apps/crates/entry/module/card-quiz/play/src/base/game/dom.rs
@@ -22,7 +22,7 @@ impl Game {
                             let theme_id = state.base.theme_id;
                             let mode = state.base.mode;
 
-                            let Current { target, others, side, phase } = &*current;
+                            let Current { target, others, side, phase, .. } = &*current;
 
                             let mut options = CardOptions::new(&target.card, theme_id, mode, *side, Size::QuizTarget);
 
@@ -43,12 +43,23 @@ impl Game {
                                 children.push(render_card_mixin(options, |dom| {
                                     dom
                                         //should be some animation
-                                        .property_signal("flipped", phase.signal().map(clone!(pair_id => move |phase| {
-                                            match phase {
-                                                CurrentPhase::Correct(id) => id == pair_id,
-                                                CurrentPhase::Wrong(id) => id != pair_id,
-                                                _ => true,
+                                        .property_signal("flipped", phase.signal().map(clone!(state, pair_id => move |phase| {
+                                            let is_incorrect_choice = state.current.lock_ref().as_ref().unwrap().incorrect_choices
+                                                .borrow()
+                                                .iter()
+                                                .find(|id| *id == &pair_id)
+                                                .is_some();
+
+                                            if is_incorrect_choice {
+                                                false
+                                            } else {
+                                                match phase {
+                                                    CurrentPhase::Correct(id) => id == pair_id,
+                                                    CurrentPhase::Wrong(id) => id != pair_id,
+                                                    CurrentPhase::Waiting => true,
+                                                }
                                             }
+
                                         })))
                                         .event(clone!(state, pair_id, phase => move |_evt:events::Click| {
                                             Self::evaluate(state.clone(), pair_id, phase.clone());

--- a/frontend/apps/crates/entry/module/card-quiz/play/src/base/game/state.rs
+++ b/frontend/apps/crates/entry/module/card-quiz/play/src/base/game/state.rs
@@ -27,10 +27,10 @@ pub struct CardId {
     pub pair_id: usize,
 }
 
-#[derive(Clone)]
 pub struct Current {
     pub target: CardId,
     pub others: Vec<CardId>,
+    pub incorrect_choices: RefCell<Vec<usize>>,
     pub side: Side,
     pub phase: Mutable<CurrentPhase>,
 }
@@ -125,6 +125,7 @@ impl Current {
         Rc::new(Self {
             target,
             others,
+            incorrect_choices: RefCell::new(Vec::new()),
             side,
             phase: Mutable::new(CurrentPhase::Waiting),
         })


### PR DESCRIPTION
Closes #1678 

- When an incorrect choice is made, the card is flipped and remains flipped;
- Removes timer between making choices because incorrect cards are no longer re-shown.