### PR TITLE
feat(home/search): Add back search help element

### DIFF
--- a/frontend/elements/src/entry/home/home/search-section/search-section-help.ts
+++ b/frontend/elements/src/entry/home/home/search-section/search-section-help.ts
@@ -19,6 +19,7 @@ export class _ extends LitElement {
                     display: inline-grid;
                     grid-template-columns: auto auto;
                     align-items: flex-start;
+                    cursor: pointer;
                 }
                 .tooltip {
                     background-color: var(--orange-1);

--- a/frontend/elements/src/entry/home/home/search-section/search-section.ts
+++ b/frontend/elements/src/entry/home/home/search-section/search-section.ts
@@ -33,8 +33,8 @@ export class _ extends LitElement {
                     pointer-events: none;
                 }
                 .width-holder {
-                    display: flex;
-                    flex-direction: row;
+                    display: grid;
+                    grid-template-columns: auto;
                     justify-content: center;
                     align-items: center;
                 }

--- a/frontend/elements/src/entry/home/home/search-section/search-section.ts
+++ b/frontend/elements/src/entry/home/home/search-section/search-section.ts
@@ -18,9 +18,14 @@ export class _ extends LitElement {
             homeStyles,
             css`
                 :host {
+                    --padding: 88px;
+
                     display: block;
                     background-color: var(--light-blue-6);
-                    padding: 88px 0;
+                    padding: var(--padding) 0;
+                }
+                :host([mode="results"]) {
+                    padding: calc(var(--padding) / 2) 0;
                 }
                 :host([mode="results"]) .home-only,
                 :host([mode="home"]) .results-only {
@@ -28,10 +33,13 @@ export class _ extends LitElement {
                     pointer-events: none;
                 }
                 .width-holder {
-                    display: grid;
-                    grid-template-columns: 1fr auto;
-                    justify-content: space-between;
+                    display: flex;
+                    flex-direction: row;
+                    justify-content: center;
                     align-items: center;
+                }
+                :host([mode="results"]) .width-holder {
+                    justify-content: space-between;
                 }
                 .center-1 {
                     grid-column: 1 / -1;
@@ -130,11 +138,9 @@ export class _ extends LitElement {
 
         // TODO: Enable once ready
         return html`
-            <!--
             <div class="help results-only">
                 <slot name="help"></slot>
             </div>
-            -->
         `;
     }
 


### PR DESCRIPTION
Related to #1372

- Makes the previously hidden search help element visible;
  - **Note** that the help element has no functionality tied to it yet.

![image](https://user-images.githubusercontent.com/4161106/147732085-3fe56ca2-84ea-4edc-af68-e129c6e74aa9.png)
