### PR TITLE
feat(fe/module/card-quiz): Play positive audio effect for the correct choice

### DIFF
--- a/frontend/apps/crates/entry/module/card-quiz/play/src/base/game/actions.rs
+++ b/frontend/apps/crates/entry/module/card-quiz/play/src/base/game/actions.rs
@@ -83,7 +83,6 @@ impl Game {
                     phase.set(CurrentPhase::Correct(pair_id));
 
                     *state.audio.borrow_mut() = Some(AUDIO_MIXER.with(|mixer| {
-                        mixer.set_from_jig(&state.base.jig);
                         let path: AudioPath<'_> = mixer.get_random_positive().into();
                         mixer.play(path, false)
                     }));

--- a/frontend/apps/crates/entry/module/card-quiz/play/src/base/game/actions.rs
+++ b/frontend/apps/crates/entry/module/card-quiz/play/src/base/game/actions.rs
@@ -2,7 +2,7 @@ use super::state::*;
 
 use std::sync::atomic::Ordering;
 
-use components::module::_common::play::prelude::*;
+use components::{module::_common::play::prelude::*, audio::mixer::{AUDIO_MIXER, AudioPath}};
 
 use crate::base::state::Phase;
 use dominator::clone;
@@ -81,6 +81,12 @@ impl Game {
             spawn_local(clone!(state, pair_id, phase => async move {
                 if pair_id == state.current.lock_ref().as_ref().unwrap_ji().target.pair_id {
                     phase.set(CurrentPhase::Correct(pair_id));
+
+                    *state.audio.borrow_mut() = Some(AUDIO_MIXER.with(|mixer| {
+                        mixer.set_from_jig(&state.base.jig);
+                        let path: AudioPath<'_> = mixer.get_random_positive().into();
+                        mixer.play(path, false)
+                    }));
                     TimeoutFuture::new(crate::config::SUCCESS_TIME).await;
                     Self::next(state);
                 } else {

--- a/frontend/apps/crates/entry/module/card-quiz/play/src/base/game/dom.rs
+++ b/frontend/apps/crates/entry/module/card-quiz/play/src/base/game/dom.rs
@@ -43,21 +43,12 @@ impl Game {
                                 children.push(render_card_mixin(options, |dom| {
                                     dom
                                         //should be some animation
-                                        .property_signal("eventOnFlipped", phase.signal().map(clone!(state => move |_| {
-                                            state.current.lock_ref().as_ref().unwrap().incorrect_choices
-                                                .borrow()
-                                                .iter()
-                                                .find(|id| *id == &pair_id)
-                                                .is_some()
-                                        })))
+                                        .property_signal(
+                                            "eventOnFlipped",
+                                            phase.signal().map(clone!(state => move |_| is_incorrect_choice(&state, &pair_id)))
+                                        )
                                         .property_signal("flipped", phase.signal().map(clone!(state, pair_id => move |phase| {
-                                            let is_incorrect_choice = state.current.lock_ref().as_ref().unwrap().incorrect_choices
-                                                .borrow()
-                                                .iter()
-                                                .find(|id| *id == &pair_id)
-                                                .is_some();
-
-                                            if is_incorrect_choice {
+                                            if is_incorrect_choice(&state, &pair_id) {
                                                 false
                                             } else {
                                                 match phase {
@@ -80,4 +71,12 @@ impl Game {
             )
         })
     }
+}
+
+fn is_incorrect_choice(state: &Rc<Game>, pair_id: &usize) -> bool {
+    state.current.lock_ref().as_ref().unwrap().incorrect_choices
+        .borrow()
+        .iter()
+        .find(|id| *id == pair_id)
+        .is_some()
 }

--- a/frontend/apps/crates/entry/module/card-quiz/play/src/base/game/state.rs
+++ b/frontend/apps/crates/entry/module/card-quiz/play/src/base/game/state.rs
@@ -1,4 +1,5 @@
 use crate::base::state::Base;
+use awsm_web::audio::AudioHandle;
 use components::module::_groups::cards::lookup::Side;
 use futures_signals::signal::Mutable;
 use rand::prelude::*;
@@ -16,6 +17,7 @@ pub struct Game {
     pub used: RefCell<Vec<CardPairId>>,
     pub current: Mutable<Option<Rc<Current>>>,
     pub rounds_played: AtomicUsize,
+    pub audio: RefCell<Option<AudioHandle>>,
 }
 
 #[derive(Clone, Debug)]
@@ -50,6 +52,7 @@ impl Game {
             rng: RefCell::new(thread_rng()),
             current: Mutable::new(None),
             rounds_played: AtomicUsize::new(0),
+            audio: RefCell::new(None),
         });
 
         Self::reset_deck(_self.clone());

--- a/frontend/apps/crates/entry/module/card-quiz/play/src/base/state.rs
+++ b/frontend/apps/crates/entry/module/card-quiz/play/src/base/state.rs
@@ -7,7 +7,7 @@ use shared::domain::jig::{
         },
         ModuleId,
     },
-    JigId, JigData,
+    JigId,
 };
 
 use futures_signals::signal::Mutable;
@@ -20,7 +20,6 @@ use super::game::state::Game;
 
 pub struct Base {
     pub jig_id: JigId,
-    pub jig: JigData,
     pub module_id: ModuleId,
     pub mode: Mode,
     pub theme_id: ThemeId,
@@ -43,7 +42,6 @@ impl Base {
     pub async fn new(init_args: InitFromRawArgs<RawData, Mode, Step>) -> Rc<Self> {
         let InitFromRawArgs {
             jig_id,
-            jig,
             module_id,
             raw,
             theme_id,
@@ -54,7 +52,6 @@ impl Base {
 
         let _self = Rc::new(Self {
             jig_id,
-            jig,
             module_id,
             mode: content.base.mode,
             theme_id,

--- a/frontend/apps/crates/entry/module/card-quiz/play/src/base/state.rs
+++ b/frontend/apps/crates/entry/module/card-quiz/play/src/base/state.rs
@@ -7,7 +7,7 @@ use shared::domain::jig::{
         },
         ModuleId,
     },
-    JigId,
+    JigId, JigData,
 };
 
 use futures_signals::signal::Mutable;
@@ -20,6 +20,7 @@ use super::game::state::Game;
 
 pub struct Base {
     pub jig_id: JigId,
+    pub jig: JigData,
     pub module_id: ModuleId,
     pub mode: Mode,
     pub theme_id: ThemeId,
@@ -42,6 +43,7 @@ impl Base {
     pub async fn new(init_args: InitFromRawArgs<RawData, Mode, Step>) -> Rc<Self> {
         let InitFromRawArgs {
             jig_id,
+            jig,
             module_id,
             raw,
             theme_id,
@@ -52,6 +54,7 @@ impl Base {
 
         let _self = Rc::new(Self {
             jig_id,
+            jig,
             module_id,
             mode: content.base.mode,
             theme_id,


### PR DESCRIPTION
Part of #2060 

- Implements `reset_from_jig` and `set_from_jig` for the `AudioMixer` so that there will always be positive and negative clips available;
- Plays a random success effect for the correct choice - Either from the list of configured effects, or from the complete list of available effects if none are configured for the JIG