### PR TITLE
fix(fe/core/input): Fix inputs leaking through higher priority z-indexes

### DIFF
--- a/frontend/elements/src/core/inputs/wrapper.ts
+++ b/frontend/elements/src/core/inputs/wrapper.ts
@@ -22,7 +22,6 @@ export class _ extends LitElement {
                     height: 100%;
                     display: grid;
                     grid-template-rows: auto 1fr auto;
-                    z-index: 1;
                 }
                 ::slotted(hebrew-buttons) {
                     grid-row: 1;


### PR DESCRIPTION
Fixes an issue where inputs would leak through an overlay with a higher z-index priority

### Before

![image](https://user-images.githubusercontent.com/4161106/147334413-74f4e353-d8b5-4196-af9e-682fcaa8c02f.png)

### After

![image](https://user-images.githubusercontent.com/4161106/147334448-fc2944c6-6b6d-44a8-9434-0d14eceea425.png)
