### PR TITLE
feat: add icon to empty collapsed module in jig/edit sidebar

### DIFF
--- a/frontend/elements/src/entry/jig/_common/sidebar-modules/module.ts
+++ b/frontend/elements/src/entry/jig/_common/sidebar-modules/module.ts
@@ -251,19 +251,14 @@ export class _ extends LitElement {
     }
 
     renderModuleImg() {
-        const { module } = this;
+        const { collapsed, module } = this;
+        
+        if (!collapsed && module === "") return nothing;
 
-        const getIconPath = (module: string) => `entry/jig/modules/small/${
-            module === "" ? "poster" : module
-        }.svg`;
-
-        if (!this.collapsed && module === "") {
-            return nothing;
-        }
-
+        const iconPath = `entry/jig/modules/small/${module || "poster"}.svg`;
         return html`
             <div class="icon">
-                ${html`<img-ui path="${getIconPath(module)}"></img-ui>`}
+                ${html`<img-ui path="${iconPath}"></img-ui>`}
             </div>
         `;
     }

--- a/frontend/elements/src/entry/jig/_common/sidebar-modules/module.ts
+++ b/frontend/elements/src/entry/jig/_common/sidebar-modules/module.ts
@@ -263,8 +263,8 @@ export class _ extends LitElement {
 
         const subtitle = module === "" ? "" : STR_MODULE_DISPLAY_NAME[module];
 
-        const iconPath =
-            module === "" ? "" : `entry/jig/modules/small/${module}.svg`;
+        const iconPath = `entry/jig/modules/small/${module}.svg`;
+        const plusModuleIconPath = `entry/jig/modules/small/${"poster"}.svg`;
 
         return html`
             <section class="${sectionClasses}">
@@ -275,8 +275,8 @@ export class _ extends LitElement {
                             ? nothing
                             : html`<div class="subtitle">${subtitle}</div>`}
                         <div class="icon">
-                            ${iconPath === ""
-                                ? nothing
+                            ${module === ""
+                                ? html`<img-ui path="${plusModuleIconPath}"></img-ui>`
                                 : html`<img-ui path="${iconPath}"></img-ui>`}
                         </div>
                     </div>

--- a/frontend/elements/src/entry/jig/_common/sidebar-modules/module.ts
+++ b/frontend/elements/src/entry/jig/_common/sidebar-modules/module.ts
@@ -251,27 +251,21 @@ export class _ extends LitElement {
     }
 
     renderModuleImg() {
-        const {module} = this;
-        
-        const iconPath = `entry/jig/modules/small/${module}.svg`;
-        const plusModuleIconPath = `entry/jig/modules/small/${"poster"}.svg`;
-        
-        if (this.collapsed) {
-            return html`
-                <div class="icon">
-                    ${ module === ""
-                        ? html`<img-ui path="${plusModuleIconPath}"></img-ui>`
-                        : html`<img-ui path="${iconPath}"></img-ui>`}
-                </div>
-            `;
+        const { module } = this;
+
+        const getIconPath = (module: string) => `entry/jig/modules/small/${
+            module === "" ? "poster" : module
+        }.svg`;
+
+        if (!this.collapsed && module === "") {
+            return nothing;
         }
+
         return html`
             <div class="icon">
-                ${ module === ""
-                    ? nothing
-                    : html`<img-ui path="${iconPath}"></img-ui>`}
+                ${html`<img-ui path="${getIconPath(module)}"></img-ui>`}
             </div>
-        `
+        `;
     }
     
     render() {

--- a/frontend/elements/src/entry/jig/_common/sidebar-modules/module.ts
+++ b/frontend/elements/src/entry/jig/_common/sidebar-modules/module.ts
@@ -250,6 +250,30 @@ export class _ extends LitElement {
         }
     }
 
+    renderModuleImg() {
+        const {module} = this;
+        
+        const iconPath = `entry/jig/modules/small/${module}.svg`;
+        const plusModuleIconPath = `entry/jig/modules/small/${"poster"}.svg`;
+        
+        if (!this.collapsed) {
+            return html`
+                <div class="icon">
+                    ${ module === ""
+                        ? html`<img-ui path="${plusModuleIconPath}"></img-ui>`
+                        : html`<img-ui path="${iconPath}"></img-ui>`}
+                </div>
+            `;
+        }
+        return html`
+            <div class="icon">
+                ${ module === ""
+                    ? nothing
+                    : html`<img-ui path="${iconPath}"></img-ui>`}
+            </div>
+        `
+    }
+    
     render() {
         const { selected, index, dragging, module } = this;
 
@@ -263,9 +287,6 @@ export class _ extends LitElement {
 
         const subtitle = module === "" ? "" : STR_MODULE_DISPLAY_NAME[module];
 
-        const iconPath = `entry/jig/modules/small/${module}.svg`;
-        const plusModuleIconPath = `entry/jig/modules/small/${"poster"}.svg`;
-
         return html`
             <section class="${sectionClasses}">
                 <div class="grid-container">
@@ -274,11 +295,7 @@ export class _ extends LitElement {
                         ${subtitle === ""
                             ? nothing
                             : html`<div class="subtitle">${subtitle}</div>`}
-                        <div class="icon">
-                            ${module === ""
-                                ? html`<img-ui path="${plusModuleIconPath}"></img-ui>`
-                                : html`<img-ui path="${iconPath}"></img-ui>`}
-                        </div>
+                        ${this.renderModuleImg()}
                     </div>
                     <div class="middle open-only">
                         <div class="decorations">

--- a/frontend/elements/src/entry/jig/_common/sidebar-modules/module.ts
+++ b/frontend/elements/src/entry/jig/_common/sidebar-modules/module.ts
@@ -256,7 +256,7 @@ export class _ extends LitElement {
         const iconPath = `entry/jig/modules/small/${module}.svg`;
         const plusModuleIconPath = `entry/jig/modules/small/${"poster"}.svg`;
         
-        if (!this.collapsed) {
+        if (this.collapsed) {
             return html`
                 <div class="icon">
                     ${ module === ""


### PR DESCRIPTION
This PR currently uses the wrong image resource.

@MendyBerger, how can I view the images/media available in the media cloud, `https://media.jicloud.org/`?

As of now though, the logic is in place for expanded and collapsed module image rendering, displaying no image for an expanded sidebar, and showing the image for the module when the sidebar is collapsed only.

Once I know the name of the correct resource in our media cloud, I'll replace it with the correct path and this should be good to go!

Collapsed:
![image](https://user-images.githubusercontent.com/13839150/147717410-a4504e01-330e-40ad-be67-72369016c4d8.png)

Expanded:
![image](https://user-images.githubusercontent.com/13839150/147717393-d6370301-bd8d-4f9d-84c2-f6a08dc2048a.png)

