### PR TITLE
feat(fe/search): Hide search results when the total is 0

### DIFF
--- a/frontend/apps/crates/entry/home/src/home/actions.rs
+++ b/frontend/apps/crates/entry/home/src/home/actions.rs
@@ -79,7 +79,7 @@ async fn fetch_profile(state: Rc<State>) {
 }
 
 async fn search_async(state: Rc<State>) {
-    let search_state = SearchResults::new(&state);
+    let search_state = SearchResults::new(&state, true);
     state.mode.set(HomePageMode::Search(Rc::clone(&search_state)));
 
     let req = state.search_selected.to_search_request();
@@ -89,6 +89,8 @@ async fn search_async(state: Rc<State>) {
         search_state.jigs.load_items(req.clone()),
         search_state.resources.load_items(req),
     );
+
+    search_state.loading.set(false);
 }
 
 pub fn search(state: Rc<State>) {

--- a/frontend/apps/crates/entry/home/src/home/search_results/dom.rs
+++ b/frontend/apps/crates/entry/home/src/home/search_results/dom.rs
@@ -1,21 +1,29 @@
-
-
-use dominator::{html, Dom};
-
-
+use dominator::{clone, html, Dom};
+use futures_signals::signal::SignalExt;
 use std::rc::Rc;
-
+use crate::home::search_results::search_results_section::SearchResultsSection;
 
 use super::state::SearchResults;
 
 impl SearchResults {
     pub fn render(self: &Rc<Self>) -> Dom {
         let state = self;
+
+        let search_results_signal = |state: Rc<SearchResultsSection>| {
+            state.total.signal_cloned().map(clone!(state => move |total| {
+                if total > 0 {
+                    Some(state.render())
+                } else {
+                    None
+                }
+            }))
+        };
+
         html!("home-search-results", {
             .property_signal("resultsCount", state.total_results_count_signal())
             .property("query", &state.query)
-            .child(state.jigs.render())
-            .child(state.resources.render())
+            .child_signal(search_results_signal(state.jigs.clone()))
+            .child_signal(search_results_signal(state.resources.clone()))
         })
     }
 }

--- a/frontend/apps/crates/entry/home/src/home/search_results/dom.rs
+++ b/frontend/apps/crates/entry/home/src/home/search_results/dom.rs
@@ -1,5 +1,5 @@
-use dominator::{clone, html, Dom};
-use futures_signals::signal::SignalExt;
+use dominator::{html, Dom};
+use futures_signals::{signal::SignalExt, map_ref};
 use std::rc::Rc;
 use crate::home::search_results::search_results_section::SearchResultsSection;
 
@@ -9,17 +9,29 @@ impl SearchResults {
     pub fn render(self: &Rc<Self>) -> Dom {
         let state = self;
 
-        let search_results_signal = |state: Rc<SearchResultsSection>| {
-            state.total.signal_cloned().map(clone!(state => move |total| {
-                if total > 0 {
-                    Some(state.render())
+        let search_results_signal = |section: Rc<SearchResultsSection>| {
+            // Ensure that jigs and resources are rendered until all requests have completed
+            let should_render_signal = map_ref! {
+                let loading = state.loading.signal_cloned(),
+                let total = section.total.signal_cloned()
+                    => {
+                        !*loading && *total > 0
+                    }
+            };
+
+            // Map the search results render call outside of map_ref so that we don't capture
+            // `section` inside the closure.
+            should_render_signal.map(move |should_render| {
+                if should_render {
+                    Some(section.render())
                 } else {
                     None
                 }
-            }))
+            })
         };
 
         html!("home-search-results", {
+            .property_signal("loading", state.loading.signal())
             .property_signal("resultsCount", state.total_results_count_signal())
             .property("query", &state.query)
             .child_signal(search_results_signal(state.jigs.clone()))

--- a/frontend/elements/src/entry/home/home/search-results/search-results.ts
+++ b/frontend/elements/src/entry/home/home/search-results/search-results.ts
@@ -2,8 +2,12 @@ import { LitElement, html, css, customElement, property } from "lit-element";
 import { nothing } from "lit-html";
 
 const STR_WE_FOUND = "We found";
+const STR_NONE_FOUND = "Oh snap! We couldn't find any matches";
+
 const STR_RESULTS = "results";
 const STR_FOR = "for";
+
+const STR_LOADING = "So many great JIGs and resources to sift through...";
 
 @customElement("home-search-results")
 export class _ extends LitElement {
@@ -29,26 +33,60 @@ export class _ extends LitElement {
         ];
     }
 
+    @property({ type: Boolean })
+    loading: boolean = false;
+
     @property()
     query: string = "";
 
     @property({ type: Number })
     resultsCount?: number = 0;
 
+    renderResultsFound() {
+        return html`
+            <h1>
+                ${STR_WE_FOUND}
+                <span class="results-count">${this.resultsCount}</span>
+                ${STR_RESULTS}
+                ${
+                    this.query.trim() !== "" ? html`
+                        ${STR_FOR}
+                        <span class="query">${this.query}</span>
+                    ` : nothing
+                }
+            </h1>
+        `;
+    }
+
+    renderNoResultsFound() {
+        return html`
+            <h1>
+                ${STR_NONE_FOUND}
+                ${
+                    this.query.trim() !== "" ? html`
+                        ${STR_FOR}
+                        <span class="query">${this.query}</span>
+                    ` : nothing
+                }
+            </h1>
+        `;
+    }
+
+    renderLoading() {
+        return html`
+            <h1>${STR_LOADING}</h1>
+        `;
+    }
+
     render() {
         return html`
+            ${this.loading
+                ? this.renderLoading()
+                : this.resultsCount
+                    ? this.renderResultsFound()
+                    : this.renderNoResultsFound()
+            }
             <div class="main">
-                <h1>
-                    ${STR_WE_FOUND}
-                    <span class="results-count">${this.resultsCount}</span>
-                    ${STR_RESULTS}
-                    ${
-                        this.query.trim() !== "" ? html`
-                            ${STR_FOR}
-                            <span class="query">${this.query}</span>
-                        ` : nothing
-                    }
-                </h1>
                 <slot name="sections"></slot>
             </div>
         `;


### PR DESCRIPTION
Part of #2155 

- Hides jigs/resources sections when their totals are 0
- Adds searching text `"So many great JIGs and resources to sift through..."`
- Adds no results found text `"Oh snap! We couldn't find any matches for [query]"`
- Only shows results once both jigs and resources searches have completed