### PR TITLE
feat(fe/jig/edit): Add confirm modal for deleting JIGs and activities

### DIFF
--- a/frontend/apps/crates/entry/admin/src/images/meta/dom.rs
+++ b/frontend/apps/crates/entry/admin/src/images/meta/dom.rs
@@ -21,6 +21,9 @@ const STR_DESCRIPTION: &str = "Image description";
 const STR_NEXT: &str = "Next";
 const STR_PUBLISH: &str = "Publish";
 
+const STR_DELETE_TITLE: &'static str = "Warning";
+const STR_DELETE_CONTENT: &'static str = "Are you sure you want to delete this image?";
+
 pub struct ImageMetaPage {}
 
 impl ImageMetaPage {
@@ -188,18 +191,24 @@ impl ImageMetaPage {
                                         }
                                     })))
                                 }),
-                                html!("modal-confirm", {
-                                    .property("mode", "deleteImage")
-                                    .property_signal("visible", state.delete_modal.signal())
-                                    .property("slot", "modal")
-                                    .event(clone!(state => move |evt:events::CustomToggle| {
-                                        state.delete_modal.set_neq(false);
-                                        if evt.value() {
-                                            actions::delete(state.clone());
-                                        }
-                                    }))
-                                })
                             ])
+                            .child_signal(state.delete_modal.signal().map(clone!(state => move |delete_modal| {
+                                if delete_modal {
+                                    Some(html!("modal-confirm", {
+                                        .property("slot", "modal")
+                                        .property("dangerous", true)
+                                        .property("title", STR_DELETE_TITLE)
+                                        .property("content", STR_DELETE_CONTENT)
+                                        .event(clone!(state => move |_evt: events::CustomCancel| state.delete_modal.set_neq(false)))
+                                        .event(clone!(state => move |_evt: events::CustomConfirm| {
+                                            state.delete_modal.set_neq(false);
+                                            actions::delete(state.clone());
+                                        }))
+                                    }))
+                                } else {
+                                    None
+                                }
+                            })))
                         }))
                     } else {
                         None

--- a/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/menu/dom.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/menu/dom.rs
@@ -130,8 +130,8 @@ fn item_delete(state: &Rc<State>, module: &Rc<ModuleState>) -> Dom {
         .property("slot", "lines")
         .property("icon", "delete")
         .event(clone!(state, module => move |_:events::Click| {
+            module.confirm_delete.set_neq(true);
             state.close_menu();
-            actions::delete(module.clone());
         }))
     })
 }

--- a/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/module/dom.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/module/dom.rs
@@ -15,6 +15,8 @@ use wasm_bindgen::prelude::*;
 
 const STR_DELETE_TITLE: &'static str = "Warning";
 const STR_DELETE_CONTENT: &'static str = "Are you sure you want to delete this activity?";
+const STR_DELETE_CONFIRM: &'static str = "Delete activity";
+const STR_DELETE_CANCEL: &'static str = "Don't delete";
 
 pub struct ModuleDom {}
 
