### PR TITLE
feat(fe/module/flashcards): Implement flip sound effect for flashcards

### DIFF
--- a/frontend/apps/crates/entry/module/flashcards/play/src/base/game/dom.rs
+++ b/frontend/apps/crates/entry/module/flashcards/play/src/base/game/dom.rs
@@ -31,7 +31,6 @@ pub fn render(state: Rc<Game>) -> Dom {
                         let mut options = CardOptions::new(&card, theme_id, mode, side, Size::Flashcards);
                         options.back_card = Some(&other);
 
-
                         children.push(render_card_mixin(options, flip_controller(state.clone(), true)));
 
                     } else {
@@ -64,18 +63,19 @@ fn flip_controller(
     initial: bool,
 ) -> impl FnOnce(DomBuilder<HtmlElement>) -> DomBuilder<HtmlElement> {
     move |dom| {
-        dom.property_signal(
-            "flipped",
-            state.gate.signal().map(move |gate| {
-                if gate == Gate::Waiting || gate == Gate::FinishingFlip {
-                    initial
-                } else {
-                    !initial
-                }
-            }),
-        )
-        .event(clone!(state => move |_evt:events::Click| {
-            Game::flip(state.clone());
-        }))
+        let is_initial = move |gate| {
+            if gate == Gate::Waiting || gate == Gate::FinishingFlip {
+                initial
+            } else {
+                !initial
+            }
+        };
+
+        dom
+            .property_signal("eventOnFlipped", state.gate.signal().map(is_initial))
+            .property_signal("flipped", state.gate.signal().map(is_initial))
+            .event(clone!(state => move |_evt:events::Click| {
+                Game::flip(state.clone());
+            }))
     }
 }

--- a/frontend/apps/crates/entry/module/matching/play/src/base/game/card/actions.rs
+++ b/frontend/apps/crates/entry/module/matching/play/src/base/game/card/actions.rs
@@ -17,7 +17,10 @@ impl CardDrag {
                     found_match = true;
                     choice.phase.set(TopPhase::Landed);
                 } else {
-                    //specific wrong answer
+                    // Only play the negative effect if they've dropped the card over a target. If
+                    // they drop the card over nothing, it could be for something like releasing
+                    // the card to select a new card.
+                    play_random_negative();
                 }
             } else {
                 //empty area
@@ -29,10 +32,6 @@ impl CardDrag {
                     .iter()
                     .find(|choice| choice.pair_id == self.pair_id)
                 {
-                    // Only play the negative effect if they've dropped the card over a target. If
-                    // they drop the card over nothing, it could be for something like releasing
-                    // the card to select a new card.
-                    play_random_negative();
                     target.phase.set(BottomPhase::Show);
                 }
             } else if current.top.iter().all(|choice| choice.is_landed()) {


### PR DESCRIPTION
Part of #2060 

- Implements sound effect when player flips a card, but not when the card reverts back to it's state;
- Fixes effect playing for matching game where the player drops a card over empty space (it shouldn't play an effect)