### PR TITLE
feat(fe/search): Condense search hero on content page

### DIFF
--- a/frontend/apps/Cargo.lock
+++ b/frontend/apps/Cargo.lock
@@ -41,8 +41,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "shared",
- "strum",
- "strum_macros",
+ "strum 0.22.0",
+ "strum_macros 0.22.0",
  "url",
  "utils",
  "uuid",
@@ -361,6 +361,8 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_json",
  "shared",
+ "strum 0.23.0",
+ "strum_macros 0.23.1",
  "utils",
  "uuid",
  "wasm-bindgen",
@@ -395,8 +397,8 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_json",
  "shared",
- "strum",
- "strum_macros",
+ "strum 0.22.0",
+ "strum_macros 0.22.0",
  "url",
  "utils",
  "uuid",
@@ -1167,8 +1169,8 @@ dependencies = [
  "serde_qs",
  "serde_repr",
  "shared",
- "strum",
- "strum_macros",
+ "strum 0.22.0",
+ "strum_macros 0.22.0",
  "thiserror",
  "unicode-segmentation",
  "url",
@@ -1727,8 +1729,8 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_json",
  "shared",
- "strum",
- "strum_macros",
+ "strum 0.22.0",
+ "strum_macros 0.22.0",
  "url",
  "utils",
  "uuid",
@@ -2265,6 +2267,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7ac893c7d471c8a21f31cfe213ec4f6d9afeed25537c772e08ef3f005f8729e"
 
 [[package]]
+name = "strum"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cae14b91c7d11c9a851d3fbc80a963198998c2a64eec840477fa92d8ce9b70bb"
+
+[[package]]
 name = "strum_macros"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2273,6 +2281,19 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
  "syn",
 ]
 
