### PR TITLE
feat(fe/components): Navigate user to Image tab when word list is created

### DIFF
--- a/frontend/apps/crates/components/src/module/_groups/cards/edit/sidebar/step_1/dom.rs
+++ b/frontend/apps/crates/components/src/module/_groups/cards/edit/sidebar/step_1/dom.rs
@@ -16,7 +16,7 @@ pub fn render<RawData: RawDataExt, E: ExtraExt>(state: Rc<Step1<RawData, E>>) ->
     html!("empty-fragment", {
         .style("display", "contents")
         .child_signal(state.base.is_empty_signal().map(clone!(state => move |is_empty| {
-            Some(match &*state.widget {
+            Some(match state.widget.get().unwrap() {
                 Widget::Single(single) => {
 
                     html!("module-sidebar-body", {
@@ -96,17 +96,18 @@ fn render_tab<RawData: RawDataExt, E: ExtraExt>(
     state: Rc<Step1<RawData, E>>,
     tab: Mutable<Tab>,
     tab_kind: MenuTabKind,
-    _enabled: bool,
+    enabled: bool,
 ) -> Dom {
     MenuTab::render(
         MenuTab::new(
             tab_kind,
             false,
+            enabled,
             clone!(tab => move || tab.signal_ref(clone!(tab_kind => move |curr| {
                 curr.kind() == tab_kind
             }))),
             clone!(state, tab_kind => move || {
-                tab.set(Tab::new(state.base.clone(), tab_kind));
+                tab.set(Tab::new(state.clone(), tab_kind));
             }),
         ),
         Some("tabs"),

--- a/frontend/apps/crates/components/src/module/_groups/cards/edit/sidebar/step_2/dom.rs
+++ b/frontend/apps/crates/components/src/module/_groups/cards/edit/sidebar/step_2/dom.rs
@@ -48,6 +48,7 @@ fn render_tab<RawData: RawDataExt, E: ExtraExt>(
         MenuTab::new(
             tab_kind,
             false,
+            false,
             clone!(state => move || state.tab.signal_ref(clone!(tab_kind => move |curr| {
                 curr.kind() == tab_kind
             }))),

--- a/frontend/apps/crates/components/src/module/_groups/cards/edit/sidebar/step_3/dom.rs
+++ b/frontend/apps/crates/components/src/module/_groups/cards/edit/sidebar/step_3/dom.rs
@@ -58,6 +58,7 @@ where
         MenuTab::new(
             tab_kind,
             false,
+            false,
             clone!(state => move || state.tab.signal_ref(clone!(tab_kind => move |curr| {
                 curr.kind() == tab_kind
             }))),

--- a/frontend/apps/crates/components/src/tabs/dom.rs
+++ b/frontend/apps/crates/components/src/tabs/dom.rs
@@ -9,6 +9,7 @@ impl MenuTab {
         html!("menu-tab-with-title", {
             .apply_if(slot.is_some(), |dom| dom.property("slot", slot.unwrap_ji()))
             .property("kind", state.kind.as_str())
+            .property("disabled", !state.enabled)
             .apply_if(state.sizeable, |dom| {
                 dom.property_signal("small", (state.active_signal) ().map(|active| !active))
             })

--- a/frontend/apps/crates/components/src/tabs/state.rs
+++ b/frontend/apps/crates/components/src/tabs/state.rs
@@ -5,6 +5,7 @@ use std::rc::Rc;
 pub struct MenuTab {
     pub kind: MenuTabKind,
     pub sizeable: bool,
+    pub enabled: bool,
     pub active_signal: BoxSignalFn<bool>,
     pub on_click: Box<dyn Fn()>,
 }
@@ -13,6 +14,7 @@ impl MenuTab {
     pub fn new<A, ASig, C>(
         kind: MenuTabKind,
         sizeable: bool,
+        enabled: bool,
         active_signal: A,
         on_click: C,
     ) -> Rc<Self>
@@ -24,6 +26,7 @@ impl MenuTab {
         Rc::new(Self {
             kind,
             sizeable,
+            enabled,
             active_signal: box_signal_fn(active_signal),
             on_click: Box::new(on_click),
         })


### PR DESCRIPTION
Closes #1847

- When a user completes a list and clicks "Done", they are taken straight to the Images tab;
- Image tab is disabled when there is an empty list;
- Cyclic reference exists for widgets so that they can access step_1 state.