### PR TITLE
feat(fe/jig/edit): Update JIG edit button settings so that it display plural/singular form

### DIFF
--- a/frontend/apps/crates/components/src/module/_common/edit/settings/button/dom.rs
+++ b/frontend/apps/crates/components/src/module/_common/edit/settings/button/dom.rs
@@ -40,6 +40,7 @@ where
                     .property("slot", "bubble")
                     .child(html!("module-settings-bubble-content", {
                         .property("kind", state.kind.as_str_id())
+                        .property_signal("value", state.value.as_ref().unwrap_ji().string_signal())
                         .apply_if(input_kind.is_some(), |dom| {
                             dom.child(
                                 match input_kind.unwrap_ji() {

--- a/frontend/elements/src/module/_common/edit/widgets/settings/bubble-content.ts
+++ b/frontend/elements/src/module/_common/edit/widgets/settings/bubble-content.ts
@@ -12,18 +12,18 @@ import { Kind } from "./button";
 const STR_LABEL: Partial<Record<Kind, string>> = {
     attempts: "Player gets",
     "continue-some": "of",
-    rounds: "Play",
+    rounds: "Complete",
     n_choices: "Display",
     n_pairs: "Display",
 };
 
-const STR_LABEL_SUFFIX: Partial<Record<Kind, string>> = {
-    attempts: "tries",
-    "time-limit": "minutes",
-    "continue-some": "items",
-    rounds: "rounds",
-    n_choices: "pairs",
-    n_pairs: "pairs",
+const STR_LABEL_SUFFIX: Partial<Record<Kind, string[]>> = {
+    attempts: ["try", "tries"],
+    "time-limit": ["minute", "minutes"],
+    "continue-some": ["item", "items"],
+    rounds: ["page", "pages"],
+    n_choices: ["card", "cards"],
+    n_pairs: ["pair", "pairs"],
 };
 
 @customElement("module-settings-bubble-content")
@@ -51,6 +51,26 @@ export class _ extends LitElement {
     @property()
     kind: Kind = "attempts";
 
+    @property()
+    value?: any;
+
+    renderLabelSuffix() {
+        const suffix_config = STR_LABEL_SUFFIX[this.kind];
+
+        if (!suffix_config) {
+            return nothing;
+        }
+
+        let suffix = null;
+        if (this.value > 1) {
+            suffix = suffix_config[1];
+        } else {
+            suffix = suffix_config[0];
+        }
+
+        return html`<span>${suffix}</span>`;
+    }
+
     render() {
         const { kind } = this;
 
@@ -60,7 +80,7 @@ export class _ extends LitElement {
         return html`
             ${label ? html`<span>${label}</span>` : nothing}
             <slot></slot>
-            ${label_suffix ? html`<span>${label_suffix}</span>` : nothing}
+            ${this.renderLabelSuffix()}
         `;
     }
 }


### PR DESCRIPTION
Closes #2174 

- Sets singular or plural based on whether the value set is more than 1;
- Changes "pairs" to "cards";
- Changes "rounds" to "pages".

![Screenshot from 2022-01-10 09-17-54](https://user-images.githubusercontent.com/4161106/148730786-bfe56eb8-37da-4798-931b-fdcd22c7b616.png)
![Screenshot from 2022-01-10 09-17-57](https://user-images.githubusercontent.com/4161106/148730789-f77ecb51-22d4-4c68-8092-ef8e439ad101.png)
![Screenshot from 2022-01-10 09-19-56](https://user-images.githubusercontent.com/4161106/148730791-6d293184-a5da-42af-941c-f1942094876a.png)
![Screenshot from 2022-01-10 09-20-04](https://user-images.githubusercontent.com/4161106/148730792-834681f5-cdf2-42bb-8b2d-793aab4a2b44.png)

