### PR TITLE
Show like and play counts in JIG info popup

### DIFF
--- a/backend/api/src/http/endpoints/jig.rs
+++ b/backend/api/src/http/endpoints/jig.rs
@@ -351,7 +351,6 @@ async fn unlike(
 /// Add a play to a jig
 async fn play(
     db: Data<PgPool>,
-    _claims: TokenUser,
     path: web::Path<JigId>,
 ) -> Result<HttpResponse, error::NotFound> {
     db::jig::jig_play(&*db, path.into_inner()).await?;

--- a/backend/api/src/http/endpoints/jig.rs
+++ b/backend/api/src/http/endpoints/jig.rs
@@ -349,10 +349,7 @@ async fn unlike(
 }
 
 /// Add a play to a jig
-async fn play(
-    db: Data<PgPool>,
-    path: web::Path<JigId>,
-) -> Result<HttpResponse, error::NotFound> {
+async fn play(db: Data<PgPool>, path: web::Path<JigId>) -> Result<HttpResponse, error::NotFound> {
     db::jig::jig_play(&*db, path.into_inner()).await?;
 
     Ok(HttpResponse::NoContent().finish())

--- a/frontend/apps/crates/entry/jig/play/src/player/actions.rs
+++ b/frontend/apps/crates/entry/jig/play/src/player/actions.rs
@@ -15,7 +15,7 @@ use shared::{
 };
 use utils::{
     iframe::{IframeAction, JigToModulePlayerMessage, ModuleToJigPlayerMessage},
-    prelude::{api_no_auth, SETTINGS, api_with_auth},
+    prelude::{api_no_auth, api_no_auth_empty, api_with_auth, SETTINGS},
     routes::{HomeRoute, Route},
     unwrap::UnwrapJiExt,
 };
@@ -128,6 +128,14 @@ pub fn load_jig(state: Rc<State>) {
             },
             Err(_) => {},
         }
+
+        // We don't need to handle an Ok Result; We can ignore Err, nothing is dependent on the
+        // success of this call. The failure should be noted in the server logs.
+        let _ = api_no_auth_empty::<EmptyError, ()>(
+            &jig::Play::PATH.replace("{id}", &state.jig_id.0.to_string()),
+            jig::Play::METHOD,
+            None,
+        ).await;
     }));
 }
 

--- a/frontend/apps/crates/entry/jig/play/src/player/sidebar/dom/info.rs
+++ b/frontend/apps/crates/entry/jig/play/src/player/sidebar/dom/info.rs
@@ -55,8 +55,8 @@ fn render_jig_info(state: Rc<State>, jig: &JigResponse) -> Dom {
     html!("jig-play-sidebar-jig-info", {
         .property("slot", "overlay")
         .property("name", &jig.jig_data.display_name)
-        .property("playedCount", "?")
-        .property("likedCount", "?")
+        .property("playedCount", jig.plays as usize)
+        .property("likedCount", jig.likes as usize)
         .property("language", &jig.jig_data.language)
         // .property("author", jig.author_id)
         .property("publishedAt", {

--- a/shared/rust/src/api/endpoints/jig.rs
+++ b/shared/rust/src/api/endpoints/jig.rs
@@ -237,7 +237,7 @@ impl ApiEndpoint for Liked {
 /// Play a JIG
 ///
 /// # Authorization
-/// * Admin, BasicAuth
+/// * None
 pub struct Play;
 impl ApiEndpoint for Play {
     type Req = ();


### PR DESCRIPTION
Closes #1505

- Updates endpoint so that user auth isn't a requirement (@MendyBerger @RickyLB)
  - My assumption with that is that most users who will be playing JIGs will not be logged in. Without this change we wouldn't have a true representation of how many times a JIG is played. 
  - It also means that the endpoint can be abused to inflate play counts - not sure to what end though lol.
- Calls the play endpoint from the frontend when a JIG is started
- Renders play count and liked count in the info popup in a JIGs side panel 

Todo

- [ ] Increment play count once a JIG is played through.