### PR TITLE
feat(be/jig_browse): add draft or live filter for browse

### DIFF
--- a/backend/api/fixtures/8_jig.sql
+++ b/backend/api/fixtures/8_jig.sql
@@ -1,18 +1,18 @@
 insert into jig_data (id, display_name, created_at, updated_at, language, last_synced_at, description, theme,
                       audio_background, audio_feedback_negative, audio_feedback_positive, direction, privacy_level, display_score,
-                      drag_assist, track_assessments)
+                      drag_assist, track_assessments, draft_or_live)
 values ('d4cad43c-1dd5-11ec-8426-83d4a42e3ac9', 'name', '2021-03-04 00:46:26.134651+00', -- live
         '2021-03-04 00:46:26.134651+00', 'en', '2021-03-04 00:46:26.134651+00', 'test description', 0, null,
-        array [0, 1], array [0, 1, 2], 0, 0,  true, true, true),
+        array [0, 1], array [0, 1, 2], 0, 0,  true, true, true, 1),
        ('d4cad4c8-1dd5-11ec-8426-a37eda7ce03f', 'name', '2021-03-04 00:46:26.134651+00', -- draft
         '2021-03-04 00:46:26.134651+00', 'en', '2021-03-04 00:46:26.134651+00', 'test description', 0, null,
-        array [0, 1], array [0, 1, 2], 0, 1, true, true, true),
+        array [0, 1], array [0, 1, 2], 0, 1, true, true, true, 0),
        ('d4cad52c-1dd5-11ec-8426-f7f3e8ceccb2', 'name', '2021-03-04 00:46:26.134651+00', -- live
         '2021-03-04 00:46:26.134651+00', 'en', '2021-03-04 00:46:26.134651+00', 'test description', 0, null,
-        array [0, 1], array [0, 1, 2], 0, 0, true, true, true),
+        array [0, 1], array [0, 1, 2], 0, 0, true, true, true, 1),
        ('d4cad586-1dd5-11ec-8426-fbcd3fd01e2a', 'draft name', '2021-03-06 00:46:26.134651+00', -- draft
         '2021-03-06 00:46:26.134651+00', 'he', '2021-03-07 00:46:26.134651+00', 'draft test description', 1, 0,
-        array []::smallint[], array []::smallint[], 1, 1, false, false, false);
+        array []::smallint[], array []::smallint[], 1, 1, false, false, false, 0);
 
 
 insert into jig (id, creator_id, author_id, live_id, draft_id)

--- a/backend/api/migrations/20220109080509_jig_data_draft_or_live.sql
+++ b/backend/api/migrations/20220109080509_jig_data_draft_or_live.sql
@@ -1,0 +1,15 @@
+alter table jig_data 
+    add column draft_or_live int2;
+
+update jig_data 
+set draft_or_live = 0
+from jig
+where jig.draft_id = jig_data.id;
+
+update jig_data 
+set draft_or_live = 1
+from jig
+where jig.live_id = jig_data.id;
+
+delete from jig_data
+where draft_or_live is NULL;

--- a/backend/api/sqlx-data.json
+++ b/backend/api/sqlx-data.json
@@ -1273,6 +1273,165 @@
       "nullable": []
     }
   },
