### PR TITLE
feat(fe/module): Scale card game font size based on text length

### DIFF
--- a/frontend/apps/crates/components/src/module/_groups/cards/edit/main/pair/card/dom.rs
+++ b/frontend/apps/crates/components/src/module/_groups/cards/edit/main/pair/card/dom.rs
@@ -10,7 +10,7 @@ use crate::{
     image::search::types::*,
     module::_groups::cards::{
         edit::{config, state::*},
-        lookup::{self, UnitType},
+        lookup,
     },
 };
 use futures_signals::signal::SignalExt;
@@ -46,7 +46,7 @@ pub fn render<RawData: RawDataExt, E: ExtraExt>(state: Rc<MainCard<RawData, E>>)
                     html!("input-textarea-content", {
                         .property_signal("value", data.signal_cloned())
                         .property_signal("fontSize", data.signal_cloned().map(|value| {
-                            lookup::get_card_font_size(value.len(), None, UnitType::Px)
+                            lookup::get_card_font_size(&value, None)
                         }))
                         .property("clickMode", "none")
                         .property("constrainWidth", config::CARD_TEXT_LIMIT_WIDTH)

--- a/frontend/apps/crates/components/src/module/_groups/cards/edit/main/pair/card/dom.rs
+++ b/frontend/apps/crates/components/src/module/_groups/cards/edit/main/pair/card/dom.rs
@@ -10,10 +10,10 @@ use crate::{
     image::search::types::*,
     module::_groups::cards::{
         edit::{config, state::*},
-        lookup,
+        lookup::{self, UnitType},
     },
 };
-use futures_signals::{map_ref, signal::SignalExt};
+use futures_signals::signal::SignalExt;
 use js_sys::Reflect;
 use shared::domain::jig::module::body::{
     ModeExt,
@@ -45,22 +45,9 @@ pub fn render<RawData: RawDataExt, E: ExtraExt>(state: Rc<MainCard<RawData, E>>)
                 Card::Text(data) => {
                     html!("input-textarea-content", {
                         .property_signal("value", data.signal_cloned())
-                        .property_signal("fontSize", {
-                            let sig = map_ref!{
-                                let value = data.signal_cloned(),
-                                let theme_id = state.base.theme_id.signal()
-                                    => {
-                                        (value.len(), *theme_id)
-                                    }
-                            };
-
-                            let mode = state.base.mode;
-
-                            sig.map(move |(len, theme_id)| {
-                                let font_size = lookup::get_card_font_size(len, theme_id, mode);
-                                format!("{}px", font_size)
-                            })
-                        })
+                        .property_signal("fontSize", data.signal_cloned().map(|value| {
+                            lookup::get_card_font_size(value.len(), None, UnitType::Px)
+                        }))
                         .property("clickMode", "none")
                         .property("constrainWidth", config::CARD_TEXT_LIMIT_WIDTH)
                         .property("constrainHeight", config::CARD_TEXT_LIMIT_HEIGHT)

--- a/frontend/apps/crates/components/src/module/_groups/cards/lookup.rs
+++ b/frontend/apps/crates/components/src/module/_groups/cards/lookup.rs
@@ -2,8 +2,8 @@ use std::fmt::{Display, Formatter, Result};
 
 use super::play::card::dom::Size;
 
-const FONT_SIZE_RANGE: (f32, f32) = (100f32, 40f32);
-const TEXT_LENGTH_RANGE: (usize, usize) = (1, 12);
+const FONT_SIZE_RANGE: (f32, f32) = (200f32, 60f32);
+const TEXT_LENGTH_RANGE: (usize, usize) = (1, 10);
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Side {
@@ -49,7 +49,7 @@ pub fn get_card_font_size(length: usize, size: Option<&Size>, unit_type: UnitTyp
             let size_scale = match size {
                 Size::Flashcards => 1f32,
                 Size::QuizTarget => 0.80f32,
-                Size::Matching | Size::QuizOption => 0.75f32,
+                Size::Matching | Size::QuizOption => 0.5f32,
                 Size::Memory => 0.5f32,
             };
 

--- a/frontend/apps/crates/components/src/module/_groups/cards/lookup.rs
+++ b/frontend/apps/crates/components/src/module/_groups/cards/lookup.rs
@@ -1,6 +1,5 @@
-use std::fmt::{Display, Formatter, Result};
-
 use super::play::card::dom::Size;
+use unicode_segmentation::UnicodeSegmentation;
 
 const FONT_SIZE_RANGE: (f32, f32) = (200f32, 60f32);
 const TEXT_LENGTH_RANGE: (usize, usize) = (1, 10);
@@ -9,20 +8,6 @@ const TEXT_LENGTH_RANGE: (usize, usize) = (1, 10);
 pub enum Side {
     Left,
     Right,
-}
-
-pub enum UnitType {
-    Px,
-    Rem,
-}
-
-impl Display for UnitType {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        match self {
-            Self::Px => write!(f, "px"),
-            Self::Rem => write!(f, "rem"),
-        }
-    }
 }
 
 impl Side {
@@ -42,7 +27,7 @@ impl Side {
     }
 }
 
-pub fn get_card_font_size(length: usize, size: Option<&Size>, unit_type: UnitType) -> String {
+pub fn get_card_font_size(value: &str, size: Option<&Size>) -> String {
     let size = match size {
         None => 40f32, // Return the original font size
         Some(size) => {
@@ -53,16 +38,17 @@ pub fn get_card_font_size(length: usize, size: Option<&Size>, unit_type: UnitTyp
                 Size::Memory => 0.5f32,
             };
 
+            let value_len = value.graphemes(true).count();
+
             // Different card games have different sized cards, this scales the final font size per
             // card size.
             let font_size_range = (FONT_SIZE_RANGE.0 * size_scale, FONT_SIZE_RANGE.1 * size_scale);
-
             let scale = (font_size_range.1 - font_size_range.0 as f32) / (TEXT_LENGTH_RANGE.1 as f32 - TEXT_LENGTH_RANGE.0 as f32);
-            let capped = std::cmp::min(TEXT_LENGTH_RANGE.1, std::cmp::max(TEXT_LENGTH_RANGE.0, length)) - TEXT_LENGTH_RANGE.0;
+            let capped = std::cmp::min(TEXT_LENGTH_RANGE.1, std::cmp::max(TEXT_LENGTH_RANGE.0, value_len)) - TEXT_LENGTH_RANGE.0;
 
             capped as f32 * scale + font_size_range.0 as f32
         }
     };
 
-    format!("{:.2}{}", size, unit_type)
+    format!("{:.2}rem", size)
 }

--- a/frontend/apps/crates/components/src/module/_groups/cards/lookup.rs
+++ b/frontend/apps/crates/components/src/module/_groups/cards/lookup.rs
@@ -1,9 +1,28 @@
-use shared::domain::jig::module::body::{ThemeId, _groups::cards::*};
+use std::fmt::{Display, Formatter, Result};
+
+use super::play::card::dom::Size;
+
+const FONT_SIZE_RANGE: (f32, f32) = (100f32, 40f32);
+const TEXT_LENGTH_RANGE: (usize, usize) = (1, 12);
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Side {
     Left,
     Right,
+}
+
+pub enum UnitType {
+    Px,
+    Rem,
+}
+
+impl Display for UnitType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        match self {
+            Self::Px => write!(f, "px"),
+            Self::Rem => write!(f, "rem"),
+        }
+    }
 }
 
 impl Side {
@@ -23,7 +42,27 @@ impl Side {
     }
 }
 
-pub fn get_card_font_size(_length: usize, _theme_id: ThemeId, _mode: Mode) -> usize {
-    //Todo - evaluate this...
-    40
+pub fn get_card_font_size(length: usize, size: Option<&Size>, unit_type: UnitType) -> String {
+    let size = match size {
+        None => 40f32, // Return the original font size
+        Some(size) => {
+            let size_scale = match size {
+                Size::Flashcards => 1f32,
+                Size::QuizTarget => 0.80f32,
+                Size::Matching | Size::QuizOption => 0.75f32,
+                Size::Memory => 0.5f32,
+            };
+
+            // Different card games have different sized cards, this scales the final font size per
+            // card size.
+            let font_size_range = (FONT_SIZE_RANGE.0 * size_scale, FONT_SIZE_RANGE.1 * size_scale);
+
+            let scale = (font_size_range.1 - font_size_range.0 as f32) / (TEXT_LENGTH_RANGE.1 as f32 - TEXT_LENGTH_RANGE.0 as f32);
+            let capped = std::cmp::min(TEXT_LENGTH_RANGE.1, std::cmp::max(TEXT_LENGTH_RANGE.0, length)) - TEXT_LENGTH_RANGE.0;
+
+            capped as f32 * scale + font_size_range.0 as f32
+        }
+    };
+
+    format!("{:.2}{}", size, unit_type)
 }

--- a/frontend/apps/crates/components/src/module/_groups/cards/play/card/dom/common.rs
+++ b/frontend/apps/crates/components/src/module/_groups/cards/play/card/dom/common.rs
@@ -2,7 +2,7 @@ use dominator::{html, Dom};
 use utils::prelude::*;
 use wasm_bindgen::JsValue;
 
-use crate::module::_groups::cards::lookup::{self, UnitType};
+use crate::module::_groups::cards::lookup;
 use shared::domain::jig::module::body::_groups::cards::{Card, Mode};
 
 //must match @elements/module/_groups/cards/play/card/styles.ts
@@ -64,7 +64,7 @@ pub struct SimpleTransform {
     pub scale: f64,
 }
 
-pub(super) fn render_media(card: &Card, size: &Size, mode: Mode, slot: Option<&str>) -> Dom {
+pub(super) fn render_media(card: &Card, size: &Size, slot: Option<&str>) -> Dom {
     match &card {
         Card::Text(s) => {
             html!("card-text", {
@@ -73,7 +73,7 @@ pub(super) fn render_media(card: &Card, size: &Size, mode: Mode, slot: Option<&s
                 })
                 .property("value", s)
                 .property("fontSize", {
-                    lookup::get_card_font_size(s.len(), Some(size), UnitType::Rem)
+                    lookup::get_card_font_size(s, Some(size))
                 })
             })
         }

--- a/frontend/apps/crates/components/src/module/_groups/cards/play/card/dom/common.rs
+++ b/frontend/apps/crates/components/src/module/_groups/cards/play/card/dom/common.rs
@@ -2,7 +2,7 @@ use dominator::{html, Dom};
 use utils::prelude::*;
 use wasm_bindgen::JsValue;
 
-use crate::module::_groups::cards::lookup::{self};
+use crate::module::_groups::cards::lookup::{self, UnitType};
 use shared::domain::jig::module::body::_groups::cards::{Card, Mode};
 
 //must match @elements/module/_groups/cards/play/card/styles.ts
@@ -64,7 +64,7 @@ pub struct SimpleTransform {
     pub scale: f64,
 }
 
-pub(super) fn render_media(card: &Card, mode: Mode, theme_id: ThemeId, slot: Option<&str>) -> Dom {
+pub(super) fn render_media(card: &Card, size: &Size, mode: Mode, slot: Option<&str>) -> Dom {
     match &card {
         Card::Text(s) => {
             html!("card-text", {
@@ -73,8 +73,7 @@ pub(super) fn render_media(card: &Card, mode: Mode, theme_id: ThemeId, slot: Opt
                 })
                 .property("value", s)
                 .property("fontSize", {
-                    let font_size = lookup::get_card_font_size(s.len(), theme_id, mode);
-                    format!("{}rem", font_size)
+                    lookup::get_card_font_size(s.len(), Some(size), UnitType::Rem)
                 })
             })
         }

--- a/frontend/apps/crates/components/src/module/_groups/cards/play/card/dom/dom.rs
+++ b/frontend/apps/crates/components/src/module/_groups/cards/play/card/dom/dom.rs
@@ -124,11 +124,11 @@ where
                 .property("scale", t.scale)
                 .property("hasTransform", true)
         })
-        .child(render_media(card, &size, mode, None))
+        .child(render_media(card, &size, None))
         .apply_if(back_card.is_some(), |dom| {
             dom
                 .property("doubleSided", true)
-                .child(render_media(back_card.unwrap_ji(), &size, mode, Some("backSideContent")))
+                .child(render_media(back_card.unwrap_ji(), &size, Some("backSideContent")))
         })
         .apply_if(mixin.is_some(), |dom| {
             (mixin.unwrap_ji()) (dom)

--- a/frontend/apps/crates/components/src/module/_groups/cards/play/card/dom/dom.rs
+++ b/frontend/apps/crates/components/src/module/_groups/cards/play/card/dom/dom.rs
@@ -124,11 +124,11 @@ where
                 .property("scale", t.scale)
                 .property("hasTransform", true)
         })
-        .child(render_media(card, mode, theme_id, None))
+        .child(render_media(card, &size, mode, None))
         .apply_if(back_card.is_some(), |dom| {
             dom
                 .property("doubleSided", true)
-                .child(render_media(back_card.unwrap_ji(), mode, theme_id, Some("backSideContent")))
+                .child(render_media(back_card.unwrap_ji(), &size, mode, Some("backSideContent")))
         })
         .apply_if(mixin.is_some(), |dom| {
             (mixin.unwrap_ji()) (dom)

--- a/frontend/elements/src/module/_groups/cards/play/card/text.ts
+++ b/frontend/elements/src/module/_groups/cards/play/card/text.ts
@@ -12,6 +12,8 @@ export class _ extends LitElement {
                     /*font-size: var(--font-size, 40rem);*/
                     color: var(--color, black);
                     text-align: center;
+                    display: inline-block;
+                    margin: 1em;
 
                     white-space: pre-wrap;
                 }


### PR DESCRIPTION
Resolves #2184 

- Implements scaled font sizes determined by the length of text in a card;
- Font size is further scaled by the `Size` used for each card game.

![Screenshot from 2022-01-06 13-26-01](https://user-images.githubusercontent.com/4161106/148376751-868a022a-da9c-4059-9eef-32eb07b821ed.png)
![Screenshot from 2022-01-06 13-23-41](https://user-images.githubusercontent.com/4161106/148376075-9256f133-da8e-4fed-8156-5d82911c985e.png)
![Screenshot from 2022-01-06 13-23-22](https://user-images.githubusercontent.com/4161106/148376083-ebf22f6b-181c-4d06-880f-8b5c025191d7.png)
![image](https://user-images.githubusercontent.com/4161106/148376955-0e69a1d8-a5ed-4e1a-9be0-d4742f547b00.png)


