### PR TITLE
feat(fe/user): Enable multi-persona selects for user registration and profile

### DIFF
--- a/frontend/apps/crates/entry/user/src/profile/state.rs
+++ b/frontend/apps/crates/entry/user/src/profile/state.rs
@@ -49,7 +49,7 @@ pub struct ProfilePageUser {
     pub subjects: MutableVec<SubjectId>,
     pub age_ranges: MutableVec<AgeRangeId>,
     pub affiliations: MutableVec<AffiliationId>,
-    pub persona: Mutable<Vec<String>>,
+    pub persona: MutableVec<String>,
 }
 
 impl ProfilePageUser {
@@ -68,7 +68,7 @@ impl ProfilePageUser {
             subjects: MutableVec::new(),
             age_ranges: MutableVec::new(),
             affiliations: MutableVec::new(),
-            persona: Mutable::new(vec![]),
+            persona: MutableVec::new(),
         }
     }
 
@@ -86,7 +86,7 @@ impl ProfilePageUser {
         self.subjects.lock_mut().replace(user.subjects);
         self.age_ranges.lock_mut().replace(user.age_ranges);
         self.affiliations.lock_mut().replace(user.affiliations);
-        self.persona.set(user.persona);
+        self.persona.lock_mut().replace_cloned(user.persona);
     }
 
     pub fn to_update(&self) -> PatchProfileRequest {
@@ -102,7 +102,7 @@ impl ProfilePageUser {
             age_ranges: Some(self.age_ranges.lock_ref().to_vec()),
             affiliations: Some(self.affiliations.lock_ref().to_vec()),
             location: Some(self.location.get_cloned()),
-            persona: Some(self.persona.get_cloned()),
+            persona: Some(self.persona.lock_ref().to_vec()),
             ..Default::default()
         }
     }

--- a/frontend/apps/crates/entry/user/src/register/pages/step_2/actions.rs
+++ b/frontend/apps/crates/entry/user/src/register/pages/step_2/actions.rs
@@ -12,10 +12,7 @@ pub fn submit(state: Rc<State>) {
     let language_error = state.language_error.get();
     let _persona_error = state.persona_error.get();
 
-    let persona_error = match &*state.persona.borrow() {
-        None => true,
-        Some(x) => x.is_empty(),
-    };
+    let persona_error = state.persona.lock_ref().is_empty();
     state.persona_error.set_neq(persona_error);
 
     let location_error = match &*state.location_json.borrow() {
@@ -47,11 +44,7 @@ impl State {
     }
 
     pub fn evaluate_persona_error(&self) {
-        let error = match &*self.persona.borrow() {
-            None => true,
-            Some(x) => x.is_empty(),
-        };
-        self.persona_error.set_neq(error);
+        self.persona_error.set_neq(self.persona.lock_ref().is_empty());
     }
 }
 
@@ -60,7 +53,7 @@ fn next_step(state: Rc<State>) {
         step_1: state.step_1.clone(),
         location_json: state.location_json.borrow().clone(),
         language: state.language.borrow().as_ref().unwrap_ji().clone(),
-        persona: state.persona.borrow().as_ref().unwrap_ji().clone(),
+        persona: state.persona.lock_ref().to_vec(),
         organization: state.organization.borrow().clone(),
         marketing: *state.marketing.borrow(),
     }));

--- a/frontend/apps/crates/entry/user/src/register/pages/step_2/state.rs
+++ b/frontend/apps/crates/entry/user/src/register/pages/step_2/state.rs
@@ -1,5 +1,5 @@
 use crate::register::state::{Step, Step1Data};
-use futures_signals::signal::{Mutable, Signal, SignalExt};
+use futures_signals::{signal::{Mutable, Signal, SignalExt}, signal_vec::MutableVec};
 use std::cell::RefCell;
 
 pub struct State {
@@ -9,7 +9,7 @@ pub struct State {
     pub location_error: Mutable<bool>,
     pub language: RefCell<Option<String>>,
     pub language_error: Mutable<bool>,
-    pub persona: RefCell<Option<Vec<String>>>,
+    pub persona: MutableVec<String>,
     pub persona_error: Mutable<bool>,
     pub organization: RefCell<Option<String>>,
     pub organization_error: Mutable<bool>,
@@ -27,7 +27,7 @@ impl State {
             location_error: Mutable::new(false),
             language: RefCell::new(None),
             language_error: Mutable::new(false),
-            persona: RefCell::new(None),
+            persona: MutableVec::new(),
             persona_error: Mutable::new(false),
             organization: RefCell::new(None),
             organization_error: Mutable::new(false),

--- a/frontend/apps/crates/entry/user/src/strings.rs
+++ b/frontend/apps/crates/entry/user/src/strings.rs
@@ -65,6 +65,7 @@ pub mod register {
             "Administrator",
             "Shaliach",
             "Tutor",
+            "Content manager",
         ];
         pub const STR_PERSONA_PLACEHOLDER: &str = "Select from the list";
         pub const STR_ONE_MORE_STEP: &str = "One more step";


### PR DESCRIPTION
Closes #2070

- Multiple personas can be selected in user profile;
- Multiple personas can be selected during registration.

TODO

- [ ] Add validation to user profile so that at least 1 persona is selected.