+  "39ce6c821ed5945ff99d62a6c19c33d8b7d6704ea06a23a719e4e04ceeef3c3c": {
+    "query": "\nselect id,\n       display_name                                                                  as \"display_name!\",\n       updated_at,\n       language                                                                      as \"language!\",\n       description                                                                   as \"description!\",\n       direction                                                                     as \"direction!: TextDirection\",\n       display_score                                                                 as \"display_score!\",\n       track_assessments                                                             as \"track_assessments!\",\n       drag_assist                                                                   as \"drag_assist!\",\n       theme                                                                         as \"theme!: ThemeId\",\n       audio_background                                                              as \"audio_background!: Option<AudioBackground>\",\n       draft_or_live                                                                 as \"draft_or_live!: DraftOrLive\",  \n       array(select row (unnest(audio_feedback_positive)))                           as \"audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>\",\n       array(select row (unnest(audio_feedback_negative)))                           as \"audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>\",\n       array(\n               select row (jig_data_module.id, kind)\n               from jig_data_module\n               where jig_data_id = jig_data.id\n               order by \"index\"\n           )                                               as \"modules!: Vec<(ModuleId, ModuleKind)>\",\n       array(select row (goal_id)\n             from jig_data_goal\n             where jig_data_id = jig_data.id)     as \"goals!: Vec<(GoalId,)>\",\n       array(select row (category_id)\n             from jig_data_category\n             where jig_data_id = jig_data.id)     as \"categories!: Vec<(CategoryId,)>\",\n       array(select row (affiliation_id)\n             from jig_data_affiliation\n             where jig_data_id = jig_data.id)     as \"affiliations!: Vec<(AffiliationId,)>\",\n       array(select row (age_range_id)\n             from jig_data_age_range\n             where jig_data_id = jig_data.id)     as \"age_ranges!: Vec<(AgeRangeId,)>\",\n       array(\n                select row (jdar.id, jdar.display_name, resource_type_id, resource_content)\n                from jig_data_additional_resource \"jdar\"\n                where jdar.jig_data_id = jig_data.id\n            )                                               as \"additional_resource!: Vec<(AddId, String, TypeId, Value)>\",\n       privacy_level                              as \"privacy_level!: PrivacyLevel\",\n       locked                                     as \"locked!\",\n       other_keywords                             as \"other_keywords!\",\n       translated_keywords                        as \"translated_keywords!\"\nfrom jig_data\n         inner join unnest($1::uuid[])\n    with ordinality t(id, ord) using (id)\norder by coalesce(updated_at, created_at) desc\nlimit 20 offset 20 * $2\n",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 1,
+          "name": "display_name!",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 2,
+          "name": "updated_at",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 3,
+          "name": "language!",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 4,
+          "name": "description!",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 5,
+          "name": "direction!: TextDirection",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 6,
+          "name": "display_score!",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 7,
+          "name": "track_assessments!",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 8,
+          "name": "drag_assist!",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 9,
+          "name": "theme!: ThemeId",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 10,
+          "name": "audio_background!: Option<AudioBackground>",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 11,
+          "name": "draft_or_live!: DraftOrLive",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 12,
+          "name": "audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 13,
+          "name": "audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 14,
+          "name": "modules!: Vec<(ModuleId, ModuleKind)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 15,
+          "name": "goals!: Vec<(GoalId,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 16,
+          "name": "categories!: Vec<(CategoryId,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 17,
+          "name": "affiliations!: Vec<(AffiliationId,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 18,
+          "name": "age_ranges!: Vec<(AgeRangeId,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 19,
+          "name": "additional_resource!: Vec<(AddId, String, TypeId, Value)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 20,
+          "name": "privacy_level!: PrivacyLevel",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 21,
+          "name": "locked!",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 22,
+          "name": "other_keywords!",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 23,
+          "name": "translated_keywords!",
+          "type_info": "Text"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "UuidArray",
+          "Int4"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        false,
+        false,
+        false,
+        false
+      ]
+    }
+  },
   "3ad66986079ea2df21f1a6af0c50510d362a19addcf3bc0f62b8f3948ea14cf8": {
     "query": "\nwith cte as (\n    select distinct style_id as id\n    from animation_style\n)\nselect id as \"id: AnimationStyleId\", display_name, created_at, updated_at\nfrom cte inner join style using (id)\norder by index\n        ",
     "describe": {
@@ -2262,6 +2421,33 @@
       ]
     }
   },
