### PR TITLE
fix(fe/elements): Set correct dimensions for img-ji element

### DIFF
--- a/frontend/elements/src/module/_common/edit/widgets/image-search/image-select.ts
+++ b/frontend/elements/src/module/_common/edit/widgets/image-search/image-select.ts
@@ -175,7 +175,7 @@ export class _ extends LitElement {
                     cursor: pointer;
                     border-radius: 4px;
                     transition: transform 0.2s, box-shadow 0.2s;
-                    grid-auto-rows: minmax(0, min-content);
+                    grid-auto-rows: minmax(0, max-content);
                 }
                 ::slotted([slot="images"]:hover),
                 ::slotted([slot="recent"]:hover) {


### PR DESCRIPTION
Bug fixes for FireFox:

- Fixes images not rendering correctly when editing modules with images;
- Fixes drag drop event redirecting to the image URL instead of placing the image in the drop container.

#### Before: 

![Screenshot from 2022-01-04 09-24-37](https://user-images.githubusercontent.com/4161106/148026925-3d5ffb0d-c6d9-4b82-9bc1-8fd6dfc4774f.png)

#### After:

![Screenshot from 2022-01-04 09-55-07](https://user-images.githubusercontent.com/4161106/148026994-209f3c80-33e9-4be3-8900-23e527ef8d98.png)