@@ -2420,8 +2441,8 @@ dependencies = [
  "serde_qs",
  "serde_repr",
  "shared",
- "strum",
- "strum_macros",
+ "strum 0.22.0",
+ "strum_macros 0.22.0",
  "thiserror",
  "url",
  "uuid",

--- a/frontend/apps/crates/entry/home/Cargo.toml
+++ b/frontend/apps/crates/entry/home/Cargo.toml
@@ -64,6 +64,8 @@ jsonwebtoken = "7.2.0"
 chrono = { version = "0.4.19", features = ["serde"] }
 chrono-tz = { version = "0.6.0", features = ["serde"] }
 zxcvbn = "2.1.2"
+strum = "0.23.0"
+strum_macros = "0.23.1"
 
 [features]
 default = ["wee_alloc"]

--- a/frontend/apps/crates/entry/home/src/home/dom/search_section/advanced_search.rs
+++ b/frontend/apps/crates/entry/home/src/home/dom/search_section/advanced_search.rs
@@ -10,8 +10,7 @@ use super::categories_select;
 
 use super::super::super::{actions::search, state::State};
 
-const STR_SEARCH: &str = "Search";
-const STR_ADVANCED: &str = "Advanced";
+const STR_SEARCH: &str = "Advanced Search";
 const STR_GOAL_LABEL: &str = "Teaching Goal";
 const STR_GOAL_PLACEHOLDER: &str = "Select from the list";
 const STR_AFFILIATION_LABEL: &str = "Affiliation";
@@ -22,12 +21,11 @@ pub fn render(state: Rc<State>) -> Dom {
         .property("slot", "advanced")
         .children(&mut [
             html!("button-rect", {
+                .attribute("style", "height: 48px")
                 .property("slot", "opener")
                 .property("kind", "text")
                 .property("color", "white")
                 .property("bold", true)
-                .text(STR_ADVANCED)
-                .child(html!("br"))
                 .text(STR_SEARCH)
             }),
 

--- a/frontend/apps/crates/entry/home/src/home/dom/search_section/mod.rs
+++ b/frontend/apps/crates/entry/home/src/home/dom/search_section/mod.rs
@@ -24,13 +24,7 @@ pub fn render(state: Rc<State>, auto_search: bool) -> Dom {
     fetch_data(state.clone(), auto_search);
 
     html!("home-search-section", {
-        // TODO: Enable once ready
-        // .property_signal("mode", state.mode.signal_cloned().map(|mode| {
-        //     match mode {
-        //         HomePageMode::Home => "home",
-        //         HomePageMode::Search(_, _) => "results",
-        //     }
-        // }))
+        .property_signal("mode", state.mode.signal_cloned().map(|mode| mode.to_string()))
         .property_signal("resultsCount", state.total_jigs_count.signal().map(|x| x as f64))
         .child(html!("home-search-section-help", {
             .property("slot", "help")

--- a/frontend/apps/crates/entry/home/src/home/state/mod.rs
+++ b/frontend/apps/crates/entry/home/src/home/state/mod.rs
@@ -1,11 +1,12 @@
 use std::{iter, rc::Rc};
 
 use dominator_helpers::futures::AsyncLoader;
-use futures_signals::{signal::Mutable};
+use futures_signals::signal::Mutable;
 use shared::domain::jig::{JigId, JigSearchQuery};
 
 use components::page_header::state::PageLinks;
 
+use strum_macros::Display;
 use super::search_results::SearchResults;
 
 mod search_state;
@@ -138,9 +139,11 @@ impl State {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Display)]
 pub enum HomePageMode {
+    #[strum(serialize = "home")]
     Home,
+    #[strum(serialize = "results")]
     Search(Rc<SearchResults>),
 }
 

--- a/frontend/elements/src/core/buttons/rectangle.ts
+++ b/frontend/elements/src/core/buttons/rectangle.ts
@@ -74,6 +74,9 @@ export class _ extends LitElement {
                 :host([color="orange"]) {
                     --color: #fc7551;
                 }
+                :host([color="white"]) {
+                    --color: #e8f3ff;
+                }
                 :host([kind="filled"]) {
                     background-color: var(--color);
                     color: #ffffff;

--- a/frontend/elements/src/entry/home/home/search-section/search-bar.ts
+++ b/frontend/elements/src/entry/home/home/search-section/search-bar.ts
@@ -8,6 +8,7 @@ export class _ extends LitElement {
                 :host {
                     position: relative;
                     display: flex;
+                    font-size: 20px;
                 }
                 .bar {
                     border-radius: 36px;
@@ -17,7 +18,6 @@ export class _ extends LitElement {
                     grid-template-columns: 1fr 200px 200px auto;
                     align-items: center;
                     padding-left: 18px;
-                    border: solid 1px #ffffff;
                     height: 48px;
                     box-sizing: border-box;
                 }
@@ -43,9 +43,10 @@ export class _ extends LitElement {
                 }
                 ::slotted([slot="button"]) {
                     /* cover .bar border */
-                    margin: -1px -2px 0 0;
                     height: 48px;
+                    font-size: 24px;
                 }
+
                 .advanced {
                     position: absolute;
                     /* add 32px for margin */

--- a/frontend/elements/src/entry/home/home/search-section/search-section.ts
+++ b/frontend/elements/src/entry/home/home/search-section/search-section.ts
@@ -40,12 +40,6 @@ export class _ extends LitElement {
                 .center-2 {
                     transition: width 0.3s;
                 }
-                :host([mode="results"]) .center-2 {
-                    width: 0;
-                }
-                :host([mode="home"]) .center-2 {
-                    width: 100%;
-                }
                 .center-3 {
                     width: 1000px;
                     margin: 0 auto;
@@ -90,15 +84,9 @@ export class _ extends LitElement {
     @property({ type: Number })
     resultsCount: number = 0;
 
-    render() {
-        return html`
-            <div class="width-holder">
-                <!--
-                    3 levels of center: 
-                        1) take both grid columns
-                        2) full width in home and 0 width in result mode
-                        3) container of actual content
-                -->
+    renderSearchSection() {
+        if (this.mode === 'home') {
+            return html`
                 <div class="center-1">
                     <div class="center-2">
                         <div class="center-3">
@@ -110,7 +98,6 @@ export class _ extends LitElement {
                                 ${STR_LEARNING}
                                 <span class="creation">${STR_CREATION}</span>
                             </h1>
-                            <slot name="search-bar"></slot>
                             <h4>
                                 ${STR_MAKE_LEARNING}
                                 <span class="results-count"
@@ -118,12 +105,50 @@ export class _ extends LitElement {
                                 >
                                 ${STR_JIGS}
                             </h4>
+                            <slot name="search-bar"></slot>
                         </div>
                     </div>
                 </div>
-                <div class="help results-only">
-                    <slot name="help"></slot>
+            `;
+        } else {
+            return html`
+                <div class="center-1">
+                    <div class="center-2">
+                        <div class="center-3">
+                            <slot name="search-bar"></slot>
+                        </div>
+                    </div>
                 </div>
+            `;
+        }
+    }
+
+    renderHelp() {
+        if (this.mode !== 'results') {
+            return null;
+        }
+
+        // TODO: Enable once ready
+        return html`
+            <!--
+            <div class="help results-only">
+                <slot name="help"></slot>
+            </div>
+            -->
+        `;
+    }
+
+    render() {
+        // 3 levels of center:
+        //  1) take both grid columns
+        //  2) full width in home and 0 width in result mode
+        //  3) container of actual content
+        return html`
+            <div class="width-holder">
+                <!--
+                -->
+                ${this.renderSearchSection()}
+                ${this.renderHelp()}
             </div>
         `;
     }


### PR DESCRIPTION
Closes #1372

- Condenses search bar for search results page (Content page);
- Increases font size for select items and search button;
- Fixes formatting of "Advanced Search" button.

### Before

![image](https://user-images.githubusercontent.com/4161106/147208943-daa6940b-00df-407d-b883-d15de06adde9.png)

### After

#### Home

![image](https://user-images.githubusercontent.com/4161106/147209005-6210f4ff-f67e-4f01-864e-1be79dc01153.png)

#### Content/Search Results

![image](https://user-images.githubusercontent.com/4161106/147209115-dfe3639e-dbd0-40d0-a9ba-e91dfeb7f7a6.png)
