### PR TITLE
feat(fe/search): Add search section anchors to result text

### DIFF
--- a/frontend/apps/crates/entry/home/src/home/search_results/dom.rs
+++ b/frontend/apps/crates/entry/home/src/home/search_results/dom.rs
@@ -32,7 +32,8 @@ impl SearchResults {
 
         html!("home-search-results", {
             .property_signal("loading", state.loading.signal())
-            .property_signal("resultsCount", state.total_results_count_signal())
+            .property_signal("jigCount", state.jigs.total.signal())
+            .property_signal("resourceCount", state.resources.total.signal())
             .property("query", &state.query)
             .child_signal(search_results_signal(state.jigs.clone()))
             .child_signal(search_results_signal(state.resources.clone()))

--- a/frontend/elements/src/entry/home/home/search-results/search-results.ts
+++ b/frontend/elements/src/entry/home/home/search-results/search-results.ts
@@ -1,13 +1,18 @@
 import { LitElement, html, css, customElement, property } from "lit-element";
-import { nothing } from "lit-html";
+import { nothing, TemplateResult } from "lit-html";
 
 const STR_WE_FOUND = "We found";
 const STR_NONE_FOUND = "Oh snap! We couldn't find any matches";
 
-const STR_RESULTS = "results";
 const STR_FOR = "for";
 
 const STR_LOADING = "So many great JIGs and resources to sift through...";
+
+const KINDS: {[key: string]: string[]} = {
+    jigs: ["JIG", "JIGs"],
+    resources: ["Resource", "Resources"],
+};
+const STR_AND = "and";
 
 @customElement("home-search-results")
 export class _ extends LitElement {
@@ -24,10 +29,14 @@ export class _ extends LitElement {
                     text-align: center;
                     font-weight: normal;
                 }
-                h1 .results-count,
+                h1 a,
                 h1 .query {
                     color: #fd7076;
                     font-weight: bold;
+                }
+
+                h1 a {
+                    text-decoration: underline;
                 }
             `,
         ];
@@ -40,14 +49,51 @@ export class _ extends LitElement {
     query: string = "";
 
     @property({ type: Number })
-    resultsCount?: number = 0;
+    jigCount: number = 0;
+
+    @property({ type: Number })
+    resourceCount: number = 0;
+
+    private scrollToResults(event: MouseEvent) {
+        event.preventDefault();
+        const slot = this.shadowRoot!.querySelector("slot") as HTMLSlotElement;
+
+        const target = event.target as HTMLAnchorElement;
+        const kind = target.getAttribute("href")!.replace(/^#/, "");
+
+        slot.assignedElements().forEach((element) => {
+            if (element.getAttribute("kind") === kind) {
+                element.scrollIntoView({
+                    behavior: "smooth",
+                });
+            }
+        })
+    }
 
     renderResultsFound() {
+        let results: TemplateResult[] = [];
+
+        const addResultCount = (kind: string, count: number) => {
+            if (count > 0) {
+                let noun = BigInt(count) === BigInt(1) ? KINDS[kind][0] : KINDS[kind][1];
+                results.push(html`<a @click="${this.scrollToResults}" href="#${kind}">${count} ${noun}</a>`);
+            }
+        }
+
+        addResultCount("jigs", this.jigCount);
+        addResultCount("resources", this.resourceCount);
+        if (this.jigCount > 0 && this.resourceCount > 0) {
+            // If we're rendering both sets of results then add STR_AND between
+            // them.
+            // NOTE: If at some point we want to include more than two results
+            // sections, then we will need to update this logic to handle it.
+            results.splice(1, 0, html` ${STR_AND} `);
+        }
+
         return html`
             <h1>
                 ${STR_WE_FOUND}
-                <span class="results-count">${this.resultsCount}</span>
-                ${STR_RESULTS}
+                ${results}
                 ${
                     this.query.trim() !== "" ? html`
                         ${STR_FOR}
@@ -82,7 +128,7 @@ export class _ extends LitElement {
         return html`
             ${this.loading
                 ? this.renderLoading()
-                : this.resultsCount
+                : this.jigCount + this.resourceCount > 0
                     ? this.renderResultsFound()
                     : this.renderNoResultsFound()
             }


### PR DESCRIPTION
Closes #2264 

- Adds anchors for JIGs and Resources to scroll to the relevant sections;
- Updates so that the noun for each is either singular or plural if the result count is 1 or more.

#### Nothing found
![Screenshot from 2022-01-14 11-45-22](https://user-images.githubusercontent.com/4161106/149495252-b1d345e9-edd3-45f8-aa7d-59ad331f8aed.png)

#### 1 Resource found (singular)
![Screenshot from 2022-01-14 11-45-05](https://user-images.githubusercontent.com/4161106/149495263-014d937d-cd98-4d9b-9d5b-992b9babf615.png)

#### Multiple JIGs found (plural)
![Screenshot from 2022-01-14 11-44-52](https://user-images.githubusercontent.com/4161106/149495268-db166301-64af-437a-9672-849df160def6.png)

#### No search query (All results)
![Screenshot from 2022-01-14 11-44-37](https://user-images.githubusercontent.com/4161106/149495273-99717ce2-563e-4731-bc77-0db312ac5ab2.png)

#### 14 JIGs (plural) and 1 resource (singular) 
![image](https://user-images.githubusercontent.com/4161106/149495384-48afd06a-2386-455d-bfb2-26dc12f1b4c3.png)
