### PR TITLE
fix(fe/admin/categories): Fix context menu alignment; Re-order items

### DIFF
--- a/frontend/apps/crates/entry/admin/src/categories/actions.rs
+++ b/frontend/apps/crates/entry/admin/src/categories/actions.rs
@@ -99,7 +99,8 @@ fn add_category(state: Rc<State>, parent: Option<Rc<Category>>) {
 
         match api_with_auth::<NewCategoryResponse, EmptyError, _>(endpoints::category::Create::PATH, endpoints::category::Create::METHOD, Some(req)).await {
             Ok(resp) => {
-                let cat = Rc::new(Category::new(resp.id, name));
+                // Categories created here should be in the editing state already.
+                let cat = Rc::new(Category::new(resp.id, name, true));
 
                 match parent {
                     Some(parent) => {

--- a/frontend/apps/crates/entry/admin/src/categories/dom.rs
+++ b/frontend/apps/crates/entry/admin/src/categories/dom.rs
@@ -110,12 +110,10 @@ impl ContentLineDom {
     pub fn render(content_state: Rc<ContentState>) -> Vec<Dom> {
         let mut children: Vec<Dom> = vec![html!("input-text-content", {
             .property("slot", "content")
+            .property_signal("editing", content_state.cat.editing.signal_cloned())
             .property_signal("value", content_state.cat.name.signal_cloned())
             .event(clone!(content_state => move |evt:events::CustomChange| {
                 actions::rename_category(&content_state.cat, content_state.state.clone(), evt.value());
-            }))
-            .after_inserted(clone!(content_state => move |elem| {
-                *content_state.input_ref.borrow_mut() = Some(elem);
             }))
         })];
 
@@ -144,7 +142,7 @@ impl MenuDom {
                     .property("kind", "text")
                     .property("color", "darkGray")
                     .property("hoverColor", "blue")
-                    .text("add")
+                    .text("Add")
                     .event(clone!(content_state => move |_evt:events::Click| {
                         actions::add_category_child(content_state.clone());
                     }))
@@ -153,16 +151,7 @@ impl MenuDom {
                     .property("kind", "text")
                     .property("color", "darkGray")
                     .property("hoverColor", "blue")
-                    .text("delete")
-                    .event(clone!(content_state => move |_evt:events::Click| {
-                        actions::delete_category(content_state.clone());
-                    }))
-                }),
-                html!("button-rect", {
-                    .property("kind", "text")
-                    .property("color", "darkGray")
-                    .property("hoverColor", "blue")
-                    .text("move up")
+                    .text("Move up")
                     .event(clone!(content_state => move |_evt:events::Click| {
                         actions::move_category(content_state.clone(), actions::Direction::Up);
                     }))
@@ -171,7 +160,7 @@ impl MenuDom {
                     .property("kind", "text")
                     .property("color", "darkGray")
                     .property("hoverColor", "blue")
-                    .text("move down")
+                    .text("Move down")
                     .event(clone!(content_state => move |_evt:events::Click| {
                         actions::move_category(content_state.clone(), actions::Direction::Down);
                     }))
@@ -180,19 +169,20 @@ impl MenuDom {
                     .property("kind", "text")
                     .property("color", "darkGray")
                     .property("hoverColor", "blue")
-                    .text("rename")
+                    .text("Rename")
                     .event(clone!(content_state => move |_evt:events::Click| {
-                        //These are only DOM changes
-                        if let Some(input_ref) = content_state.input_ref.borrow().as_ref() {
-                            let _= js_sys::Reflect::set(
-                                input_ref,
-                                &JsValue::from_str("editing"),
-                                &JsValue::from_bool(true)
-                            );
-                        }
-
+                        content_state.cat.editing.set(true);
                         content_state.close_menu();
 
+                    }))
+                }),
+                html!("button-rect", {
+                    .property("kind", "text")
+                    .property("color", "red")
+                    .property("hoverColor", "red")
+                    .text("Delete")
+                    .event(clone!(content_state => move |_evt:events::Click| {
+                        actions::delete_category(content_state.clone());
                     }))
                 }),
             ])

--- a/frontend/apps/crates/entry/admin/src/categories/state.rs
+++ b/frontend/apps/crates/entry/admin/src/categories/state.rs
@@ -27,6 +27,7 @@ pub struct Category {
     pub name: Mutable<String>,
     pub children: MutableVec<Rc<Category>>,
     pub expanded: Mutable<bool>,
+    pub editing: Mutable<bool>,
 }
 
 impl Category {
@@ -34,14 +35,19 @@ impl Category {
         self.children.signal_vec_cloned().len().map(|len| len > 0)
     }
 
-    pub fn new(id: CategoryId, name: String) -> Self {
-        Self::_new(id, name, None)
+    pub fn new(id: CategoryId, name: String, editing: bool) -> Self {
+        Self::new_internal(id, name, None, editing)
     }
     pub fn new_with_children(id: CategoryId, name: String, children: Vec<Rc<Self>>) -> Self {
-        Self::_new(id, name, Some(children))
+        Self::new_internal(id, name, Some(children), false)
     }
 
-    fn _new(id: CategoryId, name: String, children: Option<Vec<Rc<Self>>>) -> Self {
+    fn new_internal(
+        id: CategoryId,
+        name: String,
+        children: Option<Vec<Rc<Self>>>,
+        editing: bool
+    ) -> Self {
         Self {
             id,
             name: Mutable::new(name),
@@ -50,6 +56,7 @@ impl Category {
                 None => MutableVec::new(),
             },
             expanded: Mutable::new(debug::INIT_EXPANDED),
+            editing: Mutable::new(editing),
         }
     }
 }
@@ -71,8 +78,7 @@ pub struct ContentState {
     pub parent: Option<Rc<Category>>,
     pub cat: Rc<Category>,
     pub state: Rc<State>,
-    //These are only needed for imperatively toggling via menu
-    pub input_ref: RefCell<Option<HtmlElement>>,
+    //This is only needed for imperatively toggling via menu
     pub menu_ref: RefCell<Option<HtmlElement>>,
 }
 impl ContentState {
@@ -81,7 +87,6 @@ impl ContentState {
             parent,
             cat,
             state,
-            input_ref: RefCell::new(None),
             menu_ref: RefCell::new(None),
         }
     }

--- a/frontend/elements/src/core/inputs/primitives/text-content.ts
+++ b/frontend/elements/src/core/inputs/primitives/text-content.ts
@@ -112,22 +112,27 @@ export class _ extends LitElement {
 
     firstUpdated(_changed: any) {
         this.resizeInput();
+        this.handleEditing();
     }
     updated(changed: any) {
         if (typeof changed.get("editing") === "boolean") {
-            const { editing } = this;
-            this.removeGlobalListener();
-            if (editing) {
-                window.addEventListener("mousedown", this.onGlobalMouseDown);
-                const input = this.shadowRoot?.getElementById(
-                    "input"
-                ) as HTMLInputElement;
-                if (input) {
-                    input.focus();
-                    input.value = this.value;
-                    input.setSelectionRange(-1, -1);
-                    this.resizeInput();
-                }
+            this.handleEditing();
+        }
+    }
+
+    handleEditing() {
+        const { editing } = this;
+        this.removeGlobalListener();
+        if (editing) {
+            window.addEventListener("mousedown", this.onGlobalMouseDown);
+            const input = this.shadowRoot?.getElementById(
+                "input"
+            ) as HTMLInputElement;
+            if (input) {
+                input.focus();
+                input.value = this.value;
+                input.setSelectionRange(0, -1);
+                this.resizeInput();
             }
         }
     }

--- a/frontend/elements/src/core/menu/ellipses.ts
+++ b/frontend/elements/src/core/menu/ellipses.ts
@@ -43,6 +43,12 @@ export class _ extends LitElement {
                     box-shadow: 0 3px 16px 0 rgba(0, 0, 0, 0.25);
                     background-color: #ffffff;
                 }
+                ::slotted([slot="menu-content"]) {
+                    display: flex;
+                    flex-direction: column;
+                    align-items: flex-start;
+                }
+
             `,
         ];
     }


### PR DESCRIPTION
Part of #2099

@corinnewo this PR 

- Reorders category context menu - delete last;
- Delete item is red;
- Enables editing of any new category - previously you would need to have added a category and then renamed it;
- When renaming a category, the original text is selected so that it is easier to overwrite it

![image](https://user-images.githubusercontent.com/4161106/147573198-2c3a4df3-7771-4994-963d-39228a1fb64c.png)

![image](https://user-images.githubusercontent.com/4161106/147573401-229d26c4-6ae2-42f8-9e35-6cdb74c41cad.png)
