### PR TITLE
fix(fe/jig/edit): Remove double robot feet in sidebaer publish module

### DIFF
--- a/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/module/dom.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/module/dom.rs
@@ -61,7 +61,6 @@ impl ModuleDom {
                         _ => false,
                     }
                 })))
-                .property("lastBottomDecoration", index == total_len-1)
                 // TODO:
                 // .event(|_evt:events::MouseDown| {
                 //     actions::mouse_down(state.clone(), evt.x(), evt.y());

--- a/frontend/apps/crates/entry/jig/play/src/player/sidebar/dom/mod.rs
+++ b/frontend/apps/crates/entry/jig/play/src/player/sidebar/dom/mod.rs
@@ -81,7 +81,7 @@ pub fn render(state: Rc<State>) -> Dom {
                             html!("jig-sidebar-module", {
                                 .property("module", module.kind.as_str())
                                 .property("index", i as u32)
-                                .property("lastBottomDecoration", i == module_count - 1)
+                                .property("isLastModule", i == module_count - 1)
                                 .property("selected", true)
                                 .property_signal("selected", state.player_state.active_module.signal().map(move |active_module_index| {
                                     i == active_module_index

--- a/frontend/elements/src/entry/jig/_common/sidebar-modules/module.ts
+++ b/frontend/elements/src/entry/jig/_common/sidebar-modules/module.ts
@@ -208,7 +208,7 @@ export class _ extends LitElement {
     index: number = 0;
 
     @property({ type: Boolean })
-    lastBottomDecoration: boolean = false;
+    isLastModule: boolean = false;
 
     @property()
     module: ModuleKind | "" = "";
@@ -231,7 +231,7 @@ export class _ extends LitElement {
                 ${getImage("yellow/face.png", "head")}
                 ${getImage("torso-columns.svg", "torso-columns")}
             `;
-        } else if (this.lastBottomDecoration) {
+        } else if (this.isLastModule) {
             return html`
                 ${getImage("feet-spring.svg", "feet-spring")}
                 ${getImage("yellow/feet-rollers.svg", "feet-rollers")}


### PR DESCRIPTION
Resolves #2078 

- Renames `lastBottomDecoration` to `isLastModule`
- Fixes double rendered robot feet for the publish module in the sidebar.