+  "695f61600966e7be0be50f3536900ac2a78517c4ef39c5386cd8f7936119ffa3": {
+    "query": "\ninsert into jig_data\n   (display_name, language, description, direction, display_score, track_assessments, drag_assist, draft_or_live)\nvalues ($1, $2, $3, $4, $5, $6, $7, $8)\nreturning id\n",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Uuid"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Text",
+          "Text",
+          "Text",
+          "Int2",
+          "Bool",
+          "Bool",
+          "Bool",
+          "Int2"
+        ]
+      },
+      "nullable": [
+        false
+      ]
+    }
+  },
   "69b512127b70875985bb54e50242397b7e362535b1a338276778abde7b695787": {
     "query": "update user_color set color = $3 where user_id = $1 and index = $2",
     "describe": {
@@ -2349,6 +2535,99 @@
       },
       "nullable": [
         false
+      ]
+    }
+  },
+  "6ffc9a09db2520683bf54bf3c12678770f68fcae5ab13336a7d86ea6ba68d616": {
+    "query": "\nselect jig.id                                       as \"id!: JigId\",\n       creator_id,\n       author_id                                as \"author_id\",\n       (select given_name || ' '::text || family_name\n        from user_profile\n        where user_profile.user_id = author_id) as \"author_name\",\n       live_id                                  as \"live_id!\",\n       draft_id                                 as \"draft_id!\",\n       published_at,\n       liked_count                              as \"liked_count!\",\n       (\n           select play_count\n           from jig_play_count\n           where jig_play_count.jig_id = jig.id\n       )                                        as \"play_count!\",\n       rating                                   as \"rating?: JigRating\",\n       blocked                                  as \"blocked!\",\n       curated                                  as \"curated!\",\n       jig_focus                                as \"jig_focus!: JigFocus\"\nfrom jig\n    inner join jig_admin_data \"admin\" on admin.jig_id = jig.id\nwhere blocked = false\n    and (author_id = $1 or $1 is null)\n    and (jig_focus = $2 or $2 is null)\n    ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id!: JigId",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 1,
+          "name": "creator_id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 2,
+          "name": "author_id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 3,
+          "name": "author_name",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 4,
+          "name": "live_id!",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 5,
+          "name": "draft_id!",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 6,
+          "name": "published_at",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 7,
+          "name": "liked_count!",
+          "type_info": "Int8"
+        },
+        {
+          "ordinal": 8,
+          "name": "play_count!",
+          "type_info": "Int8"
+        },
+        {
+          "ordinal": 9,
+          "name": "rating?: JigRating",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 10,
+          "name": "blocked!",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 11,
+          "name": "curated!",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 12,
+          "name": "jig_focus!: JigFocus",
+          "type_info": "Int2"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Int2"
+        ]
+      },
+      "nullable": [
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true
       ]
     }
   },
@@ -2761,32 +3040,6 @@
         ]
       },
       "nullable": []
-    }
-  },
-  "7aa2451fd319ecf8bfc0bc178ab2a1daccf5f26be72b1bbad3fa94c18488144c": {
-    "query": "\ninsert into jig_data\n   (display_name, language, description, direction, display_score, track_assessments, drag_assist)\nvalues ($1, $2, $3, $4, $5, $6, $7)\nreturning id\n",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id",
-          "type_info": "Uuid"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Text",
-          "Text",
-          "Text",
-          "Int2",
-          "Bool",
-          "Bool",
-          "Bool"
-        ]
-      },
-      "nullable": [
-        false
-      ]
     }
   },
   "7ae63cb702c40e9ca6ff187714217834737f1e8f1ee4a866a9fee21bacebeb74": {
@@ -3797,6 +4050,29 @@
       ]
     }
   },
+  "a26b0db193caea15a2fbcaf1801a744dff07ec4800ed4a9783893fd466f49708": {
+    "query": "\nselect count(*) as \"count!: i64\"\nfrom jig\ninner join jig_data on jig.draft_id = jig_data.id or jig.live_id = jig_data.id\nwhere (privacy_level = $1 or $1 is null)\n    and (author_id = $2 or $2 is null)\n    and (jig_focus = $3 or $3 is null)\n    and (draft_or_live = $4 or $4 is null)\n",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "count!: i64",
+          "type_info": "Int8"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int2",
+          "Uuid",
+          "Int2",
+          "Int2"
+        ]
+      },
+      "nullable": [
+        null
+      ]
+    }
+  },
   "a4970e4a6b9f203bbc4c123f495e95a26a661265f6a10d19287e1342310aaac6": {
     "query": "\nselect index     as \"index!: i16\",\n       direction as \"direction: TextDirection\",\n       display_score,\n       track_assessments,\n       drag_assist,\n       expires_at as \"expires_at: DateTime<Utc>\"\nfrom jig_player_session\nwhere jig_id = $1\n",
     "describe": {
@@ -4727,220 +5003,6 @@
       ]
     }
   },
