### PR TITLE
fix(fe/components): Force dominator to release previous DomHandles

### DIFF
--- a/frontend/apps/crates/components/src/module/_common/edit/entry/state.rs
+++ b/frontend/apps/crates/components/src/module/_common/edit/entry/state.rs
@@ -1,4 +1,4 @@
-use dominator::clone;
+use dominator::{clone, DomHandle};
 use futures_signals::signal::{Mutable, Signal, SignalExt};
 
 use std::cell::RefCell;
@@ -52,6 +52,7 @@ where
     pub(super) history: RefCell<Option<Rc<HistoryStateImpl<RawData>>>>,
     pub(super) raw_loaded: Mutable<bool>,
     pub(super) page_body_switcher: AsyncLoader,
+    pub(super) dom_body_handle: Mutable<Option<DomHandle>>,
     pub(super) reset_from_history_loader: AsyncLoader,
     pub(super) on_init_ready: RefCell<Option<Box<dyn Fn()>>>,
 }
@@ -144,6 +145,7 @@ where
             screenshot_loader: Rc::new(AsyncLoader::new()),
             save_loader: Rc::new(AsyncLoader::new()),
             page_body_switcher: AsyncLoader::new(),
+            dom_body_handle: Mutable::new(None),
             reset_from_history_loader: AsyncLoader::new(),
             on_init_ready: RefCell::new(None),
         });

--- a/frontend/apps/crates/components/src/module/_common/play/entry/state.rs
+++ b/frontend/apps/crates/components/src/module/_common/play/entry/state.rs
@@ -1,5 +1,5 @@
 use crate::audio::mixer::AUDIO_MIXER;
-use dominator::{clone, Dom};
+use dominator::{clone, Dom, DomHandle};
 use dominator_helpers::futures::AsyncLoader;
 use futures_signals::signal::Mutable;
 use shared::domain::jig::module::body::Instructions;
@@ -34,6 +34,7 @@ where
     pub(super) opts: StateOpts<RawData>,
     pub(super) raw_loader: AsyncLoader,
     pub(super) page_body_switcher: AsyncLoader,
+    pub(super) dom_body_handle: Mutable<Option<DomHandle>>,
     phantom: PhantomData<(Mode, Step)>,
 }
 
@@ -83,6 +84,7 @@ where
             phase: Mutable::new(Rc::new(InitPhase::Loading(loading_kind))),
             raw_loader: AsyncLoader::new(),
             page_body_switcher: AsyncLoader::new(),
+            dom_body_handle: Mutable::new(None),
             phantom: PhantomData,
         });
 


### PR DESCRIPTION
Resolves #2110 

- Calling `set_inner_html` on an `HtmlElement` does not drop references held for that element. This is because the underlying `DomHandle` that dominator knows about still exists. This change forces dominator to release references held by the previous handle whenever a new signal is fired to render a new body for a page.