### PR TITLE
feat(fe/module/edit): Add module mode subtitle for modules which set a mode

### DIFF
--- a/frontend/apps/crates/components/src/module/_common/edit/entry/base/dom/regular.rs
+++ b/frontend/apps/crates/components/src/module/_common/edit/entry/base/dom/regular.rs
@@ -6,6 +6,7 @@ use futures_signals::{
     signal::{Mutable, SignalExt},
 };
 use serde::Deserialize;
+use wasm_bindgen::JsValue;
 use std::rc::Rc;
 
 use crate::{jigzi_help::JigziHelp, module::_common::edit::header::controller::dom::ControllerDom};
@@ -153,6 +154,7 @@ where
                 h.title.clone()
             })
         })
+        .property("subtitle", state.mode.map_or(JsValue::UNDEFINED, |m| JsValue::from_str(m.label())))
         .child_signal(tab_config_sig().map(|tab| {
             let HeaderConfigTab {title, body} = tab;
 

--- a/frontend/apps/crates/components/src/module/_common/edit/entry/base/state.rs
+++ b/frontend/apps/crates/components/src/module/_common/edit/entry/base/state.rs
@@ -138,6 +138,7 @@ where
     pub steps_completed: Mutable<HashSet<Step>>,
     pub history: Rc<HistoryStateImpl<RawData>>,
     pub preview_mode: Mutable<Option<PreviewMode>>,
+    pub mode: Option<Mode>,
     phantom: PhantomData<Mode>,
 }
 
@@ -177,6 +178,7 @@ where
         let theme_choice = init_args.theme_choice.clone();
         let steps_completed = init_args.steps_completed.clone();
         let jig = init_args.jig.clone();
+        let mode = init_args.raw.mode();
 
         // get a BaseInit
         let init = init_from_raw(init_args).await;
@@ -215,6 +217,7 @@ where
             steps_completed,
             history: app.history.borrow().as_ref().unwrap_ji().clone(),
             preview_mode,
+            mode,
             phantom: PhantomData,
         }
     }

--- a/frontend/elements/src/module/_common/edit/header.ts
+++ b/frontend/elements/src/module/_common/edit/header.ts
@@ -21,12 +21,27 @@ export class _ extends LitElement {
                     text-align: left;
                     color: var(--dark-blue-4);
                 }
+                :host([subtitle]) .title {
+                    margin-top: 30px;
+                }
+                .subtitle {
+                    margin: 10px 0 10px 0;
+                    font-family: Poppins;
+                    font-size: 24px;
+                    font-weight: 500;
+                    letter-spacing: normal;
+                    text-align: left;
+                    color: var(--dark-blue-4);
+                }
             `,
         ];
     }
 
-    @property()
+    @property({ type: String })
     headerTitle: string = "";
+
+    @property({ type: String, reflect: true })
+    subtitle?: string;
 
     render() {
         return html`