@@ -43,6 +45,8 @@ impl ModuleDom {
                         .property("dangerous", true)
                         .property("title", STR_DELETE_TITLE)
                         .property("content", STR_DELETE_CONTENT)
+                        .property("cancel_text", STR_DELETE_CANCEL)
+                        .property("confirm_text", STR_DELETE_CONFIRM)
                         .event(clone!(state => move |_evt: events::CustomCancel| state.confirm_delete.set_neq(false)))
                         .event(clone!(state => move |_evt: events::CustomConfirm| {
                             state.confirm_delete.set_neq(false);

--- a/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/module/dom.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/module/dom.rs
@@ -12,6 +12,10 @@ use std::rc::Rc;
 use std::str::FromStr;
 use utils::prelude::*;
 use wasm_bindgen::prelude::*;
+
+const STR_DELETE_TITLE: &'static str = "Warning";
+const STR_DELETE_CONTENT: &'static str = "Are you sure you want to delete this activity?";
+
 pub struct ModuleDom {}
 
 impl ModuleDom {
@@ -33,6 +37,22 @@ impl ModuleDom {
 
         html!("empty-fragment", {
             .property("slot", if index == 0 { "cover-module" } else { "modules" })
+            .child_signal(state.confirm_delete.signal().map(clone!(state => move |confirm_delete| {
+                if confirm_delete {
+                    Some(html!("modal-confirm", {
+                        .property("dangerous", true)
+                        .property("title", STR_DELETE_TITLE)
+                        .property("content", STR_DELETE_CONTENT)
+                        .event(clone!(state => move |_evt: events::CustomCancel| state.confirm_delete.set_neq(false)))
+                        .event(clone!(state => move |_evt: events::CustomConfirm| {
+                            state.confirm_delete.set_neq(false);
+                            actions::delete(state.clone());
+                        }))
+                    }))
+                } else {
+                    None
+                }
+            })))
             .child(html!("jig-edit-sidebar-filler", {
                 .style("display", {
                     if is_filler { "block" } else {"none"}

--- a/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/module/state.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/module/state.rs
@@ -18,6 +18,7 @@ pub struct State {
     pub index: usize,
     pub total_len: usize,
     pub elem: RefCell<Option<HtmlElement>>,
+    pub confirm_delete: Mutable<bool>,
 }
 
 impl State {
@@ -35,6 +36,7 @@ impl State {
             tried_module_at_cover: Mutable::new(false),
             drag: Mutable::new(None),
             elem: RefCell::new(None),
+            confirm_delete: Mutable::new(false),
         }
     }
 

--- a/frontend/apps/crates/entry/jig/edit/src/gallery/dom.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/gallery/dom.rs
@@ -20,6 +20,8 @@ const STR_SHOW_JIG_DRAFT: &'static str = "Show drafts";
 
 const STR_DELETE_TITLE: &'static str = "Warning";
 const STR_DELETE_CONTENT: &'static str = "Are you sure you want to delete this JIG?";
+const STR_DELETE_CONFIRM: &'static str = "Delete JIG";
+const STR_DELETE_CANCEL: &'static str = "Don't delete";
 
 impl JigGallery {
     fn visible_jigs_option_string(visible_jigs: &VisibleJigs) -> &'static str {
@@ -43,6 +45,8 @@ impl JigGallery {
                         .property("dangerous", true)
                         .property("title", STR_DELETE_TITLE)
                         .property("content", STR_DELETE_CONTENT)
+                        .property("cancel_text", STR_DELETE_CANCEL)
+                        .property("confirm_text", STR_DELETE_CONFIRM)
                         .event(clone!(state => move |_evt: events::CustomCancel| state.confirm_delete.set_neq(None)))
                         .event(clone!(state => move |_evt: events::CustomConfirm| {
                             state.confirm_delete.set_neq(None);

--- a/frontend/apps/crates/entry/jig/edit/src/gallery/dom.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/gallery/dom.rs
@@ -18,6 +18,9 @@ const STR_SHOW_JIG_ALL: &'static str = "Show all my JIGs";
 const STR_SHOW_JIG_PUBLISHED: &'static str = "Show published JIGs";
 const STR_SHOW_JIG_DRAFT: &'static str = "Show drafts";
 
+const STR_DELETE_TITLE: &'static str = "Warning";
+const STR_DELETE_CONTENT: &'static str = "Are you sure you want to delete this JIG?";
+
 impl JigGallery {
     fn visible_jigs_option_string(visible_jigs: &VisibleJigs) -> &'static str {
         match visible_jigs {
@@ -34,6 +37,20 @@ impl JigGallery {
 
         html!("empty-fragment", {
             .child(page_header::dom::render(Rc::new(page_header::state::State::new()), None, Some(PageLinks::Create)))
+            .child_signal(state.confirm_delete.signal().map(clone!(state => move |confirm_delete| {
+                confirm_delete.map(|jig_id| {
+                    html!("modal-confirm", {
+                        .property("dangerous", true)
+                        .property("title", STR_DELETE_TITLE)
+                        .property("content", STR_DELETE_CONTENT)
+                        .event(clone!(state => move |_evt: events::CustomCancel| state.confirm_delete.set_neq(None)))
+                        .event(clone!(state => move |_evt: events::CustomConfirm| {
+                            state.confirm_delete.set_neq(None);
+                            state.delete_jig(jig_id);
+                        }))
+                    })
+                })
+            })))
             .child(
                 html!("jig-gallery", {
                     .property("jigFocus", state.focus.as_str())
@@ -138,7 +155,7 @@ impl JigGallery {
                                     .property("icon", "delete")
                                     .text(STR_DELETE)
                                     .event(clone!(state, jig => move |_: events::Click| {
-                                        state.delete_jig(jig.id);
+                                        state.confirm_delete.set_neq(Some(jig.id));
                                     }))
                                 }),
                             ])

--- a/frontend/apps/crates/entry/jig/edit/src/gallery/state.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/gallery/state.rs
@@ -2,7 +2,7 @@ use std::rc::Rc;
 
 use dominator_helpers::futures::AsyncLoader;
 use futures_signals::{signal::Mutable, signal_vec::MutableVec};
-use shared::domain::{jig::{JigFocus, JigResponse}, meta::AgeRange};
+use shared::domain::{jig::{JigFocus, JigResponse, JigId}, meta::AgeRange};
 use strum_macros::{Display, EnumIter, EnumString};
 
 pub const TEMPLATE_KINDS: &[&str] = &[
@@ -27,6 +27,7 @@ pub struct JigGallery {
     pub jigs: MutableVec<JigResponse>,
     pub visible_jigs: Rc<Mutable<VisibleJigs>>,
     pub age_ranges: Mutable<Vec<AgeRange>>,
+    pub confirm_delete: Mutable<Option<JigId>>,
 }
 
 impl JigGallery {
@@ -37,6 +38,7 @@ impl JigGallery {
             jigs: MutableVec::new(),
             visible_jigs: Rc::new(Mutable::new(VisibleJigs::All)),
             age_ranges: Mutable::new(vec![]),
+            confirm_delete: Mutable::new(None),
         })
     }
 }

--- a/frontend/apps/crates/utils/src/events.rs
+++ b/frontend/apps/crates/utils/src/events.rs
@@ -213,3 +213,23 @@ impl CustomSelectedChange {
         self.data().selected
     }
 }
+
+// Custom Confirm
+#[derive(Deserialize, Debug)]
+pub struct CustomConfirmData;
+
+make_custom_event_serde!(
+    "custom-confirm",
+    CustomConfirm,
+    CustomConfirmData
+);
+
+// Custom Cancel
+#[derive(Deserialize, Debug)]
+pub struct CustomCancelData;
+
+make_custom_event_serde!(
+    "custom-cancel",
+    CustomCancel,
+    CustomCancelData
+);

--- a/frontend/elements/src/_bundles/jig/edit/imports.ts
+++ b/frontend/elements/src/_bundles/jig/edit/imports.ts
@@ -64,3 +64,4 @@ import "@elements/entry/jig/edit/post-publish/post-publish";
 import "@elements/entry/jig/edit/post-publish/post-publish-action";
 import "@elements/module/_groups/design/edit/sidebar/widgets/theme-selector/option";
 import "@elements/_bundles/_sub-bundles/hebrew-buttons";
+import "@elements/core/modals/confirm";

--- a/frontend/elements/src/core/buttons/icon.ts
+++ b/frontend/elements/src/core/buttons/icon.ts
@@ -3,7 +3,7 @@ import { nothing } from "lit-html";
 import { classMap } from "lit-html/directives/class-map";
 import "@elements/core/images/ui";
 
-export type IconSize = "small" | "medium";
+export type IconSize = "x-small" | "small" | "medium";
 
 export type IconKind =
     | "circle-x-blue"
@@ -38,6 +38,10 @@ export class _ extends LitElement {
                     cursor: pointer;
                     width: var(--button-width, 32px);
                     height: var(--button-height, 32px);
+                }
+                :host([size="x-small"]) {
+                    width: 16px;
+                    height: 16px;
                 }
                 :host([size="small"]) {
                     width: 24px;

--- a/frontend/elements/src/core/modals/confirm.ts
+++ b/frontend/elements/src/core/modals/confirm.ts
@@ -1,20 +1,13 @@
 import { LitElement, html, css, customElement, property } from "lit-element";
 import { classMap } from "lit-html/directives/class-map";
-import { nothing } from "lit-html";
 import { BaseButton } from "@elements/_styles/buttons";
 import "@elements/core/buttons/icon";
 import "@elements/core/buttons/rectangle";
 
-export type Mode = "deleteModule" | "deleteImage";
-
+const STR_DEFAULT_CANCEL_TEXT = "Cancel";
+const STR_DEFAULT_CONFIRM_TEXT = "Confirm";
 const STR_TITLE_WARNING = "Warning";
-const STR_BODY_DELETE_MODULE = "Are you sure you want to delete this activity?";
-const STR_CONFIRM_DELETE_MODULE = "Delete activity";
-const STR_CANCEL_DELETE_MODULE = "Don't delete";
 
-const STR_BODY_DELETE_IMAGE = "Are you sure you want to delete this image?";
-const STR_CONFIRM_DELETE_IMAGE = "Delete image";
-const STR_CANCEL_DELETE_IMAGE = "Don't delete";
 @customElement("modal-confirm")
 export class _ extends BaseButton {
     static get styles() {
@@ -29,12 +22,12 @@ export class _ extends BaseButton {
                     align-items: center;
                     width: 100vw;
                     height: 100vh;
-                    opacity: 0.8;
                     background-color: var(--light-blue-3);
+                    z-index: 6;
                 }
                 section {
                     width: 419px;
-                    height: 276px;
+                    min-height: 276px;
                     border-radius: 16px;
                     -webkit-backdrop-filter: blur(30px);
                     backdrop-filter: blur(30px);
@@ -45,15 +38,16 @@ export class _ extends BaseButton {
                     flex-direction: column;
                 }
 
-
                 .close {
                     align-self: flex-end;
+                    margin: .5em .5em 0 0;
                 }
 
                 .contents {
                     display: flex;
                     flex-direction: column;
                     padding: 0 32px; 32px; 32px;
+                    flex: 1;
                 }
                 .warning {
                     color: var(--dark-red-2);
@@ -75,7 +69,7 @@ export class _ extends BaseButton {
                     letter-spacing: -0.32px;
                     text-align: left;
                 }
-                .body {
+                .content {
                   font-size: 16px;
                   font-weight: normal;
                   font-stretch: normal;
@@ -84,23 +78,13 @@ export class _ extends BaseButton {
                   letter-spacing: normal;
                   text-align: left;
                   color: var(--dark-gray-6);
+                  flex: 1;
                 }
                 .options {
-                    margin-top: 40px;
+                    margin: 2em 0 1em 0;
                     display: flex;
                     justify-content: space-between;
                     align-items: center;
-                }
-                .confirm-warning {
-                  font-size: 16px;
-                  font-weight: 500;
-                  font-stretch: normal;
-                  font-style: normal;
-                  line-height: 1.5;
-                  letter-spacing: normal;
-                  text-align: center;
-                  color: var(--dark-red-2);
-                  cursor: pointer;
                 }
                 `,
         ];
@@ -108,6 +92,7 @@ export class _ extends BaseButton {
 
     onAnyClick(evt: MouseEvent) {
         const path = evt.composedPath();
+        // Makes sure that only clicking the overlay will trigger a cancel event.
         if (!path.includes(this.shadowRoot?.getElementById("section") as any)) {
             this.onCancel();
         }
@@ -115,76 +100,116 @@ export class _ extends BaseButton {
 
     onCancel() {
         this.dispatchEvent(
-            new CustomEvent("custom-toggle", {
-                detail: { value: false },
-            })
+            new CustomEvent("custom-cancel", {})
         );
     }
 
     onConfirm() {
         this.dispatchEvent(
-            new CustomEvent("custom-toggle", {
-                detail: { value: true },
-            })
+            new CustomEvent("custom-confirm", {})
         );
     }
 
-    @property()
-    mode: Mode = "deleteModule";
+    @property({ type: String })
+    title!: string;
+
+    @property({ type: String })
+    content!: string;
+
+    @property({ type: String })
+    cancel_text: string = STR_DEFAULT_CANCEL_TEXT;
+
+    @property({ type: String })
+    confirm_text: string = STR_DEFAULT_CONFIRM_TEXT;
 
     @property({ type: Boolean })
-    visible: boolean = false;
+    dangerous: boolean = false;
 
-    render() {
-        const { visible, mode } = this;
+    buttonProps(isPrimary: Boolean) {
+        let color = "blue";
+        let kind = "filled";
 
-        if (!visible) {
-            return nothing;
+        if (!isPrimary && this.dangerous) {
+            color = "red";
+            kind = "text";
+        } else if (!isPrimary && !this.dangerous) {
+            kind = "text";
         }
 
-        const title = STR_TITLE_WARNING;
-        const body =
-            mode === "deleteModule"
-                ? STR_BODY_DELETE_MODULE
-                : STR_BODY_DELETE_IMAGE;
-        const confirm_str =
-            mode === "deleteModule"
-                ? STR_CONFIRM_DELETE_MODULE
-                : STR_CONFIRM_DELETE_IMAGE;
-        const cancel_str =
-            mode === "deleteModule"
-                ? STR_CANCEL_DELETE_MODULE
-                : STR_CANCEL_DELETE_IMAGE;
-        const confirm = html`<div class="confirm-warning">${confirm_str}</div>`;
-        const cancel = html`<button-rect color="blue"
-            >${cancel_str}</button-rect
-        >`;
+        return [color, kind];
+    }
 
+    renderConfirm(isPrimary: Boolean) {
+        const [color, kind] = this.buttonProps(isPrimary);
+
+        return html`
+            <div @click=${this.onConfirm}>
+                <button-rect color=${color} kind=${kind}>${this.confirm_text}</button-rect>
+            </div>
+        `;
+    }
+
+    renderCancel(isPrimary: Boolean) {
+        const [color, kind] = this.buttonProps(isPrimary);
+
+        return html`
+            <div @click=${this.onCancel}>
+                <button-rect color=${color} kind=${kind}>${this.cancel_text}</button-rect>
+            </div>
+        `;
+    }
+
+    renderActions() {
+        if (this.dangerous) {
+            return html`
+                <div class="options">
+                    ${this.renderConfirm(false)}
+                    ${this.renderCancel(true)}
+                </div>
+            `;
+        } else {
+            return html`
+                <div class="options">
+                    ${this.renderCancel(false)}
+                    ${this.renderConfirm(true)}
+                </div>
+            `;
+        }
+    }
+
+    renderTitle() {
         const titleClasses = classMap({
             title: true,
-            warning: mode === "deleteModule" || mode === "deleteImage",
+            warning: this.dangerous,
         });
 
+
+        return html`
+            <div class="${titleClasses}">${this.title}</div>
+        `;
+    }
+
+    renderContent() {
+        return html`
+            <div class="content">${this.content}</div>
+        `;
+    }
+
+    render() {
         return html`
             <article @click=${this.onAnyClick}>
                 <section id="section">
                     <button-icon
+                        size="small"
                         class="close"
                         icon="x"
                         @click=${this.onCancel}
                     ></button-icon>
                     <div class="contents">
-                        <div class="${titleClasses}">${title}</div>
+                        ${this.renderTitle()}
                         <div class="divider"></div>
-                        <div class="body">${body}</div>
-                        <div class="options">
-                            <div @click=${this.onConfirm} class="confirm">
-                                ${confirm}
-                            </div>
-                            <div @click=${this.onCancel} class="cancel">
-                                ${cancel}
-                            </div>
-                        </div>
+                        ${this.renderContent()}
+                        ${this.renderActions()}
                     </div>
                 </section>
             </article>

--- a/frontend/elements/src/core/modals/confirm.ts
+++ b/frontend/elements/src/core/modals/confirm.ts
@@ -13,7 +13,7 @@ export class _ extends BaseButton {
     static get styles() {
         return [
             css`
-                article {
+                .overlay {
                     position: fixed;
                     top: 0;
                     left: 0;
@@ -22,10 +22,22 @@ export class _ extends BaseButton {
                     align-items: center;
                     width: 100vw;
                     height: 100vh;
+                    opacity: 0.8;
                     background-color: var(--light-blue-3);
                     z-index: 6;
                 }
-                section {
+                .container {
+                    position: fixed;
+                    top: 0;
+                    left: 0;
+                    display: flex;
+                    justify-content: center;
+                    align-items: center;
+                    width: 100vw;
+                    height: 100vh;
+                    z-index: 7;
+                }
+                .section {
                     width: 419px;
                     min-height: 276px;
                     border-radius: 16px;
@@ -33,7 +45,7 @@ export class _ extends BaseButton {
                     backdrop-filter: blur(30px);
                     box-shadow: 0 3px 16px 0 rgba(0, 0, 0, 0.16);
                     background-color: var(--white);
-
+                    opacity: 1;
                     display: flex;
                     flex-direction: column;
                 }
@@ -197,8 +209,10 @@ export class _ extends BaseButton {
 
     render() {
         return html`
-            <article @click=${this.onAnyClick}>
-                <section id="section">
+            <div class="overlay">
+            </div>
+            <div class="container" @click=${this.onAnyClick}>
+                <div class="section">
                     <button-icon
                         size="small"
                         class="close"
@@ -211,8 +225,8 @@ export class _ extends BaseButton {
                         ${this.renderContent()}
                         ${this.renderActions()}
                     </div>
-                </section>
-            </article>
+                </div>
+            </div>
         `;
     }
 }

--- a/frontend/elements/src/core/modals/confirm.ts
+++ b/frontend/elements/src/core/modals/confirm.ts
@@ -13,6 +13,10 @@ export class _ extends BaseButton {
     static get styles() {
         return [
             css`
+                :host {
+                    --overlay-z-index: 300;
+                }
+
                 .overlay {
                     position: fixed;
                     top: 0;
@@ -24,20 +28,15 @@ export class _ extends BaseButton {
                     height: 100vh;
                     opacity: 0.8;
                     background-color: var(--light-blue-3);
-                    z-index: 6;
-                }
-                .container {
-                    position: fixed;
-                    top: 0;
-                    left: 0;
-                    display: flex;
-                    justify-content: center;
-                    align-items: center;
-                    width: 100vw;
-                    height: 100vh;
-                    z-index: 7;
+                    z-index: var(--overlay-z-index);
                 }
                 .section {
+                    position: fixed;
+                    top: 50%;
+                    left: 50%;
+                    transform: translate(-50%, -50%);
+                    z-index: var(--overlay-z-index);
+
                     width: 419px;
                     min-height: 276px;
                     border-radius: 16px;
@@ -209,22 +208,19 @@ export class _ extends BaseButton {
 
     render() {
         return html`
-            <div class="overlay">
-            </div>
-            <div class="container" @click=${this.onAnyClick}>
-                <div class="section">
-                    <button-icon
-                        size="small"
-                        class="close"
-                        icon="x"
-                        @click=${this.onCancel}
-                    ></button-icon>
-                    <div class="contents">
-                        ${this.renderTitle()}
-                        <div class="divider"></div>
-                        ${this.renderContent()}
-                        ${this.renderActions()}
-                    </div>
+            <div class="overlay" @click=${this.onAnyClick}></div>
+            <div class="section">
+                <button-icon
+                    size="x-small"
+                    class="close"
+                    icon="x"
+                    @click=${this.onCancel}
+                ></button-icon>
+                <div class="contents">
+                    ${this.renderTitle()}
+                    <div class="divider"></div>
+                    ${this.renderContent()}
+                    ${this.renderActions()}
                 </div>
             </div>
         `;

--- a/frontend/storybook/src/components/core/modals/confirm.ts
+++ b/frontend/storybook/src/components/core/modals/confirm.ts
@@ -1,33 +1,36 @@
 import { argsToAttrs, deleteNone } from "@utils/attributes";
 import "@elements/core/modals/confirm";
-import { ConfirmMode } from "@elements/core/modals/confirm";
 
 export default {
     title: "Core / Modals",
 };
 
-interface Args {
-    mode: ConfirmMode;
-}
-
 const DEFAULT_ARGS: Args = {
-    mode: "deleteModule",
+    title: "Warning",
+    body: "Are you sure you want to delete this thing?",
+    cancel_text: "Cancel",
+    confirm_text: "Confirm",
+    dangerous: true,
 };
 
 export const Confirm = (props?: Partial<Args>) => {
     props = props ? { ...DEFAULT_ARGS, ...props } : DEFAULT_ARGS;
 
-    return `<modal-confirm ${argsToAttrs(props)}></model-confirm>`;
+
+    const cancel = () => {
+        console.log('foo')
+    }
+
+    const confirm = () => {
+        console.log('confirm')
+    }
+
+    return `
+        <div @cancel="${cancel}" @confirm="${confirm}">
+            <modal-confirm ${argsToAttrs(props)}></modal-confirm>
+        </div>
+    `;
 };
 
 //Continuing the previous example
-Confirm.argTypes = {
-    mode: {
-        control: {
-            type: "inline-radio",
-            options: ["deleteModule"],
-        },
-    },
-};
-
 Confirm.args = DEFAULT_ARGS;

--- a/frontend/storybook/src/components/core/modals/confirm.ts
+++ b/frontend/storybook/src/components/core/modals/confirm.ts
@@ -7,7 +7,7 @@ export default {
 
 const DEFAULT_ARGS: Args = {
     title: "Warning",
-    body: "Are you sure you want to delete this thing?",
+    content: "Are you sure you want to delete this thing?",
     cancel_text: "Cancel",
     confirm_text: "Confirm",
     dangerous: true,

--- a/frontend/storybook/src/components/core/modals/confirm.ts
+++ b/frontend/storybook/src/components/core/modals/confirm.ts
@@ -16,19 +16,8 @@ const DEFAULT_ARGS: Args = {
 export const Confirm = (props?: Partial<Args>) => {
     props = props ? { ...DEFAULT_ARGS, ...props } : DEFAULT_ARGS;
 
-
-    const cancel = () => {
-        console.log('foo')
-    }
-
-    const confirm = () => {
-        console.log('confirm')
-    }
-
     return `
-        <div @cancel="${cancel}" @confirm="${confirm}">
-            <modal-confirm ${argsToAttrs(props)}></modal-confirm>
-        </div>
+        <modal-confirm ${argsToAttrs(props)}></modal-confirm>
     `;
 };
 


### PR DESCRIPTION
Closes #1943 

- Adds an `x-small` variant to `button-icon` so that smaller sized buttons can be rendered without extra css outside of the button;
- Refactors the modal-confirm element so that callers can define properties
  - Replaces the `CustomToggle` event with a `CustomCancel` and `CustomConfirm`;
  - Removes the visible property so that callers can either render or not render the modal;
  - Adds a `dangerous` property so that the modal will switch the primary action to be cancel and change the text colors.
- Implements the confirm modal for deleting JIGs and for deleting activities when editing a JIG;
- Updates the usage of modal-confirm for deleting images from the admin section (**untested**).

![image](https://user-images.githubusercontent.com/4161106/147334972-cbcc15e8-aaf7-4e25-85e1-eef39468fcf3.png)

![image](https://user-images.githubusercontent.com/4161106/147334902-970f4908-39b7-4f3c-8104-3a93c5598795.png)


