### PR TITLE
fix(fe/tooltips): Show the permanently close button in tooltips

### DIFF
--- a/frontend/apps/crates/components/src/jigzi_help/actions.rs
+++ b/frontend/apps/crates/components/src/jigzi_help/actions.rs
@@ -3,6 +3,7 @@ use std::rc::Rc;
 use dominator::clone;
 use gloo_timers::future::TimeoutFuture;
 use wasm_bindgen_futures::spawn_local;
+use utils::{storage, unwrap::UnwrapJiExt};
 
 use super::JigziHelp;
 
@@ -15,5 +16,17 @@ impl JigziHelp {
             TimeoutFuture::new(INFO_TOOLTIP_DELAY).await;
             state.show_info_tooltip.set(true);
         }));
+    }
+
+    pub(super) fn permanently_close(self: &Rc<Self>) {
+        let state = self;
+
+        if state.show_id != "debug" {
+            self.permanently_closed.set(true);
+
+            let _ = storage::get_local_storage()
+                .unwrap_ji()
+                .set_item(&format!("tooltip-{}", state.show_id), "hidden");
+        }
     }
 }

--- a/frontend/apps/crates/components/src/jigzi_help/state.rs
+++ b/frontend/apps/crates/components/src/jigzi_help/state.rs
@@ -1,12 +1,14 @@
 use std::rc::Rc;
 
 use futures_signals::signal::Mutable;
+use utils::{storage, unwrap::UnwrapJiExt};
 
 pub struct JigziHelp {
     pub title: String,
     pub body: String,
     pub show_id: String,
     pub show_info_tooltip: Mutable<bool>,
+    pub(super) permanently_closed: Mutable<bool>,
 }
 
 impl JigziHelp {
@@ -15,11 +17,18 @@ impl JigziHelp {
         body: String,
         show_id: &str,
     ) -> Rc<Self> {
+        let permanently_closed = storage::get_local_storage()
+            .unwrap_ji()
+            .get_item(&format!("tooltip-{}", show_id))
+            .unwrap_ji()
+            .map_or(false, |v| v == "hidden");
+
         Rc::new(Self {
             title,
             body,
             show_id: show_id.to_string(),
             show_info_tooltip: Mutable::new(false),
+            permanently_closed: Mutable::new(permanently_closed),
         })
     }
 }

--- a/frontend/apps/crates/utils/src/events.rs
+++ b/frontend/apps/crates/utils/src/events.rs
@@ -14,6 +14,7 @@ temp_make_event!(Ready, "ready" => web_sys::Event);
 
 temp_make_event!(Open, "open" => web_sys::Event);
 temp_make_event!(Close, "close" => web_sys::Event);
+temp_make_event!(PermanentlyClose, "permanently-close" => web_sys::Event);
 
 temp_make_event!(Submit, "submit" => web_sys::Event);
 

--- a/frontend/elements/src/core/overlays/tooltip/info.ts
+++ b/frontend/elements/src/core/overlays/tooltip/info.ts
@@ -78,6 +78,8 @@ export class _ extends LitElement {
                     margin: 8px 0 36px 0;
                 }
                 .noshow {
+                    background: transparent;
+                    border: none;
                     font-size: 13px;
                     font-weight: 500;
                     color: var(--light-blue-4);
@@ -196,7 +198,7 @@ export class _ extends LitElement {
             this.onClose();
         };
         return html`
-            <div @click=${onClick} class="noshow">${STR_NO_SHOW_AGAIN}</div>
+            <button @click=${onClick} class="noshow">${STR_NO_SHOW_AGAIN}</button>
         `;
     }
 

--- a/frontend/elements/src/core/overlays/tooltip/info.ts
+++ b/frontend/elements/src/core/overlays/tooltip/info.ts
@@ -92,16 +92,8 @@ export class _ extends LitElement {
         super.connectedCallback();
 
         window.addEventListener("mousedown", this.onGlobalMouseDown);
-
-        const { showId } = this;
-
-        if (showId !== "" && showId !== "debug") {
-            if (localStorage.getItem("tooltip-" + showId) === "hidden") {
-                //hiding due to storage
-                this.onClose();
-            }
-        }
     }
+
     disconnectedCallback() {
         super.disconnectedCallback();
         window.removeEventListener("mousedown", this.onGlobalMouseDown);
@@ -134,8 +126,8 @@ export class _ extends LitElement {
     @property()
     body: string = "";
 
-    @property()
-    showId: string | "debug" = "";
+    @property({ type: Boolean })
+    showPermanentlyClose: boolean = false;
 
     @property({ type: Boolean })
     closeable: boolean = false;
@@ -181,6 +173,33 @@ export class _ extends LitElement {
     @property({ type: Number })
     arrowNudge: number = 0;
 
+
+    renderClose() {
+        if (!this.closeable) {
+            return nothing;
+        }
+
+        return html`
+            <button class="close-button" @click=${this.onClose}>
+                <fa-icon icon="fa-light fa-xmark"></fa-icon>
+            </button>
+        `;
+    }
+
+    renderPermanentlyClose() {
+        if (!this.showPermanentlyClose) {
+            return nothing;
+        }
+
+        const onClick = () => {
+            this.dispatchEvent(new Event("permanently-close"));
+            this.onClose();
+        };
+        return html`
+            <div @click=${onClick} class="noshow">${STR_NO_SHOW_AGAIN}</div>
+        `;
+    }
+
     render() {
         const {
             container,
@@ -192,10 +211,8 @@ export class _ extends LitElement {
             marginY,
             contentAnchor,
             targetAnchor,
-            closeable,
             title,
             body,
-            showId,
             arrowNudge,
         } = this;
 
@@ -227,16 +244,14 @@ export class _ extends LitElement {
                     .arrowNudge=${arrowNudge}
                 >
                     <section class="content">
-                        ${closeable ? renderClose(this.onClose) : nothing}
+                        ${this.renderClose()}
                         ${title !== ""
                             ? html`<div class="title">${title}</div>`
                             : nothing}
                         ${body !== ""
                             ? html`<section class="body">${body}</section>`
                             : nothing}
-                        ${showId !== ""
-                            ? renderShowId(showId, this.onClose)
-                            : nothing}
+                        ${this.renderPermanentlyClose()}
                     </section>
                 </tooltip-container>
             </overlay-content>
@@ -244,26 +259,3 @@ export class _ extends LitElement {
     }
 }
 
-function renderClose(onClose: () => any) {
-    return html`
-        <button class="close-button" @click=${onClose}>
-            <fa-icon icon="fa-light fa-xmark"></fa-icon>
-        </button>
-    `;
-}
-
-function renderShowId(showId: string, onClose: () => any) {
-    const onClick = () => {
-        if (showId === "debug") {
-            //skipping showId action because it's debug
-        } else {
-            //setting ${showId}
-            localStorage.setItem("tooltip-" + showId, "hidden");
-        }
-
-        onClose();
-    };
-    return html`
-        <div @click=${onClick} class="noshow">${STR_NO_SHOW_AGAIN}</div>
-    `;
-}


### PR DESCRIPTION
Resolves #2103 

- Adds back the "Don't show tips again" button
- Moves the buttons logic out of the element and into the JigziHelp component
  - For now no other code uses that button. In the future we can create a dedicated tooltip component to handle that logic.
- Converts the button to a  `<button />` instead of a `<div />` 

![image](https://user-images.githubusercontent.com/4161106/149068829-4b925f3d-da33-4d98-baa3-5eb3c716bf8c.png)
