### PR TITLE
feat: change listen & learn choices

### DIFF
--- a/shared/rust/src/domain/jig/module/body/tapping_board.rs
+++ b/shared/rust/src/domain/jig/module/body/tapping_board.rs
@@ -130,8 +130,6 @@ pub enum Mode {
     Talk,
     /// Read mode
     Read,
-    /// Draw mode
-    Draw,
     /// Scene mode
     Scene,
     /// Photo album mode
@@ -157,7 +155,6 @@ impl ModeExt for Mode {
             Self::Images,
             Self::Talk,
             Self::Read,
-            Self::Draw,
             Self::Scene,
             Self::PhotoAlbum,
             Self::Comic,
@@ -172,7 +169,6 @@ impl ModeExt for Mode {
             Self::Images => "images",
             Self::Talk => "talk",
             Self::Read => "read",
-            Self::Draw => "draw",
             Self::Scene => "scene",
             Self::PhotoAlbum => "photo-album",
             Self::Comic => "comic",
@@ -186,7 +182,6 @@ impl ModeExt for Mode {
         const STR_IMAGES_LABEL: &'static str = "Images";
         const STR_TALK_LABEL: &'static str = "Talking Pictures";
         const STR_READ_LABEL: &'static str = "Read Along";
-        const STR_DRAW_LABEL: &'static str = "Interactive drawing";
         const STR_SCENE_LABEL: &'static str = "Scene";
         const STR_PHOTO_ALBUM_LABEL: &'static str = "Photo Album";
         const STR_COMIC_LABEL: &'static str = "Comics";
@@ -198,7 +193,6 @@ impl ModeExt for Mode {
             Self::Images => STR_IMAGES_LABEL,
             Self::Talk => STR_TALK_LABEL,
             Self::Read => STR_READ_LABEL,
-            Self::Draw => STR_DRAW_LABEL,
             Self::Scene => STR_SCENE_LABEL,
             Self::PhotoAlbum => STR_PHOTO_ALBUM_LABEL,
             Self::Comic => STR_COMIC_LABEL,

--- a/shared/rust/src/domain/jig/module/body/tapping_board.rs
+++ b/shared/rust/src/domain/jig/module/body/tapping_board.rs
@@ -136,6 +136,12 @@ pub enum Mode {
     Scene,
     /// Photo album mode
     PhotoAlbum,
+    /// Comic mode
+    Comic,
+    /// Timeline mode
+    Timeline,
+    /// Family Tree mode
+    FamilyTree,
 }
 
 impl Default for Mode {
@@ -154,6 +160,9 @@ impl ModeExt for Mode {
             Self::Draw,
             Self::Scene,
             Self::PhotoAlbum,
+            Self::Comic,
+            Self::Timeline,
+            Self::FamilyTree,
         ]
     }
 
@@ -166,17 +175,23 @@ impl ModeExt for Mode {
             Self::Draw => "draw",
             Self::Scene => "scene",
             Self::PhotoAlbum => "photo-album",
+            Self::Comic => "comic",
+            Self::Timeline => "timeline",
+            Self::FamilyTree => "family-tree",
         }
     }
 
     fn label(&self) -> &'static str {
-        const STR_WORDS_LABEL: &'static str = "Tap words & hear";
-        const STR_IMAGES_LABEL: &'static str = "Tap images & hear";
-        const STR_TALK_LABEL: &'static str = "Tap & talk";
-        const STR_READ_LABEL: &'static str = "Tap & read";
+        const STR_WORDS_LABEL: &'static str = "Words";
+        const STR_IMAGES_LABEL: &'static str = "Images";
+        const STR_TALK_LABEL: &'static str = "Talking Pictures";
+        const STR_READ_LABEL: &'static str = "Read Along";
         const STR_DRAW_LABEL: &'static str = "Interactive drawing";
-        const STR_SCENE_LABEL: &'static str = "Interactive scene";
-        const STR_PHOTO_ALBUM_LABEL: &'static str = "Interactive photo album";
+        const STR_SCENE_LABEL: &'static str = "Scene";
+        const STR_PHOTO_ALBUM_LABEL: &'static str = "Photo Album";
+        const STR_COMIC_LABEL: &'static str = "Comics";
+        const STR_TIMELINE_LABEL: &'static str = "Timeline";
+        const STR_FAMILY_TREE_LABEL: &'static str = "Family Tree";
 
         match self {
             Self::Words => STR_WORDS_LABEL,
@@ -186,6 +201,9 @@ impl ModeExt for Mode {
             Self::Draw => STR_DRAW_LABEL,
             Self::Scene => STR_SCENE_LABEL,
             Self::PhotoAlbum => STR_PHOTO_ALBUM_LABEL,
+            Self::Comic => STR_COMIC_LABEL,
+            Self::Timeline => STR_TIMELINE_LABEL,
+            Self::FamilyTree => STR_FAMILY_TREE_LABEL,
         }
     }
 }


### PR DESCRIPTION
closes #2201

Programmatical changes are ready for this PR.

The missing piece for sandbox is the media for the 3 new choice. Here are the routes that the front-end is requesting pictures from.

- https://media.jicloud.org/ui/module/tapping-board/edit/choose/comic.png
- https://media.jicloud.org/ui/module/tapping-board/edit/choose/timeline.png
- https://media.jicloud.org/ui/module/tapping-board/edit/choose/family-tree.png

This is similar to when we added the picture to the empty module on the jig sidebar. I can't yet add pictures to the media server yet. @MendyBerger, is it possible if you could upload those pictures for me? That or we could talk about getting me DropBox credentials so I can do so as well.

Thank you so much 🙏

![image](https://user-images.githubusercontent.com/13839150/149069274-23536ef1-eb56-4098-a6f2-a0b94dc3d52e.png)
![image](https://user-images.githubusercontent.com/13839150/149069279-9ad342f7-7202-40e3-b4c1-c874fe5ae2a9.png)
![image](https://user-images.githubusercontent.com/13839150/149069290-65d23d79-967d-429b-b775-105fdadcafb2.png)
