### PR TITLE
fix(fe/module/edit): Don't render tooltips with empty content

### DIFF
--- a/frontend/apps/crates/components/src/module/_common/edit/entry/base/dom/regular.rs
+++ b/frontend/apps/crates/components/src/module/_common/edit/entry/base/dom/regular.rs
@@ -101,7 +101,7 @@ where
     struct HeaderConfigStep {
         tabs: Vec<HeaderConfigTab>,
     }
-    #[derive(Deserialize, Default, Clone)]
+    #[derive(Debug, Deserialize, Default, Clone)]
     struct HeaderConfigTab {
         title: String,
         body: String,
@@ -154,14 +154,20 @@ where
             })
         })
         .child_signal(tab_config_sig().map(|tab| {
-            Some(
-                JigziHelp::new(
-                    tab.title,
-                    tab.body,
-                    "module-header"
+            let HeaderConfigTab {title, body} = tab;
+
+            if !title.is_empty() && !body.is_empty() {
+                Some(
+                    JigziHelp::new(
+                        title,
+                        body,
+                        "module-header"
+                    )
+                    .render(Some("help"))
                 )
-                .render(Some("help"))
-            )
+            } else {
+                None
+            }
         }))
         .child(ControllerDom::render(
             state.history.clone(),


### PR DESCRIPTION
Part of #2110

- Doesn't render a tooltip when the tooltip content is empty - Resolves the empty tooltip issue in Preview Mode.

@MendyBerger I'm not merging this yet because I think you were working with the tooltips recently.
