### PR TITLE
fix(fe/module/flashcards): Play flip effect whenever in Flipping state

### DIFF
--- a/frontend/apps/crates/entry/module/flashcards/play/src/base/game/dom.rs
+++ b/frontend/apps/crates/entry/module/flashcards/play/src/base/game/dom.rs
@@ -63,17 +63,15 @@ fn flip_controller(
     initial: bool,
 ) -> impl FnOnce(DomBuilder<HtmlElement>) -> DomBuilder<HtmlElement> {
     move |dom| {
-        let is_initial = move |gate| {
-            if gate == Gate::Waiting || gate == Gate::FinishingFlip {
-                initial
-            } else {
-                !initial
-            }
-        };
-
         dom
-            .property_signal("eventOnFlipped", state.gate.signal().map(is_initial))
-            .property_signal("flipped", state.gate.signal().map(is_initial))
+            .property_signal("eventOnFlipped", state.gate.signal().map(move |gate| gate == Gate::Flipping))
+            .property_signal("flipped", state.gate.signal().map(move |gate| {
+                if gate == Gate::Waiting || gate == Gate::FinishingFlip {
+                    initial
+                } else {
+                    !initial
+                }
+            }))
             .event(clone!(state => move |_evt:events::Click| {
                 Game::flip(state.clone());
             }))


### PR DESCRIPTION
Part of #2060 

- Ensures the flip sound effect is always played when in the `Gate::Flipping` state