### PR TITLE
feat: add transparency to image search input

### DIFF
--- a/frontend/elements/src/core/inputs/composed/search.ts
+++ b/frontend/elements/src/core/inputs/composed/search.ts
@@ -30,6 +30,7 @@ export class _ extends LitElement {
                     font-size: 16px;
                     padding: 0;
                     margin-left: 8px;
+                    background-color: transparent;
                 }
                 input:focus {
                     outline: none;


### PR DESCRIPTION
closes #1884 

Before
![image](https://user-images.githubusercontent.com/13839150/148065535-6fb4f534-bd91-4e9f-9596-f7a58fa62cf4.png)

After
![image](https://user-images.githubusercontent.com/13839150/148065557-71aae5d1-30da-448a-b64c-a23e1c237083.png)
