### PR TITLE
fix(fe/jig/play): Track play count once a JIG is played to completion

### DIFF
--- a/frontend/elements/src/entry/home/home/search-results/search-result.ts
+++ b/frontend/elements/src/entry/home/home/search-results/search-result.ts
@@ -1,8 +1,8 @@
 import { LitElement, html, css, customElement, property } from "lit-element";
 import { nothing } from "lit-html";
 
-const STR_PLAYED = "Played";
-const STR_LIKED = "Liked";
+const STR_PLAYED = "Plays";
+const STR_LIKED = "Likes";
 const STR_JI_TEAM = "Ji Team";
 const STR_DESCRIPTION = "Description";
 const STR_ADDITIONAL_RESOURCES = "Additional resources";

--- a/frontend/elements/src/entry/jig/play/sidebar/jig-info.ts
+++ b/frontend/elements/src/entry/jig/play/sidebar/jig-info.ts
@@ -3,8 +3,8 @@ import "@elements/core/popups/popup-body";
 import { nothing } from "lit-html";
 
 const STR_JI_TEAM = "Ji Team";
-const STR_LIKED = "Liked";
-const STR_PLAYED = "Played";
+const STR_LIKED = "Likes";
+const STR_PLAYED = "Plays";
 const STR_ADDITIONAL_RESOURCES = "Additional resources";
 const STR_COURSES = "Courses";
 const STR_COURSES_SUBHEADING = "This JIG is a apart of the following courses:";


### PR DESCRIPTION
Closes #1505 

- Updates played/liked to plays/likes;
- Moves the call to `/jig/{id}/play` to the end of a JIG.