### PR TITLE
feat(fe/components/cards): Implement flip sound effects

### DIFF
--- a/frontend/apps/crates/components/src/module/_groups/cards/play/card/dom/plain.rs
+++ b/frontend/apps/crates/components/src/module/_groups/cards/play/card/dom/plain.rs
@@ -1,10 +1,13 @@
-use crate::module::_groups::cards::lookup::Side;
+use std::cell::RefCell;
+
+use crate::{module::_groups::cards::lookup::Side, audio::mixer::{AUDIO_MIXER, AudioPath}};
+use awsm_web::audio::AudioHandle;
 use dominator::{html, Dom, DomBuilder};
 use shared::domain::jig::module::body::{
     ModeExt,
     _groups::cards::{Card, Mode},
 };
-use utils::prelude::*;
+use utils::{events, prelude::*};
 use web_sys::HtmlElement;
 
 use super::common::*;
@@ -25,6 +28,7 @@ pub struct CardOptions<'a> {
     //use the opposite
     pub side: Side,
     pub slot: Option<&'a str>,
+    pub audio: RefCell<Option<AudioHandle>>,
 }
 
 /*
@@ -50,6 +54,7 @@ impl<'a> CardOptions<'a> {
             simple_transform: None,
             slot: None,
             style_kind: StyleKind::Theme,
+            audio: RefCell::new(None),
         }
     }
 }
@@ -86,6 +91,7 @@ where
         side,
         slot,
         style_kind,
+        audio,
     } = options;
 
     html!("play-card", {
@@ -132,6 +138,11 @@ where
         })
         .apply_if(mixin.is_some(), |dom| {
             (mixin.unwrap_ji()) (dom)
+        })
+        .event(move |_evt: events::CustomCardFlipped| {
+            *audio.borrow_mut() = Some(AUDIO_MIXER.with(|mixer| {
+                mixer.play(AudioPath::new_cdn("module/cards/flip_card_3.mp3".to_string()), false)
+            }));
         })
     })
 }

--- a/frontend/apps/crates/entry/module/card-quiz/play/src/base/game/dom.rs
+++ b/frontend/apps/crates/entry/module/card-quiz/play/src/base/game/dom.rs
@@ -43,6 +43,13 @@ impl Game {
                                 children.push(render_card_mixin(options, |dom| {
                                     dom
                                         //should be some animation
+                                        .property_signal("eventOnFlipped", phase.signal().map(clone!(state => move |_| {
+                                            state.current.lock_ref().as_ref().unwrap().incorrect_choices
+                                                .borrow()
+                                                .iter()
+                                                .find(|id| *id == &pair_id)
+                                                .is_some()
+                                        })))
                                         .property_signal("flipped", phase.signal().map(clone!(state, pair_id => move |phase| {
                                             let is_incorrect_choice = state.current.lock_ref().as_ref().unwrap().incorrect_choices
                                                 .borrow()

--- a/frontend/apps/crates/utils/src/events.rs
+++ b/frontend/apps/crates/utils/src/events.rs
@@ -233,3 +233,13 @@ make_custom_event_serde!(
     CustomCancel,
     CustomCancelData
 );
+
+// Custom Card Flipped
+#[derive(Deserialize, Debug)]
+pub struct CustomCardFlippedData;
+
+make_custom_event_serde!(
+    "custom-card-flipped",
+    CustomCardFlipped,
+    CustomCardFlippedData
+);

--- a/frontend/elements/src/module/_groups/cards/play/card/card.ts
+++ b/frontend/elements/src/module/_groups/cards/play/card/card.ts
@@ -95,7 +95,11 @@ export class _ extends LitElement {
     @property({ type: Boolean, reflect: true })
     flipped: boolean = false;
 
-    // whether or not showing front vs. back
+    // whether to dispatch an event when a card is flipped
+    // Note: This is an interim **workaround**. The code that interfaces with this
+    // element uses references with non-static lifetimes which makes it tricky to
+    // run logic inside card-flipped event handler because of the 'static
+    // requirement.
     @property({ type: Boolean })
     eventOnFlipped: boolean = false;
 

--- a/frontend/elements/src/module/_groups/cards/play/card/card.ts
+++ b/frontend/elements/src/module/_groups/cards/play/card/card.ts
@@ -95,6 +95,10 @@ export class _ extends LitElement {
     @property({ type: Boolean, reflect: true })
     flipped: boolean = false;
 
+    // whether or not showing front vs. back
+    @property({ type: Boolean })
+    eventOnFlipped: boolean = false;
+
     // required for styling
     @property()
     theme: ThemeId = "blank";
@@ -126,6 +130,14 @@ export class _ extends LitElement {
     // style mode - see helpers definition
     @property()
     styleKind: StyleKind = "theme";
+
+    updated(changedProperties: Map<string, unknown>) {
+        if (changedProperties.get('flipped') && this.eventOnFlipped) {
+            this.dispatchEvent(
+                new CustomEvent("custom-card-flipped", {})
+            );
+        }
+    }
 
     connectedCallback() {
         super.connectedCallback();


### PR DESCRIPTION
Part of #2060

- Add a new properties to the play-card element: `eventOnFlipped`;
- Adds an event to the element which dispatches a new `CustomCardFlipped` event if `eventOnFlipped` is true;
- For the card-quiz game, only plays the flipped sound effect if the player makes an incorrect choice
  - Changes in another PR will include a sound effect for making the correct choice.

**Note** doesn't implement flip sound effects for other card games yet.