### PR TITLE
refactor(fe): Clean-up profile types; Reduce calls to profile endpoint

### DIFF
--- a/frontend/apps/crates/components/src/page_header/actions.rs
+++ b/frontend/apps/crates/components/src/page_header/actions.rs
@@ -1,16 +1,9 @@
 use std::rc::Rc;
 
 use dominator::clone;
-use shared::{
-    api::{
-        endpoints::{self, user::Profile},
-        ApiEndpoint,
-    },
-    domain::user::UserProfile,
-    error::EmptyError,
-};
+use shared::api::endpoints;
 use utils::{
-    prelude::{api_with_auth_status, ApiEndpointExt},
+    prelude::{ApiEndpointExt, get_user},
     routes::{Route, UserRoute},
     storage::delete_csrf_token,
     unwrap::UnwrapJiExt,
@@ -19,25 +12,12 @@ use utils::{
 use super::state::{LoggedInState, State};
 
 pub fn fetch_profile(state: Rc<State>) {
-    state.loader.load(clone!(state => async move {
-        let (result, status) = api_with_auth_status::<UserProfile, EmptyError, ()>(Profile::PATH, Profile::METHOD, None).await;
-
-        match status  {
-            401 | 403 => {
-                state.logged_in.set(LoggedInState::LoggedOut)
-            }
-            _ => {
-                match result {
-                    Err(_) => {
-                        log::info!("error fetching profile");
-                    },
-                    Ok(profile) => {
-                        state.logged_in.set(LoggedInState::LoggedIn(profile))
-                    }
-                }
-            }
-        };
-    }));
+    match get_user() {
+        Some(profile) => {
+            state.logged_in.set(LoggedInState::LoggedIn(profile));
+        },
+        None => {},
+    }
 }
 
 pub fn logout(state: Rc<State>) {

--- a/frontend/apps/crates/components/src/page_header/state.rs
+++ b/frontend/apps/crates/components/src/page_header/state.rs
@@ -23,7 +23,7 @@ impl State {
 
 #[derive(Clone, Debug)]
 pub enum LoggedInState {
-    LoggedIn(UserProfile),
+    LoggedIn(&'static UserProfile),
     LoggedOut,
     Loading,
 }

--- a/frontend/apps/crates/entry/home/src/home/actions.rs
+++ b/frontend/apps/crates/entry/home/src/home/actions.rs
@@ -1,18 +1,15 @@
 use crate::home::search_results::SearchResults;
 
-use super::state::{HomePageMode};
+use super::state::HomePageMode;
 use dominator::clone;
 use futures::join;
 
 use shared::{
     api::{
-        endpoints::{jig, user::Profile},
+        endpoints::jig,
         ApiEndpoint,
     },
-    domain::{
-        jig::{JigCountResponse},
-        user::UserProfile
-    },
+    domain::jig::JigCountResponse,
     error::EmptyError
 };
 use std::rc::Rc;
@@ -72,21 +69,13 @@ async fn fetch_metadata(state: Rc<State>) {
 }
 
 async fn fetch_profile(state: Rc<State>) {
-    let (result, status) =
-        api_with_auth_status::<UserProfile, EmptyError, ()>(Profile::PATH, Profile::METHOD, None)
-            .await;
-    match status {
-        403 | 401 => {
-            //not logged in
-        }
-        _ => match result {
-            Err(_) => {}
-            Ok(profile) => {
-                state.is_logged_in.set(true);
-                state.search_selected.set_from_profile(&profile);
-            }
+    match get_user() {
+        Some(profile) => {
+            state.is_logged_in.set(true);
+            state.search_selected.set_from_profile(profile);
         },
-    };
+        None => {},
+    }
 }
 
 async fn search_async(state: Rc<State>) {


### PR DESCRIPTION
- Cleans up the global `USER` so that the type is a no longer a `OnceCell<Mutable<Option<>>>` and is instead a `OnceCell<>`
- Reduces the amount of calls to the profile endpoint by reusing the `get_user()` function.