@@ -36,6 +51,9 @@ export class _ extends LitElement {
                     <slot name="help"></slot>
                 </div>
                 <div class="title">${this.headerTitle}</div>
+                ${this.subtitle && html`
+                    <div class="subtitle">${this.subtitle}</div>
+                `}
                 <slot></slot>
             </section>
         `;

--- a/shared/rust/src/domain/jig/module/body.rs
+++ b/shared/rust/src/domain/jig/module/body.rs
@@ -36,7 +36,7 @@ pub mod card_quiz;
 /// Matching
 pub mod matching;
 
-/// Legacy  
+/// Legacy
 pub mod legacy;
 
 /// Groups that share types
@@ -158,6 +158,9 @@ pub trait BodyExt<Mode: ModeExt, Step: StepExt>:
     /// will usually populate an inner .content
     fn new_mode(mode: Mode) -> Self;
 
+    /// Fetch the mode for this module
+    fn mode(&self) -> Option<Mode>;
+
     /// requires an additional step of choosing the mode
     fn requires_choose_mode(&self) -> bool;
 
@@ -268,13 +271,13 @@ pub trait ModeExt: Copy + Default + PartialEq + Eq + Hash {
     /// for headers, labels, etc.
     fn label(&self) -> &'static str;
 
-    /// Image tag filters for search  
+    /// Image tag filters for search
     /// The actual ImageTag enum variants are in components
     fn image_tag_filters(&self) -> Option<Vec<i16>> {
         None
     }
 
-    /// Image tag priorities for search  
+    /// Image tag priorities for search
     /// The actual ImageTag enum variants are in components
     fn image_tag_priorities(&self) -> Option<Vec<i16>> {
         None

--- a/shared/rust/src/domain/jig/module/body/card_quiz.rs
+++ b/shared/rust/src/domain/jig/module/body/card_quiz.rs
@@ -75,6 +75,10 @@ impl BodyExt<Mode, Step> for ModuleData {
         }
     }
 
+    fn mode(&self) -> Option<Mode> {
+        self.content.as_ref().map(|c| c.base.mode.clone())
+    }
+
     fn requires_choose_mode(&self) -> bool {
         self.content.is_none()
     }

--- a/shared/rust/src/domain/jig/module/body/cover.rs
+++ b/shared/rust/src/domain/jig/module/body/cover.rs
@@ -40,6 +40,10 @@ impl BodyExt<(), Step> for ModuleData {
         }
     }
 
+    fn mode(&self) -> Option<()> {
+        None
+    }
+
     fn requires_choose_mode(&self) -> bool {
         false
     }

--- a/shared/rust/src/domain/jig/module/body/drag_drop.rs
+++ b/shared/rust/src/domain/jig/module/body/drag_drop.rs
@@ -41,6 +41,10 @@ impl BodyExt<Mode, Step> for ModuleData {
         }
     }
 
+    fn mode(&self) -> Option<Mode> {
+        self.content.as_ref().map(|c| c.mode.clone())
+    }
+
     fn requires_choose_mode(&self) -> bool {
         self.content.is_none()
     }

--- a/shared/rust/src/domain/jig/module/body/flashcards.rs
+++ b/shared/rust/src/domain/jig/module/body/flashcards.rs
@@ -83,6 +83,10 @@ impl BodyExt<Mode, Step> for ModuleData {
         }
     }
 
+    fn mode(&self) -> Option<Mode> {
+        self.content.as_ref().map(|c| c.base.mode.clone())
+    }
+
     fn requires_choose_mode(&self) -> bool {
         self.content.is_none()
     }

--- a/shared/rust/src/domain/jig/module/body/legacy.rs
+++ b/shared/rust/src/domain/jig/module/body/legacy.rs
@@ -47,6 +47,10 @@ impl BodyExt<(), ()> for ModuleData {
         unimplemented!("can't create new legacy modules!")
     }
 
+    fn mode(&self) -> Option<()> {
+        None
+    }
+
     fn requires_choose_mode(&self) -> bool {
         false
     }

--- a/shared/rust/src/domain/jig/module/body/matching.rs
+++ b/shared/rust/src/domain/jig/module/body/matching.rs
@@ -78,6 +78,10 @@ impl BodyExt<Mode, Step> for ModuleData {
         }
     }
 
+    fn mode(&self) -> Option<Mode> {
+        self.content.as_ref().map(|c| c.base.mode.clone())
+    }
+
     fn requires_choose_mode(&self) -> bool {
         self.content.is_none()
     }

--- a/shared/rust/src/domain/jig/module/body/memory.rs
+++ b/shared/rust/src/domain/jig/module/body/memory.rs
@@ -51,6 +51,10 @@ impl BodyExt<Mode, Step> for ModuleData {
         }
     }
 
+    fn mode(&self) -> Option<Mode> {
+        self.content.as_ref().map(|c| c.base.mode.clone())
+    }
+
     fn requires_choose_mode(&self) -> bool {
         self.content.is_none()
     }

--- a/shared/rust/src/domain/jig/module/body/poster.rs
+++ b/shared/rust/src/domain/jig/module/body/poster.rs
@@ -34,6 +34,10 @@ impl BodyExt<Mode, Step> for ModuleData {
         }
     }
 
+    fn mode(&self) -> Option<Mode> {
+        self.content.as_ref().map(|c| c.mode.clone())
+    }
+
     fn requires_choose_mode(&self) -> bool {
         self.content.is_none()
     }

--- a/shared/rust/src/domain/jig/module/body/resource_cover.rs
+++ b/shared/rust/src/domain/jig/module/body/resource_cover.rs
@@ -40,6 +40,10 @@ impl BodyExt<(), Step> for ModuleData {
         }
     }
 
+    fn mode(&self) -> Option<()> {
+        None
+    }
+
     fn requires_choose_mode(&self) -> bool {
         false
     }

--- a/shared/rust/src/domain/jig/module/body/tapping_board.rs
+++ b/shared/rust/src/domain/jig/module/body/tapping_board.rs
@@ -41,6 +41,10 @@ impl BodyExt<Mode, Step> for ModuleData {
         }
     }
 
+    fn mode(&self) -> Option<Mode> {
+        self.content.as_ref().map(|c| c.mode.clone())
+    }
+
     fn requires_choose_mode(&self) -> bool {
         self.content.is_none()
     }

--- a/shared/rust/src/domain/jig/module/body/video.rs
+++ b/shared/rust/src/domain/jig/module/body/video.rs
@@ -36,6 +36,10 @@ impl BodyExt<Mode, Step> for ModuleData {
         }
     }
 
+    fn mode(&self) -> Option<Mode> {
+        self.content.as_ref().map(|c| c.mode.clone())
+    }
+
     fn requires_choose_mode(&self) -> bool {
         self.content.is_none()
     }


### PR DESCRIPTION
Closes #1564 

- Adds a subtitle when editing a module which has modes;
- Shifts the spacing when the subtitle is present so that the content doesn't get squashed too much by the addition of the subtitle element:

#### Without subtitle:

![image](https://user-images.githubusercontent.com/4161106/148085996-321a139d-928e-46ae-97f3-cf1c3c7e7662.png)

#### With subtitle:

![Screenshot from 2022-01-04 17-48-26](https://user-images.githubusercontent.com/4161106/148086027-1f367758-796b-4eff-a16f-186ff387c722.png)
