### PR TITLE
fix(fe/elements): Render popup-player fullscreen on Firefox

### DIFF
--- a/frontend/elements/src/core/player-popup/player-popup.ts
+++ b/frontend/elements/src/core/player-popup/player-popup.ts
@@ -25,6 +25,8 @@ export class _ extends LitElement {
                     left: 0;
                     z-index: 9999;
                     display: grid;
+                    grid-template-columns: 100%;
+                    grid-template-rows: 100%;
                     place-content: center;
                     height: 100vh;
                     width: 100vw;


### PR DESCRIPTION
- Resolves sizing issue with the popup player with Firefox (Ubuntu 21.04)

### Before

![image](https://user-images.githubusercontent.com/4161106/147736526-5a415b7c-32e6-470d-8a4d-f0d69a3e5ccd.png)

### After

![image](https://user-images.githubusercontent.com/4161106/147736604-05d43717-1088-488d-94fc-302fec2291a5.png)