-  "ccdb219afab7ecca4bed858e7e8209636b4664cef5e635c94e1777f440493c41": {
-    "query": "\nselect jig.id                                              as \"jig_id: JigId\",\n       privacy_level                                       as \"privacy_level: PrivacyLevel\",\n       jig_focus                                           as \"jig_focus!: JigFocus\",\n       creator_id,\n       author_id,\n       (select given_name || ' '::text || family_name\n        from user_profile\n        where user_profile.user_id = author_id)            as \"author_name\",\n       published_at,\n       liked_count,\n       (\n            select play_count\n            from jig_play_count\n            where jig_play_count.jig_id = jig.id\n       )                                                   as \"play_count!\",\n       display_name                                        as \"display_name!\",\n       updated_at,\n       language                                            as \"language!\",\n       description                                         as \"description!\",\n       direction                                           as \"direction!: TextDirection\",\n       display_score                                       as \"display_score!\",\n       track_assessments                                   as \"track_assessments!\",\n       drag_assist                                         as \"drag_assist!\",\n       theme                                               as \"theme!: ThemeId\",\n       locked                                              as \"locked!\",\n       other_keywords                                      as \"other_keywords!\",\n       translated_keywords                                 as \"translated_keywords!\",\n       rating                                              as \"rating!: Option<JigRating>\",\n       blocked                                             as \"blocked!\",\n       curated                                             as \"curated!\",\n       audio_background                                    as \"audio_background!: Option<AudioBackground>\",\n       array(select row (unnest(audio_feedback_positive))) as \"audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>\",\n       array(select row (unnest(audio_feedback_negative))) as \"audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>\",\n       array(\n               select row (jig_data_module.id, kind)\n               from jig_data_module\n               where jig_data_id = jig_data.id\n               order by \"index\"\n           )                                               as \"modules!: Vec<(ModuleId, ModuleKind)>\",\n       array(select row (goal_id)\n             from jig_data_goal\n             where jig_data_id = jig_data.id)              as \"goals!: Vec<(GoalId,)>\",\n       array(select row (category_id)\n             from jig_data_category\n             where jig_data_id = jig_data.id)              as \"categories!: Vec<(CategoryId,)>\",\n       array(select row (affiliation_id)\n             from jig_data_affiliation\n             where jig_data_id = jig_data.id)              as \"affiliations!: Vec<(AffiliationId,)>\",\n       array(select row (age_range_id)\n             from jig_data_age_range\n             where jig_data_id = jig_data.id)              as \"age_ranges!: Vec<(AgeRangeId,)>\",\n       array(\n                select row (jdar.id, jdar.display_name, resource_type_id, resource_content)\n                from jig_data_additional_resource \"jdar\"\n                where jdar.jig_data_id = jig_data.id\n            )                                               as \"additional_resource!: Vec<(AddId, String, TypeId, Value)>\"\nfrom jig_data\n         inner join jig on jig_data.id = jig.draft_id\n         inner join jig_admin_data \"admin\" on admin.jig_id = jig.id\nwhere (author_id = $2 or $2 is null)\nand (jig_focus = $3 or $3 is null)\norder by coalesce(updated_at, created_at) desc\nlimit 20 offset 20 * $1\n",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "jig_id: JigId",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 1,
-          "name": "privacy_level: PrivacyLevel",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 2,
-          "name": "jig_focus!: JigFocus",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 3,
-          "name": "creator_id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 4,
-          "name": "author_id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 5,
-          "name": "author_name",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 6,
-          "name": "published_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 7,
-          "name": "liked_count",
-          "type_info": "Int8"
-        },
-        {
-          "ordinal": 8,
-          "name": "play_count!",
-          "type_info": "Int8"
-        },
-        {
-          "ordinal": 9,
-          "name": "display_name!",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 10,
-          "name": "updated_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 11,
-          "name": "language!",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 12,
-          "name": "description!",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 13,
-          "name": "direction!: TextDirection",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 14,
-          "name": "display_score!",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 15,
-          "name": "track_assessments!",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 16,
-          "name": "drag_assist!",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 17,
-          "name": "theme!: ThemeId",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 18,
-          "name": "locked!",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 19,
-          "name": "other_keywords!",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 20,
-          "name": "translated_keywords!",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 21,
-          "name": "rating!: Option<JigRating>",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 22,
-          "name": "blocked!",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 23,
-          "name": "curated!",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 24,
-          "name": "audio_background!: Option<AudioBackground>",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 25,
-          "name": "audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 26,
-          "name": "audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 27,
-          "name": "modules!: Vec<(ModuleId, ModuleKind)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 28,
-          "name": "goals!: Vec<(GoalId,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 29,
-          "name": "categories!: Vec<(CategoryId,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 30,
-          "name": "affiliations!: Vec<(AffiliationId,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 31,
-          "name": "age_ranges!: Vec<(AgeRangeId,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 32,
-          "name": "additional_resource!: Vec<(AddId, String, TypeId, Value)>",
-          "type_info": "RecordArray"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Int4",
-          "Uuid",
-          "Int2"
-        ]
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        true,
-        true,
-        null,
-        true,
-        false,
-        null,
-        false,
-        true,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        true,
-        false,
-        false,
-        true,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-      ]
-    }
-  },
   "cd49cef54182b43dd7943bcd51fd3c535f4a8ec0dae95cbc8ceb39f7f757fe02": {
     "query": "delete from locale_entry where id = $1",
     "describe": {
@@ -4963,28 +5025,6 @@
         ]
       },
       "nullable": []
