### PR TITLE
fix(be/update_admin_data): add new endpoint for admin data update

### DIFF
--- a/backend/api/sqlx-data.json
+++ b/backend/api/sqlx-data.json
@@ -208,21 +208,6 @@
       "nullable": []
     }
   },
-  "09e722529d2a3e91d6e8dc33dac3ad8caa93006e5aafb1b0ea478410e3efb899": {
-    "query": "\nupdate jig_admin_data\nset rating = coalesce($2, rating),\n    blocked = coalesce($3, blocked),\n    curated = coalesce($4, curated)\nwhere jig_id = $1\n",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Int2",
-          "Bool",
-          "Bool"
-        ]
-      },
-      "nullable": []
-    }
-  },
   "0a1f9e5fee4b10a173b8723976cecfb920f90a4828d723abb14f6e0215cf880b": {
     "query": "select exists(select 1 from locale_entry where id = $1 for update) as \"exists!\"",
     "describe": {
@@ -2244,25 +2229,17 @@
       ]
     }
   },
-  "668625f47ad262dd929fbf9a85a5d319af1f0bb4297b2fad9ad7ab19d77ccf69": {
-    "query": "\nselect exists(select 1 from user_scope where user_id = $1 and scope = $2) as \"authed!\"\n",
+  "674424a88094e0ceb29cc4c2c4548cc97162b931eff9316fcdb78ede5cf7d7da": {
+    "query": "\nupdate jig_admin_data\nset blocked = coalesce($2, blocked)\nwhere jig_id = $1 and $2 is distinct from blocked\n            ",
     "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "authed!",
-          "type_info": "Bool"
-        }
-      ],
+      "columns": [],
       "parameters": {
         "Left": [
           "Uuid",
-          "Int2"
+          "Bool"
         ]
       },
-      "nullable": [
-        null
-      ]
+      "nullable": []
     }
   },
   "68a6cedcf31dbac17f23ec2cf4cdead5973b0bf72e32708d64e680ecc2997f6b": {
@@ -4543,6 +4520,19 @@
       ]
     }
   },
+  "bfd314e70437482954c5dfb3a40ab08990a0bea43779d810e9dd903e87e10c81": {
+    "query": "\nupdate jig_admin_data\nset curated = coalesce($2, curated)\nwhere jig_id = $1 and $2 is distinct from curated\n            ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Bool"
+        ]
+      },
+      "nullable": []
+    }
+  },
   "c0503b4756010f70f84bfc842758cc356568bcb7324b0c0a8454f49511300942": {
     "query": "insert into user_scope (user_id, scope) values ($1, $2)",
     "describe": {
@@ -4708,6 +4698,19 @@
       "nullable": [
         null
       ]
+    }
+  },
+  "ca807853c119226252820e8cd0f9476d114f3e5e98ffed0dcd059d05063760a4": {
+    "query": "\nupdate jig_admin_data\nset rating = coalesce($2, rating)\nwhere jig_id = $1 and $2 is distinct from rating\n            ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Int2"
+        ]
+      },
+      "nullable": []
     }
   },
   "cb1eb42e7bcc8143deb3eec658b4a6d23278f99ce5bf5062886d0b18c1b2b1d3": {

--- a/shared/rust/src/api/endpoints/jig.rs
+++ b/shared/rust/src/api/endpoints/jig.rs
@@ -4,7 +4,7 @@ use crate::{
         jig::{
             JigBrowseQuery, JigBrowseResponse, JigCountResponse, JigCreateRequest, JigId,
             JigLikedResponse, JigResponse, JigSearchQuery, JigSearchResponse,
-            JigUpdateDraftDataRequest,
+            JigUpdateAdminDataRequest, JigUpdateDraftDataRequest,
         },
         CreateResponse,
     },
@@ -261,4 +261,24 @@ impl ApiEndpoint for Play {
     type Err = EmptyError;
     const PATH: &'static str = "/v1/jig/{id}/play";
     const METHOD: Method = Method::Put;
+}
+
+/// Update an admin data for a JIG.
+///
+/// # Authorization
+///
+/// * Standard + [`UserScope::ManageJig`](crate::domain::user::UserScope)
+///
+/// # Errors
+///
+/// * [`Unauthorized`](http::StatusCode::UNAUTHORIZED) if authorization is not valid.
+/// * [`Forbidden`](http::StatusCode::FORBIDDEN) if the user does not have sufficient permission to perform the action.
+/// * [`BadRequest`](http::StatusCode::BAD_REQUEST) if the request is missing/invalid.
+pub struct JigAdminDataUpdate;
+impl ApiEndpoint for JigAdminDataUpdate {
+    type Req = JigUpdateAdminDataRequest;
+    type Res = ();
+    type Err = EmptyError;
+    const PATH: &'static str = "/v1/jig/{id}/admin";
+    const METHOD: Method = Method::Patch;
 }

--- a/shared/rust/src/domain/jig.rs
+++ b/shared/rust/src/domain/jig.rs
@@ -359,6 +359,26 @@ pub struct JigAdminData {
 }
 
 /// These fields can be edited by admin and can be viewed by everyone
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct JigUpdateAdminDataRequest {
+    /// Rating for jig, weighted for jig search
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub rating: Option<JigRating>,
+
+    /// if true does not appear in search
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub blocked: Option<bool>,
+
+    /// Indicates jig has been curated by admin
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub curated: Option<bool>,
+}
+
+/// These fields can be edited by admin and can be viewed by everyone
 #[derive(Serialize, Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct JigAdminUpdateData {
@@ -668,11 +688,6 @@ pub struct JigUpdateDraftDataRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub other_keywords: Option<String>,
-
-    /// Rating by admin for Jig
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(default)]
-    pub admin_data: Option<JigAdminUpdateData>,
 }
 
 /// Query for [`Browse`](crate::api::endpoints::jig::Browse).


### PR DESCRIPTION
closes #2192 

New endpoint to update admin data for jig by `jig_id`.

`PATCH /v1/jig/{id}/admin`

- request body
> - curated 
> - rating
> - blocked