### PR TITLE
fix(admin): Move admin data update into separate request

### DIFF
--- a/frontend/apps/crates/entry/admin/src/curation/jig/actions.rs
+++ b/frontend/apps/crates/entry/admin/src/curation/jig/actions.rs
@@ -1,7 +1,7 @@
 use std::rc::Rc;
 
 use dominator::clone;
-use shared::{domain::jig::JigUpdateDraftDataRequest, error::EmptyError, api::{endpoints, ApiEndpoint}};
+use shared::{domain::jig::{JigUpdateDraftDataRequest, JigUpdateAdminDataRequest}, error::EmptyError, api::{endpoints::{self, jig::JigAdminDataUpdate}, ApiEndpoint}};
 use utils::prelude::api_with_auth_empty;
 
 use super::state::CurationJig;
@@ -13,6 +13,20 @@ impl CurationJig {
         let res = api_with_auth_empty::<EmptyError, JigUpdateDraftDataRequest>(
             &path,
             endpoints::jig::UpdateDraftData::METHOD,
+            Some(req),
+        ).await;
+        match res {
+            Ok(res) => res,
+            Err(_) => todo!(),
+        }
+    }
+
+    pub async fn save_admin_data(self: &Rc<Self>) {
+        let path = endpoints::jig::JigAdminDataUpdate::PATH.replace("{id}", &self.jig_id.0.to_string());
+        let req = self.jig.to_update_admin_data_request();
+        let res = api_with_auth_empty::<EmptyError, JigUpdateAdminDataRequest>(
+            &path,
+            endpoints::jig::JigAdminDataUpdate::METHOD,
             Some(req),
         ).await;
         match res {
@@ -35,6 +49,7 @@ impl CurationJig {
         let state = self;
         state.loader.load(clone!(state => async move {
             state.save_draft().await;
+            state.save_admin_data().await;
             state.publish().await;
         }))
     }

--- a/frontend/apps/crates/entry/admin/src/curation/jig/state/jig.rs
+++ b/frontend/apps/crates/entry/admin/src/curation/jig/state/jig.rs
@@ -4,12 +4,14 @@ use std::rc::Rc;
 
 use futures_signals::signal::Mutable;
 use futures_signals::signal_vec::MutableVec;
-use shared::domain::jig::{JigFocus, PrivacyLevel, JigRating, JigAdminUpdateData};
-use shared::domain::jig::additional_resource::AdditionalResource;
-use shared::domain::meta::AffiliationId;
 use shared::domain::{
+    meta::AffiliationId,
     category::CategoryId,
-    jig::{JigId, JigResponse, JigUpdateDraftDataRequest, LiteModule},
+    jig::{
+        additional_resource::AdditionalResource,
+        JigFocus, PrivacyLevel, JigRating, JigId, JigResponse, JigUpdateDraftDataRequest,
+        JigUpdateAdminDataRequest, LiteModule
+    },
     meta::{AgeRangeId, GoalId},
 };
 
@@ -68,10 +70,13 @@ impl EditableJig {
             categories: Some(self.categories.get_cloned().into_iter().collect()),
             affiliations: Some(self.affiliations.get_cloned().into_iter().collect()),
             privacy_level: Some(self.privacy_level.get()),
-            admin_data: Some(JigAdminUpdateData {
-                rating: self.rating.get_cloned(),
-                ..Default::default()
-            }),
+            ..Default::default()
+        }
+    }
+
+    pub fn to_update_admin_data_request(&self) -> JigUpdateAdminDataRequest {
+        JigUpdateAdminDataRequest {
+            rating: self.rating.get_cloned(),
             ..Default::default()
         }
     }


### PR DESCRIPTION
- Updates the admin creation page to call the new admin data update endpoint implemented in #2194 

