### PR TITLE
fix(fe/home): Use correct fields for likes/plays

### DIFF
--- a/frontend/apps/crates/entry/home/src/home/search_results/search_results_section/dom.rs
+++ b/frontend/apps/crates/entry/home/src/home/search_results/search_results_section/dom.rs
@@ -56,8 +56,8 @@ impl SearchResultsSection {
         html!("home-search-result", {
             .property("slot", "results")
             .property("title", &jig.jig_data.display_name)
-            .property("playedCount", jig.likes)
-            .property("likedCount", jig.plays)
+            .property("playedCount", jig.plays)
+            .property("likedCount", jig.likes)
             .property("author", &jig.author_name.clone().unwrap_or_default())
             .property("language", &jig.jig_data.language)
             .property("kind", match state.focus {


### PR DESCRIPTION
- Fixes swapped liked/played counts on search results

#### Before

![Screenshot from 2022-01-05 13-32-45](https://user-images.githubusercontent.com/4161106/148211171-bf8c51b8-3268-4db8-b245-6da436b64cfd.png)

#### After

![image](https://user-images.githubusercontent.com/4161106/148211202-250e1507-cb29-480a-9752-7342208ed683.png)