-    }
-  },
-  "d0ea56773e1b3d2ff4c33aefbbd37de5a6ff14885adf825f9c361b6e71fe303c": {
-    "query": "\nselect count(*) as \"count!: i64\"\nfrom jig\nleft join jig_data on jig.draft_id = jig_data.id\nwhere (privacy_level = $1 or $1 is null)\n    and (author_id = $2 or $2 is null)\n    and (jig_focus = $3 or $3 is null)\n",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "count!: i64",
-          "type_info": "Int8"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Int2",
-          "Uuid",
-          "Int2"
-        ]
-      },
-      "nullable": [
-        null
-      ]
     }
   },
   "d201d9e5aec8be8b9ecf9a698f834a73a0fabc887886d198e12d387b8e9d78f5": {

--- a/backend/api/src/http/endpoints/jig.rs
+++ b/backend/api/src/http/endpoints/jig.rs
@@ -207,12 +207,19 @@ async fn browse(
         db.as_ref(),
         author_id,
         query.jig_focus,
+        query.draft_or_live,
         query.page.unwrap_or(0) as i32,
     )
     .await?;
 
-    let total_count =
-        db::jig::filtered_count(db.as_ref(), None, author_id, query.jig_focus).await?;
+    let total_count = db::jig::filtered_count(
+        db.as_ref(),
+        None,
+        author_id,
+        query.jig_focus,
+        query.draft_or_live,
+    )
+    .await?;
 
     let pages = (total_count / 20 + (total_count % 20 != 0) as u64) as u32;
 

--- a/backend/api/tests/integration/jig/snapshots/integration__jig__cover__update_no_modules_changes.snap
+++ b/backend/api/tests/integration/jig/snapshots/integration__jig__cover__update_no_modules_changes.snap
@@ -13,7 +13,7 @@ expression: body
   "plays": 0,
   "jigFocus": "modules",
   "jigData": {
-    "draftOrLive": "Draft",
+    "draftOrLive": "draft",
     "displayName": "test",
     "modules": [
       {

--- a/backend/api/tests/integration/snapshots/integration__jig__browse_own_simple.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__browse_own_simple.snap
@@ -15,7 +15,77 @@ expression: body
       "plays": 0,
       "jigFocus": "modules",
       "jigData": {
-        "draftOrLive": "Draft",
+        "draftOrLive": "live",
+        "displayName": "name",
+        "modules": [
+          {
+            "id": "a6b248f8-1dd7-11ec-8426-975953035335",
+            "kind": "Cover"
+          },
+          {
+            "id": "a6b24970-1dd7-11ec-8426-57136b411853",
+            "kind": "Flashcards"
+          },
+          {
+            "id": "a6b249c0-1dd7-11ec-8426-f77e58fd17c6",
+            "kind": "Memory"
+          }
+        ],
+        "ageRanges": [],
+        "affiliations": [],
+        "goals": [],
+        "language": "en",
+        "categories": [],
+        "additionalResources": [
+          {
+            "id": "286b828c-1dd9-11ec-8426-571b03b2d3df",
+            "displayName": "link test",
+            "resourceTypeId": "a91aca34-519e-11ec-ab46-175eaaf1ff23",
+            "link": "url://url.url.url/urlese"
+          },
+          {
+            "id": "286b82fa-1dd9-11ec-8426-2b6953011bae",
+            "displayName": "link test",
+            "resourceTypeId": "a91aca34-519e-11ec-ab46-175eaaf1ff23",
+            "link": "url://url.url.url/url"
+          }
+        ],
+        "description": "test description",
+        "lastEdited": "[last_edited]",
+        "defaultPlayerSettings": {
+          "direction": "ltr",
+          "displayScore": true,
+          "trackAssessments": true,
+          "dragAssist": true
+        },
+        "theme": "Blank",
+        "audioBackground": null,
+        "audioEffects": {
+          "feedbackPositive": "[audio]",
+          "feedbackNegative": "[audio]"
+        },
+        "privacyLevel": "public",
+        "locked": false,
+        "otherKeywords": "",
+        "translatedKeywords": ""
+      },
+      "adminData": {
+        "rating": null,
+        "blocked": false,
+        "curated": false
+      }
+    },
+    {
+      "id": "3a71522a-cd77-11eb-8dc1-af3e35f7c743",
+      "publishedAt": null,
+      "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
+      "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
+      "authorName": "Bobby Tables",
+      "likes": 0,
+      "plays": 0,
+      "jigFocus": "modules",
+      "jigData": {
+        "draftOrLive": "draft",
         "displayName": "name",
         "modules": [
           {
@@ -74,52 +144,8 @@ expression: body
         "blocked": false,
         "curated": false
       }
-    },
-    {
-      "id": "3a71522a-cd77-11eb-8dc1-af3e35f7c743",
-      "publishedAt": null,
-      "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
-      "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
-      "authorName": "Bobby Tables",
-      "likes": 0,
-      "plays": 0,
-      "jigFocus": "modules",
-      "jigData": {
-        "draftOrLive": "Draft",
-        "displayName": "draft name",
-        "modules": [],
-        "ageRanges": [],
-        "affiliations": [],
-        "goals": [],
-        "language": "he",
-        "categories": [],
-        "additionalResources": [],
-        "description": "draft test description",
-        "lastEdited": "[last_edited]",
-        "defaultPlayerSettings": {
-          "direction": "rtl",
-          "displayScore": false,
-          "trackAssessments": false,
-          "dragAssist": false
-        },
-        "theme": "Jigzi",
-        "audioBackground": "funForKids",
-        "audioEffects": {
-          "feedbackPositive": "[audio]",
-          "feedbackNegative": "[audio]"
-        },
-        "privacyLevel": "unlisted",
-        "locked": false,
-        "otherKeywords": "",
-        "translatedKeywords": ""
-      },
-      "adminData": {
-        "rating": null,
-        "blocked": false,
-        "curated": false
-      }
     }
   ],
   "pages": 1,
-  "totalJigCount": 2
+  "totalJigCount": 4
 }

--- a/backend/api/tests/integration/snapshots/integration__jig__browse_simple.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__browse_simple.snap
@@ -15,7 +15,77 @@ expression: body
       "plays": 0,
       "jigFocus": "modules",
       "jigData": {
-        "draftOrLive": "Draft",
+        "draftOrLive": "live",
+        "displayName": "name",
+        "modules": [
+          {
+            "id": "a6b248f8-1dd7-11ec-8426-975953035335",
+            "kind": "Cover"
+          },
+          {
+            "id": "a6b24970-1dd7-11ec-8426-57136b411853",
+            "kind": "Flashcards"
+          },
+          {
+            "id": "a6b249c0-1dd7-11ec-8426-f77e58fd17c6",
+            "kind": "Memory"
+          }
+        ],
+        "ageRanges": [],
+        "affiliations": [],
+        "goals": [],
+        "language": "en",
+        "categories": [],
+        "additionalResources": [
+          {
+            "id": "286b828c-1dd9-11ec-8426-571b03b2d3df",
+            "displayName": "link test",
+            "resourceTypeId": "a91aca34-519e-11ec-ab46-175eaaf1ff23",
+            "link": "url://url.url.url/urlese"
+          },
+          {
+            "id": "286b82fa-1dd9-11ec-8426-2b6953011bae",
+            "displayName": "link test",
+            "resourceTypeId": "a91aca34-519e-11ec-ab46-175eaaf1ff23",
+            "link": "url://url.url.url/url"
+          }
+        ],
+        "description": "test description",
+        "lastEdited": "[last_edited]",
+        "defaultPlayerSettings": {
+          "direction": "ltr",
+          "displayScore": true,
+          "trackAssessments": true,
+          "dragAssist": true
+        },
+        "theme": "Blank",
+        "audioBackground": null,
+        "audioEffects": {
+          "feedbackPositive": "[audio]",
+          "feedbackNegative": "[audio]"
+        },
+        "privacyLevel": "public",
+        "locked": false,
+        "otherKeywords": "",
+        "translatedKeywords": ""
+      },
+      "adminData": {
+        "rating": null,
+        "blocked": false,
+        "curated": false
+      }
+    },
+    {
+      "id": "3a71522a-cd77-11eb-8dc1-af3e35f7c743",
+      "publishedAt": null,
+      "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
+      "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
+      "authorName": "Bobby Tables",
+      "likes": 0,
+      "plays": 0,
+      "jigFocus": "modules",
+      "jigData": {
+        "draftOrLive": "draft",
         "displayName": "name",
         "modules": [
           {
@@ -74,52 +144,8 @@ expression: body
         "blocked": false,
         "curated": false
       }
-    },
-    {
-      "id": "3a71522a-cd77-11eb-8dc1-af3e35f7c743",
-      "publishedAt": null,
-      "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
-      "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
-      "authorName": "Bobby Tables",
-      "likes": 0,
-      "plays": 0,
-      "jigFocus": "modules",
-      "jigData": {
-        "draftOrLive": "Draft",
-        "displayName": "draft name",
-        "modules": [],
-        "ageRanges": [],
-        "affiliations": [],
-        "goals": [],
-        "language": "he",
-        "categories": [],
-        "additionalResources": [],
-        "description": "draft test description",
-        "lastEdited": "[last_edited]",
-        "defaultPlayerSettings": {
-          "direction": "rtl",
-          "displayScore": false,
-          "trackAssessments": false,
-          "dragAssist": false
-        },
-        "theme": "Jigzi",
-        "audioBackground": "funForKids",
-        "audioEffects": {
-          "feedbackPositive": "[audio]",
-          "feedbackNegative": "[audio]"
-        },
-        "privacyLevel": "unlisted",
-        "locked": false,
-        "otherKeywords": "",
-        "translatedKeywords": ""
-      },
-      "adminData": {
-        "rating": null,
-        "blocked": false,
-        "curated": false
-      }
     }
   ],
   "pages": 1,
-  "totalJigCount": 2
+  "totalJigCount": 4
 }

--- a/backend/api/tests/integration/snapshots/integration__jig__clone-2.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__clone-2.snap
@@ -13,7 +13,7 @@ expression: body
   "plays": 0,
   "jigFocus": "modules",
   "jigData": {
-    "draftOrLive": "Live",
+    "draftOrLive": "live",
     "displayName": "name",
     "modules": [],
     "ageRanges": [],

--- a/backend/api/tests/integration/snapshots/integration__jig__clone.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__clone.snap
@@ -13,7 +13,7 @@ expression: body
   "plays": 0,
   "jigFocus": "modules",
   "jigData": {
-    "draftOrLive": "Draft",
+    "draftOrLive": "draft",
     "displayName": "draft name",
     "modules": [],
     "ageRanges": [],

--- a/backend/api/tests/integration/snapshots/integration__jig__create_default-2.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__create_default-2.snap
@@ -13,7 +13,7 @@ expression: body
   "plays": 0,
   "jigFocus": "modules",
   "jigData": {
-    "draftOrLive": "Draft",
+    "draftOrLive": "draft",
     "displayName": "",
     "modules": [],
     "ageRanges": [],

--- a/backend/api/tests/integration/snapshots/integration__jig__create_default-3.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__create_default-3.snap
@@ -13,7 +13,7 @@ expression: body
   "plays": 0,
   "jigFocus": "modules",
   "jigData": {
-    "draftOrLive": "Live",
+    "draftOrLive": "live",
     "displayName": "",
     "modules": [],
     "ageRanges": [],

--- a/backend/api/tests/integration/snapshots/integration__jig__get-2.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__get-2.snap
@@ -13,7 +13,7 @@ expression: body
   "plays": 0,
   "jigFocus": "modules",
   "jigData": {
-    "draftOrLive": "Live",
+    "draftOrLive": "live",
     "displayName": "name",
     "modules": [
       {

--- a/backend/api/tests/integration/snapshots/integration__jig__get.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__get.snap
@@ -13,7 +13,7 @@ expression: body
   "plays": 0,
   "jigFocus": "modules",
   "jigData": {
-    "draftOrLive": "Draft",
+    "draftOrLive": "draft",
     "displayName": "name",
     "modules": [
       {

--- a/backend/api/tests/integration/snapshots/integration__jig__update_and_publish-2.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__update_and_publish-2.snap
@@ -13,7 +13,7 @@ expression: body
   "plays": 0,
   "jigFocus": "modules",
   "jigData": {
-    "draftOrLive": "Draft",
+    "draftOrLive": "draft",
     "displayName": "draft name",
     "modules": [],
     "ageRanges": [],

--- a/backend/api/tests/integration/snapshots/integration__jig__update_and_publish-3.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__update_and_publish-3.snap
@@ -13,7 +13,7 @@ expression: body
   "plays": 0,
   "jigFocus": "modules",
   "jigData": {
-    "draftOrLive": "Live",
+    "draftOrLive": "live",
     "displayName": "name",
     "modules": [],
     "ageRanges": [],

--- a/backend/api/tests/integration/snapshots/integration__jig__update_and_publish-4.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__update_and_publish-4.snap
@@ -13,7 +13,7 @@ expression: body
   "plays": 0,
   "jigFocus": "modules",
   "jigData": {
-    "draftOrLive": "Live",
+    "draftOrLive": "live",
     "displayName": "draft name",
     "modules": [],
     "ageRanges": [],

--- a/backend/api/tests/integration/snapshots/integration__jig__update_and_publish.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__update_and_publish.snap
@@ -13,7 +13,7 @@ expression: body
   "plays": 0,
   "jigFocus": "modules",
   "jigData": {
-    "draftOrLive": "Draft",
+    "draftOrLive": "draft",
     "displayName": "draft name",
     "modules": [],
     "ageRanges": [],

--- a/shared/rust/src/domain/jig.rs
+++ b/shared/rust/src/domain/jig.rs
@@ -169,6 +169,7 @@ pub struct JigCreateRequest {
 /// Whether the data is draft or live.
 #[derive(Serialize, Deserialize, Clone, Copy, Debug)]
 #[cfg_attr(feature = "backend", derive(sqlx::Type))]
+#[serde(rename_all = "camelCase")]
 #[repr(i16)]
 pub enum DraftOrLive {
     /// Represents a draft copy
@@ -707,6 +708,11 @@ pub struct JigBrowseQuery {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub jig_focus: Option<JigFocus>,
+
+    /// Optionally browse by draft or live.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub draft_or_live: Option<DraftOrLive>,
 }
 
 /// Response for [`Browse`](crate::api::endpoints::jig::Browse).


### PR DESCRIPTION
#2177 

- Added filter to browse for draft or live jigs in Jig Browse.
- Added migration: 
> - for purging `jig_data_id` not associated with a `jig_id`, 
> - adding `int2` column `draft_or_live` and updated this field with corresponding draft or live value for each entry in jig data.