### PR TITLE
feat: Incomplete JIG modules

### DIFF
--- a/backend/api/fixtures/8_jig.sql
+++ b/backend/api/fixtures/8_jig.sql
@@ -10,6 +10,14 @@ values ('d4cad43c-1dd5-11ec-8426-83d4a42e3ac9', 'name', '2021-03-04 00:46:26.134
        ('d4cad52c-1dd5-11ec-8426-f7f3e8ceccb2', 'name', '2021-03-04 00:46:26.134651+00', -- live
         '2021-03-04 00:46:26.134651+00', 'en', '2021-03-04 00:46:26.134651+00', 'test description', 0, null,
         array [0, 1], array [0, 1, 2], 0, 0, true, true, true, 1),
+
+       ('38ef2e9c-9d7f-4a96-aed4-164f7f42bf0c', 'name', '2021-03-04 00:46:26.134651+00', -- live
+        '2021-03-04 00:46:26.134651+00', 'en', '2021-03-04 00:46:26.134651+00', 'test description', 0, null,
+        array [0, 1], array [0, 1, 2], 0, 0, true, true, true, 1),
+       ('456f571e-ea27-460e-b065-2bbd77d350ae', 'name', '2021-03-04 00:46:26.134651+00', -- draft
+        '2021-03-04 00:46:26.134651+00', 'en', '2021-03-04 00:46:26.134651+00', 'test description', 0, null,
+        array [0, 1], array [0, 1, 2], 0, 1, true, true, true, 0),
+
        ('d4cad586-1dd5-11ec-8426-fbcd3fd01e2a', 'draft name', '2021-03-06 00:46:26.134651+00', -- draft
         '2021-03-06 00:46:26.134651+00', 'he', '2021-03-07 00:46:26.134651+00', 'draft test description', 1, 0,
         array []::smallint[], array []::smallint[], 1, 1, false, false, false, 0);
@@ -21,7 +29,10 @@ values ('0cc084bc-7c83-11eb-9f77-e3218dffb008', '1f241e1b-b537-493f-a230-075cb16
         'd4cad4c8-1dd5-11ec-8426-a37eda7ce03f'),
        ('3a71522a-cd77-11eb-8dc1-af3e35f7c743', '1f241e1b-b537-493f-a230-075cb16315be',
         '1f241e1b-b537-493f-a230-075cb16315be', 'd4cad52c-1dd5-11ec-8426-f7f3e8ceccb2',
-        'd4cad586-1dd5-11ec-8426-fbcd3fd01e2a');
+        'd4cad586-1dd5-11ec-8426-fbcd3fd01e2a'),
+       ('19becb2b-bff7-4c1b-bb2c-16f2e098d3d3', '1f241e1b-b537-493f-a230-075cb16315be',
+        '1f241e1b-b537-493f-a230-075cb16315be', '38ef2e9c-9d7f-4a96-aed4-164f7f42bf0c',
+        '456f571e-ea27-460e-b065-2bbd77d350ae');
 
 insert into jig_data_module (id, stable_id, jig_data_id, index, kind, is_complete, contents, created_at)
 values ('a6b248f8-1dd7-11ec-8426-975953035335', '0cbfdd82-7c83-11eb-9f77-d7d86264c3bc',
@@ -35,7 +46,11 @@ values ('a6b248f8-1dd7-11ec-8426-975953035335', '0cbfdd82-7c83-11eb-9f77-d7d8626
        ('a6b24a42-1dd7-11ec-8426-a7165f9281a2', '0cc03a02-7c83-11eb-9f77-f77f9ad65e9a',
         'd4cad4c8-1dd5-11ec-8426-a37eda7ce03f', 1, 1, false, '{}', '2021-03-04 00:46:26.134651+00'),
        ('a6b24a88-1dd7-11ec-8426-57525d09b22c', '5fac2632-cd4a-11eb-ae4e-7b9a797001a5',
-        'd4cad4c8-1dd5-11ec-8426-a37eda7ce03f', 2, 3, false, '{}', '2021-03-04 00:46:26.134651+00');
+        'd4cad4c8-1dd5-11ec-8426-a37eda7ce03f', 2, 3, false, '{}', '2021-03-04 00:46:26.134651+00'),
+       ('56841805-d762-478b-8f07-e263917058b9', 'e780f91a-0a95-45e0-82e2-fbf5a5d1489e',
+        '456f571e-ea27-460e-b065-2bbd77d350ae', 0, 0, true, '{}', '2021-03-04 00:46:26.134651+00'),
+       ('865eeae6-f081-49bb-87bb-827296a8a82b', '1bda342c-4e2c-4ed9-a8b8-5ae3eafc8a66',
+        '38ef2e9c-9d7f-4a96-aed4-164f7f42bf0c', 0, 0, true, '{}', '2021-03-04 00:46:26.134651+00');
 
 
 insert into jig_data_additional_resource (jig_data_id, id, display_name, resource_type_id, resource_content)

--- a/backend/api/sqlx-data.json
+++ b/backend/api/sqlx-data.json
@@ -766,6 +766,29 @@
       "nullable": []
     }
   },
+  "1c2c17db162048500c44d0f1b794f014c828fbeb4b2bb949eb020ed15bf43c5f": {
+    "query": "\nselect count(*) as \"count!: i64\"\nfrom jig\nleft join jig_admin_data \"admin\" on admin.jig_id = jig.id\nleft join jig_data \"jig_dt\" on jig_dt.id = jig.draft_id\nleft join jig_data \"jig_tt\" on jig_tt.id = jig.live_id\nwhere (jig_dt.privacy_level = $1 or $1 is null)\n    and (author_id = $2 or $2 is null)\n    and (jig_focus = $3 or $3 is null)\n    and ((jig_dt.draft_or_live = $4 or $4 is null)\n    or (jig_tt.draft_or_live = $4 or $4 is null))\n",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "count!: i64",
+          "type_info": "Int8"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int2",
+          "Uuid",
+          "Int2",
+          "Int2"
+        ]
+      },
+      "nullable": [
+        null
+      ]
+    }
+  },
   "1c72ff4451fa5342ae8ae20bb4169b62efa25b9b44c80ce26bf9a9619336dd60": {
     "query": "delete from user_pdf_library where id = $1",
     "describe": {
@@ -1059,6 +1082,34 @@
         null,
         null,
         null
+      ]
+    }
+  },
+  "2afb5e944e653036cac881d1758257055a14ebb5a521fc0caad5b0cdd03a36fd": {
+    "query": "\n    select live_id                                  as \"live_id!\",\n           draft_id                                 as \"draft_id!\"\n    from jig\n        left join jig_admin_data \"admin\" on admin.jig_id = jig.id\n        left join jig_data \"jig_dt\" on jig_dt.id = jig.draft_id\n        left join jig_data \"jig_tt\" on jig_tt.id = jig.live_id\n    where blocked = false\n        and (jig_dt.draft_or_live is not null and jig_tt.draft_or_live is not null)\n        and ((jig_dt.draft_or_live = $3 or $3 is null)\n              or (jig_tt.draft_or_live = $3 or $3 is null))\n        and (author_id = $1 or $1 is null)\n        and (jig_focus = $2 or $2 is null)\n        ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "live_id!",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 1,
+          "name": "draft_id!",
+          "type_info": "Uuid"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Int2",
+          "Int2"
+        ]
+      },
+      "nullable": [
+        true,
+        true
       ]
     }
   },
@@ -1366,34 +1417,6 @@
         ]
       },
       "nullable": []
-    }
-  },
-  "419d3eb3266ab440660fcd3e3d4934325bcbb9ee96cb66c74932cd07b8708b34": {
-    "query": "\n    select live_id                                  as \"live_id!\",\n           draft_id                                 as \"draft_id!\"\n    from jig\n        left join jig_admin_data \"admin\" on admin.jig_id = jig.id\n        left join jig_data \"jig_dt\" on jig_dt.id = jig.draft_id\n        left join jig_data \"jig_tt\" on jig_tt.id = jig.live_id\n    where blocked = false\n        and (jig_dt.draft_or_live is not null and jig_tt.draft_or_live is not null)\n        and ((jig_dt.draft_or_live = $3 or $3 is null) \n              or (jig_tt.draft_or_live = $3 or $3 is null))\n        and (author_id = $1 or $1 is null)\n        and (jig_focus = $2 or $2 is null)\n        ",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "live_id!",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 1,
-          "name": "draft_id!",
-          "type_info": "Uuid"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Int2",
-          "Int2"
-        ]
-      },
-      "nullable": [
-        true,
-        true
-      ]
     }
   },
   "41d611eeb98a3c32644ff2440ecdb979eefaa5e86a155d4c2e57aabb42415fea": {
@@ -1794,6 +1817,225 @@
         ]
       },
       "nullable": []
+    }
+  },
+  "54d64693aedfaecebe7e07fe11fa6fb0275efe352abef2e80cf8eba780941133": {
+    "query": "\nwith cte as (\n    select * from unnest($1::uuid[]) with ordinality t(id, ord) order by ord desc\n)\nselect  jig.id                                              as \"jig_id: JigId\",\n        privacy_level                                       as \"privacy_level: PrivacyLevel\",\n        jig_focus                                           as \"jig_focus!: JigFocus\",\n        creator_id,\n        author_id,\n        (select given_name || ' '::text || family_name\n         from user_profile\n         where user_profile.user_id = author_id)            as \"author_name\",\n        published_at,\n        liked_count,\n        (\n             select play_count\n             from jig_play_count\n             where jig_play_count.jig_id = jig.id\n        )                                                   as \"play_count!\",\n       display_name                                                                  as \"display_name!\",\n       updated_at,\n       language                                                                      as \"language!\",\n       description                                                                   as \"description!\",\n       direction                                                                     as \"direction!: TextDirection\",\n       display_score                                                                 as \"display_score!\",\n       track_assessments                                                             as \"track_assessments!\",\n       drag_assist                                                                   as \"drag_assist!\",\n       theme                                                                         as \"theme!: ThemeId\",\n       audio_background                                                              as \"audio_background!: Option<AudioBackground>\",\n       draft_or_live                                                                 as \"draft_or_live!: DraftOrLive\",\n       array(select row (unnest(audio_feedback_positive)))                           as \"audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>\",\n       array(select row (unnest(audio_feedback_negative)))                           as \"audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>\",\n       array(\n               select row (jig_data_module.id, kind, is_complete)\n               from jig_data_module\n               where jig_data_id = jig_data.id\n               order by \"index\"\n           )                                               as \"modules!: Vec<(ModuleId, ModuleKind, bool)>\",\n       array(select row (goal_id)\n             from jig_data_goal\n             where jig_data_id = jig_data.id)     as \"goals!: Vec<(GoalId,)>\",\n       array(select row (category_id)\n             from jig_data_category\n             where jig_data_id = jig_data.id)     as \"categories!: Vec<(CategoryId,)>\",\n       array(select row (affiliation_id)\n             from jig_data_affiliation\n             where jig_data_id = jig_data.id)     as \"affiliations!: Vec<(AffiliationId,)>\",\n       array(select row (age_range_id)\n             from jig_data_age_range\n             where jig_data_id = jig_data.id)     as \"age_ranges!: Vec<(AgeRangeId,)>\",\n       array(\n                select row (jdar.id, jdar.display_name, resource_type_id, resource_content)\n                from jig_data_additional_resource \"jdar\"\n                where jdar.jig_data_id = jig_data.id\n            )                                               as \"additional_resource!: Vec<(AddId, String, TypeId, Value)>\",\n       locked                                     as \"locked!\",\n       other_keywords                             as \"other_keywords!\",\n       translated_keywords                        as \"translated_keywords!\",\n       rating                                     as \"rating!: Option<JigRating>\",\n       blocked                                    as \"blocked!\",\n       curated                                    as \"curated!\"\nfrom jig_data\n    inner join cte on cte.id = jig_data.id\n    inner join jig on jig_data.id = jig.draft_id or jig_data.id = jig.live_id\n    inner join jig_admin_data \"admin\" on admin.jig_id = jig.id\nwhere cte.ord >= (20 * $2)\norder by ord asc\nlimit 20\n",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "jig_id: JigId",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 1,
+          "name": "privacy_level: PrivacyLevel",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 2,
+          "name": "jig_focus!: JigFocus",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 3,
+          "name": "creator_id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 4,
+          "name": "author_id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 5,
+          "name": "author_name",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 6,
+          "name": "published_at",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 7,
+          "name": "liked_count",
+          "type_info": "Int8"
+        },
+        {
+          "ordinal": 8,
+          "name": "play_count!",
+          "type_info": "Int8"
+        },
+        {
+          "ordinal": 9,
+          "name": "display_name!",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 10,
+          "name": "updated_at",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 11,
+          "name": "language!",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 12,
+          "name": "description!",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 13,
+          "name": "direction!: TextDirection",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 14,
+          "name": "display_score!",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 15,
+          "name": "track_assessments!",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 16,
+          "name": "drag_assist!",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 17,
+          "name": "theme!: ThemeId",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 18,
+          "name": "audio_background!: Option<AudioBackground>",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 19,
+          "name": "draft_or_live!: DraftOrLive",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 20,
+          "name": "audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 21,
+          "name": "audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 22,
+          "name": "modules!: Vec<(ModuleId, ModuleKind, bool)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 23,
+          "name": "goals!: Vec<(GoalId,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 24,
+          "name": "categories!: Vec<(CategoryId,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 25,
+          "name": "affiliations!: Vec<(AffiliationId,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 26,
+          "name": "age_ranges!: Vec<(AgeRangeId,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 27,
+          "name": "additional_resource!: Vec<(AddId, String, TypeId, Value)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 28,
+          "name": "locked!",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 29,
+          "name": "other_keywords!",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 30,
+          "name": "translated_keywords!",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 31,
+          "name": "rating!: Option<JigRating>",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 32,
+          "name": "blocked!",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 33,
+          "name": "curated!",
+          "type_info": "Bool"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "UuidArray",
+          "Int4"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        true,
+        true,
+        null,
+        true,
+        false,
+        null,
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false
+      ]
     }
   },
   "56567f2d09b683dfb6209093ff0ded597cda78b614466626b84956d955eb69c6": {
@@ -2868,29 +3110,6 @@
         ]
       },
       "nullable": []
-    }
-  },
-  "846719f4139daa74e1aab62e27ee8f3b91de4f861a9f912cb7a99a8abfe3d4a5": {
-    "query": "\nselect count(*) as \"count!: i64\"\nfrom jig\nleft join jig_admin_data \"admin\" on admin.jig_id = jig.id\nleft join jig_data \"jig_dt\" on jig_dt.id = jig.draft_id\nleft join jig_data \"jig_tt\" on jig_tt.id = jig.live_id\nwhere (jig_dt.privacy_level = $1 or $1 is null)\n    and (author_id = $2 or $2 is null)\n    and (jig_focus = $3 or $3 is null)\n    and ((jig_dt.draft_or_live = $4 or $4 is null) \n    or (jig_tt.draft_or_live = $4 or $4 is null))\n",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "count!: i64",
-          "type_info": "Int8"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Int2",
-          "Uuid",
-          "Int2",
-          "Int2"
-        ]
-      },
-      "nullable": [
-        null
-      ]
     }
   },
   "84f05210fc0d761dda68090751705c6448814262eab6eae4c3c1fc04290cf357": {
@@ -4044,225 +4263,6 @@
       ]
     }
   },
-  "b61b0d815e03c605c775e686f9f34f0a4c2ccf3bc0fdffc82d218f45d2f5a4d9": {
-    "query": "\nwith cte as (\n    select * from unnest($1::uuid[]) with ordinality t(id, ord) order by ord desc\n)\nselect  jig.id                                              as \"jig_id: JigId\",\n        privacy_level                                       as \"privacy_level: PrivacyLevel\",\n        jig_focus                                           as \"jig_focus!: JigFocus\",\n        creator_id,\n        author_id,\n        (select given_name || ' '::text || family_name\n         from user_profile\n         where user_profile.user_id = author_id)            as \"author_name\",\n        published_at,\n        liked_count,\n        (\n             select play_count\n             from jig_play_count\n             where jig_play_count.jig_id = jig.id\n        )                                                   as \"play_count!\",\n       display_name                                                                  as \"display_name!\",\n       updated_at,\n       language                                                                      as \"language!\",\n       description                                                                   as \"description!\",\n       direction                                                                     as \"direction!: TextDirection\",\n       display_score                                                                 as \"display_score!\",\n       track_assessments                                                             as \"track_assessments!\",\n       drag_assist                                                                   as \"drag_assist!\",\n       theme                                                                         as \"theme!: ThemeId\",\n       audio_background                                                              as \"audio_background!: Option<AudioBackground>\",\n       draft_or_live                                                                 as \"draft_or_live!: DraftOrLive\",  \n       array(select row (unnest(audio_feedback_positive)))                           as \"audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>\",\n       array(select row (unnest(audio_feedback_negative)))                           as \"audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>\",\n       array(\n               select row (jig_data_module.id, kind)\n               from jig_data_module\n               where jig_data_id = jig_data.id\n               order by \"index\"\n           )                                               as \"modules!: Vec<(ModuleId, ModuleKind)>\",\n       array(select row (goal_id)\n             from jig_data_goal\n             where jig_data_id = jig_data.id)     as \"goals!: Vec<(GoalId,)>\",\n       array(select row (category_id)\n             from jig_data_category\n             where jig_data_id = jig_data.id)     as \"categories!: Vec<(CategoryId,)>\",\n       array(select row (affiliation_id)\n             from jig_data_affiliation\n             where jig_data_id = jig_data.id)     as \"affiliations!: Vec<(AffiliationId,)>\",\n       array(select row (age_range_id)\n             from jig_data_age_range\n             where jig_data_id = jig_data.id)     as \"age_ranges!: Vec<(AgeRangeId,)>\",\n       array(\n                select row (jdar.id, jdar.display_name, resource_type_id, resource_content)\n                from jig_data_additional_resource \"jdar\"\n                where jdar.jig_data_id = jig_data.id\n            )                                               as \"additional_resource!: Vec<(AddId, String, TypeId, Value)>\",\n       locked                                     as \"locked!\",\n       other_keywords                             as \"other_keywords!\",\n       translated_keywords                        as \"translated_keywords!\",\n       rating                                     as \"rating!: Option<JigRating>\",\n       blocked                                    as \"blocked!\",\n       curated                                    as \"curated!\"\nfrom jig_data\n    inner join cte on cte.id = jig_data.id\n    inner join jig on jig_data.id = jig.draft_id or jig_data.id = jig.live_id\n    inner join jig_admin_data \"admin\" on admin.jig_id = jig.id\nwhere cte.ord >= (20 * $2)\norder by ord asc\nlimit 20 \n",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "jig_id: JigId",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 1,
-          "name": "privacy_level: PrivacyLevel",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 2,
-          "name": "jig_focus!: JigFocus",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 3,
-          "name": "creator_id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 4,
-          "name": "author_id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 5,
-          "name": "author_name",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 6,
-          "name": "published_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 7,
-          "name": "liked_count",
-          "type_info": "Int8"
-        },
-        {
-          "ordinal": 8,
-          "name": "play_count!",
-          "type_info": "Int8"
-        },
-        {
-          "ordinal": 9,
-          "name": "display_name!",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 10,
-          "name": "updated_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 11,
-          "name": "language!",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 12,
-          "name": "description!",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 13,
-          "name": "direction!: TextDirection",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 14,
-          "name": "display_score!",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 15,
-          "name": "track_assessments!",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 16,
-          "name": "drag_assist!",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 17,
-          "name": "theme!: ThemeId",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 18,
-          "name": "audio_background!: Option<AudioBackground>",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 19,
-          "name": "draft_or_live!: DraftOrLive",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 20,
-          "name": "audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 21,
-          "name": "audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 22,
-          "name": "modules!: Vec<(ModuleId, ModuleKind)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 23,
-          "name": "goals!: Vec<(GoalId,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 24,
-          "name": "categories!: Vec<(CategoryId,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 25,
-          "name": "affiliations!: Vec<(AffiliationId,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 26,
-          "name": "age_ranges!: Vec<(AgeRangeId,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 27,
-          "name": "additional_resource!: Vec<(AddId, String, TypeId, Value)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 28,
-          "name": "locked!",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 29,
-          "name": "other_keywords!",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 30,
-          "name": "translated_keywords!",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 31,
-          "name": "rating!: Option<JigRating>",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 32,
-          "name": "blocked!",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 33,
-          "name": "curated!",
-          "type_info": "Bool"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "UuidArray",
-          "Int4"
-        ]
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        true,
-        true,
-        null,
-        true,
-        false,
-        null,
-        false,
-        true,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        true,
-        true,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        false,
-        false,
-        false,
-        true,
-        false,
-        false
-      ]
-    }
-  },
   "b73bc1e83d2008fc5b9cc7e9a6c9a6b67b136c45a41e39a8929b554dc5c98485": {
     "query": "update \"settings\" set algolia_index_version = $1",
     "describe": {
@@ -4883,6 +4883,158 @@
       "nullable": []
     }
   },
+  "d1db4e2f898f5a82c2cf63caf08a56c953869f717e7a4afd548242cac605bb11": {
+    "query": "\nselect id,\n       display_name                                                                  as \"display_name!\",\n       updated_at,\n       language                                                                      as \"language!\",\n       description                                                                   as \"description!\",\n       direction                                                                     as \"direction!: TextDirection\",\n       display_score                                                                 as \"display_score!\",\n       track_assessments                                                             as \"track_assessments!\",\n       drag_assist                                                                   as \"drag_assist!\",\n       theme                                                                         as \"theme!: ThemeId\",\n       audio_background                                                              as \"audio_background!: Option<AudioBackground>\",\n       array(select row (unnest(audio_feedback_positive)))                           as \"audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>\",\n       array(select row (unnest(audio_feedback_negative)))                           as \"audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>\",\n       array(\n               select row (jig_data_module.id, kind, is_complete)\n               from jig_data_module\n               where jig_data_id = jig_data.id\n               order by \"index\"\n           )                                               as \"modules!: Vec<(ModuleId, ModuleKind, bool)>\",\n       array(select row (goal_id)\n             from jig_data_goal\n             where jig_data_id = jig_data.id)     as \"goals!: Vec<(GoalId,)>\",\n       array(select row (category_id)\n             from jig_data_category\n             where jig_data_id = jig_data.id)     as \"categories!: Vec<(CategoryId,)>\",\n       array(select row (affiliation_id)\n             from jig_data_affiliation\n             where jig_data_id = jig_data.id)     as \"affiliations!: Vec<(AffiliationId,)>\",\n       array(select row (age_range_id)\n             from jig_data_age_range\n             where jig_data_id = jig_data.id)     as \"age_ranges!: Vec<(AgeRangeId,)>\",\n       array(\n                select row (jdar.id, jdar.display_name, resource_type_id, resource_content)\n                from jig_data_additional_resource \"jdar\"\n                where jdar.jig_data_id = jig_data.id\n            )                                               as \"additional_resource!: Vec<(AddId, String, TypeId, Value)>\",\n       privacy_level                              as \"privacy_level!: PrivacyLevel\",\n       locked                                     as \"locked!\",\n       other_keywords                             as \"other_keywords!\",\n       translated_keywords                        as \"translated_keywords!\"\nfrom jig_data\n         inner join unnest($1::uuid[])\n    with ordinality t(id, ord) using (id)\nwhere draft_or_live is not null\norder by t.ord\n",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 1,
+          "name": "display_name!",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 2,
+          "name": "updated_at",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 3,
+          "name": "language!",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 4,
+          "name": "description!",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 5,
+          "name": "direction!: TextDirection",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 6,
+          "name": "display_score!",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 7,
+          "name": "track_assessments!",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 8,
+          "name": "drag_assist!",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 9,
+          "name": "theme!: ThemeId",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 10,
+          "name": "audio_background!: Option<AudioBackground>",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 11,
+          "name": "audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 12,
+          "name": "audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 13,
+          "name": "modules!: Vec<(ModuleId, ModuleKind, bool)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 14,
+          "name": "goals!: Vec<(GoalId,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 15,
+          "name": "categories!: Vec<(CategoryId,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 16,
+          "name": "affiliations!: Vec<(AffiliationId,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 17,
+          "name": "age_ranges!: Vec<(AgeRangeId,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 18,
+          "name": "additional_resource!: Vec<(AddId, String, TypeId, Value)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 19,
+          "name": "privacy_level!: PrivacyLevel",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 20,
+          "name": "locked!",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 21,
+          "name": "other_keywords!",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 22,
+          "name": "translated_keywords!",
+          "type_info": "Text"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "UuidArray"
+        ]
+      },
+      "nullable": [
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true
+      ]
+    }
+  },
   "d201d9e5aec8be8b9ecf9a698f834a73a0fabc887886d198e12d387b8e9d78f5": {
     "query": "\nselect kind as \"kind: ImageKind\"\nfrom image_metadata\ninner join image_upload on image_metadata.id = image_upload.image_id\nwhere (id = $1 and uploaded_at is not null and processed_at >= uploaded_at is not true)\nfor no key update of image_upload\nfor share of image_metadata\nskip locked\n        ",
     "describe": {
@@ -4948,6 +5100,219 @@
         ]
       },
       "nullable": []
+    }
+  },
+  "d775a58904ffe5c8b82e635775151ef65bb41a6ff881628b610e6b00729a622f": {
+    "query": "\nwith cte as (\n    select id      as \"jig_id\",\n           creator_id,\n           author_id,\n           liked_count,\n           play_count,\n           case\n               when $2 = 0 then jig.draft_id\n               when $2 = 1 then jig.live_id\n               end as \"draft_or_live_id\",\n           published_at,\n           rating,\n           blocked,\n           curated,\n           jig_focus\n    from jig\n    left join jig_play_count on jig_play_count.jig_id = jig.id\n    left join jig_admin_data \"admin\" on admin.jig_id = jig.id\n    where id = $1\n)\nselect cte.jig_id                                          as \"jig_id: JigId\",\n       display_name,\n       creator_id,\n       author_id,\n       (select given_name || ' '::text || family_name\n        from user_profile\n        where user_profile.user_id = author_id)            as \"author_name\",\n       published_at,\n       updated_at,\n       privacy_level                                       as \"privacy_level!: PrivacyLevel\",\n       jig_focus                                           as \"jig_focus!: JigFocus\",\n       language,\n       description,\n       direction                                           as \"direction: TextDirection\",\n       display_score,\n       track_assessments,\n       drag_assist,\n       theme                                               as \"theme: ThemeId\",\n       audio_background                                    as \"audio_background: AudioBackground\",\n       liked_count,\n       play_count,\n       locked,\n       other_keywords,\n       translated_keywords,\n       rating                                               as \"rating?: JigRating\",\n       blocked                                              as \"blocked\",\n       curated,\n       array(select row (unnest(audio_feedback_positive))) as \"audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>\",\n       array(select row (unnest(audio_feedback_negative))) as \"audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>\",\n       array(\n               select row (jig_data_module.id, kind, is_complete)\n               from jig_data_module\n               where jig_data_id = cte.draft_or_live_id\n               order by \"index\"\n           )                                               as \"modules!: Vec<(ModuleId, ModuleKind, bool)>\",\n       array(select row (goal_id)\n             from jig_data_goal\n             where jig_data_id = cte.draft_or_live_id)     as \"goals!: Vec<(GoalId,)>\",\n       array(select row (category_id)\n             from jig_data_category\n             where jig_data_id = cte.draft_or_live_id)     as \"categories!: Vec<(CategoryId,)>\",\n       array(select row (affiliation_id)\n             from jig_data_affiliation\n             where jig_data_id = cte.draft_or_live_id)     as \"affiliations!: Vec<(AffiliationId,)>\",\n       array(select row (age_range_id)\n             from jig_data_age_range\n             where jig_data_id = cte.draft_or_live_id)     as \"age_ranges!: Vec<(AgeRangeId,)>\",\n       array(\n             select row (jdar.id, jdar.display_name, resource_type_id, resource_content)\n             from jig_data_additional_resource \"jdar\"\n             where jdar.jig_data_id = cte.draft_or_live_id\n       )                                                    as \"additional_resource!: Vec<(AddId, String, TypeId, Value)>\"\nfrom jig_data\n         inner join cte on cte.draft_or_live_id = jig_data.id\n",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "jig_id: JigId",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 1,
+          "name": "display_name",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 2,
+          "name": "creator_id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 3,
+          "name": "author_id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 4,
+          "name": "author_name",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 5,
+          "name": "published_at",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 6,
+          "name": "updated_at",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 7,
+          "name": "privacy_level!: PrivacyLevel",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 8,
+          "name": "jig_focus!: JigFocus",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 9,
+          "name": "language",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 10,
+          "name": "description",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 11,
+          "name": "direction: TextDirection",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 12,
+          "name": "display_score",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 13,
+          "name": "track_assessments",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 14,
+          "name": "drag_assist",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 15,
+          "name": "theme: ThemeId",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 16,
+          "name": "audio_background: AudioBackground",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 17,
+          "name": "liked_count",
+          "type_info": "Int8"
+        },
+        {
+          "ordinal": 18,
+          "name": "play_count",
+          "type_info": "Int8"
+        },
+        {
+          "ordinal": 19,
+          "name": "locked",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 20,
+          "name": "other_keywords",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 21,
+          "name": "translated_keywords",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 22,
+          "name": "rating?: JigRating",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 23,
+          "name": "blocked",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 24,
+          "name": "curated",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 25,
+          "name": "audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 26,
+          "name": "audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 27,
+          "name": "modules!: Vec<(ModuleId, ModuleKind, bool)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 28,
+          "name": "goals!: Vec<(GoalId,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 29,
+          "name": "categories!: Vec<(CategoryId,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 30,
+          "name": "affiliations!: Vec<(AffiliationId,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 31,
+          "name": "age_ranges!: Vec<(AgeRangeId,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 32,
+          "name": "additional_resource!: Vec<(AddId, String, TypeId, Value)>",
+          "type_info": "RecordArray"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Int4"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
+        true,
+        true,
+        null,
+        true,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ]
     }
   },
   "d8032d2eb89764dbd098df12c400d66030d32259400b2f539d60658605ca7648": {
@@ -5237,219 +5602,6 @@
       "nullable": [
         true,
         true
-      ]
-    }
-  },
-  "e97c542fec5c52c27c0516c8ffe3e4bd7154646f3db51905864251009b159411": {
-    "query": "\nwith cte as (\n    select id      as \"jig_id\",\n           creator_id,\n           author_id,\n           liked_count,\n           play_count,\n           case\n               when $2 = 0 then jig.draft_id\n               when $2 = 1 then jig.live_id\n               end as \"draft_or_live_id\",\n           published_at,\n           rating,\n           blocked,\n           curated,\n           jig_focus\n    from jig\n    left join jig_play_count on jig_play_count.jig_id = jig.id\n    left join jig_admin_data \"admin\" on admin.jig_id = jig.id\n    where id = $1\n)\nselect cte.jig_id                                          as \"jig_id: JigId\",\n       display_name,\n       creator_id,\n       author_id,\n       (select given_name || ' '::text || family_name\n        from user_profile\n        where user_profile.user_id = author_id)            as \"author_name\",\n       published_at,\n       updated_at,\n       privacy_level                                       as \"privacy_level!: PrivacyLevel\",\n       jig_focus                                           as \"jig_focus!: JigFocus\",\n       language,\n       description,\n       direction                                           as \"direction: TextDirection\",\n       display_score,\n       track_assessments,\n       drag_assist,\n       theme                                               as \"theme: ThemeId\",\n       audio_background                                    as \"audio_background: AudioBackground\",\n       liked_count,\n       play_count,\n       locked,\n       other_keywords,\n       translated_keywords,\n       rating                                               as \"rating?: JigRating\",\n       blocked                                              as \"blocked\",\n       curated,\n       array(select row (unnest(audio_feedback_positive))) as \"audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>\",\n       array(select row (unnest(audio_feedback_negative))) as \"audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>\",\n       array(\n               select row (jig_data_module.id, kind)\n               from jig_data_module\n               where jig_data_id = cte.draft_or_live_id\n               order by \"index\"\n           )                                               as \"modules!: Vec<(ModuleId, ModuleKind)>\",\n       array(select row (goal_id)\n             from jig_data_goal\n             where jig_data_id = cte.draft_or_live_id)     as \"goals!: Vec<(GoalId,)>\",\n       array(select row (category_id)\n             from jig_data_category\n             where jig_data_id = cte.draft_or_live_id)     as \"categories!: Vec<(CategoryId,)>\",\n       array(select row (affiliation_id)\n             from jig_data_affiliation\n             where jig_data_id = cte.draft_or_live_id)     as \"affiliations!: Vec<(AffiliationId,)>\",\n       array(select row (age_range_id)\n             from jig_data_age_range\n             where jig_data_id = cte.draft_or_live_id)     as \"age_ranges!: Vec<(AgeRangeId,)>\",\n       array(\n             select row (jdar.id, jdar.display_name, resource_type_id, resource_content)\n             from jig_data_additional_resource \"jdar\"\n             where jdar.jig_data_id = cte.draft_or_live_id\n       )                                                    as \"additional_resource!: Vec<(AddId, String, TypeId, Value)>\"\nfrom jig_data\n         inner join cte on cte.draft_or_live_id = jig_data.id\n",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "jig_id: JigId",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 1,
-          "name": "display_name",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 2,
-          "name": "creator_id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 3,
-          "name": "author_id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 4,
-          "name": "author_name",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 5,
-          "name": "published_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 6,
-          "name": "updated_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 7,
-          "name": "privacy_level!: PrivacyLevel",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 8,
-          "name": "jig_focus!: JigFocus",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 9,
-          "name": "language",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 10,
-          "name": "description",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 11,
-          "name": "direction: TextDirection",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 12,
-          "name": "display_score",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 13,
-          "name": "track_assessments",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 14,
-          "name": "drag_assist",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 15,
-          "name": "theme: ThemeId",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 16,
-          "name": "audio_background: AudioBackground",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 17,
-          "name": "liked_count",
-          "type_info": "Int8"
-        },
-        {
-          "ordinal": 18,
-          "name": "play_count",
-          "type_info": "Int8"
-        },
-        {
-          "ordinal": 19,
-          "name": "locked",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 20,
-          "name": "other_keywords",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 21,
-          "name": "translated_keywords",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 22,
-          "name": "rating?: JigRating",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 23,
-          "name": "blocked",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 24,
-          "name": "curated",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 25,
-          "name": "audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 26,
-          "name": "audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 27,
-          "name": "modules!: Vec<(ModuleId, ModuleKind)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 28,
-          "name": "goals!: Vec<(GoalId,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 29,
-          "name": "categories!: Vec<(CategoryId,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 30,
-          "name": "affiliations!: Vec<(AffiliationId,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 31,
-          "name": "age_ranges!: Vec<(AgeRangeId,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 32,
-          "name": "additional_resource!: Vec<(AddId, String, TypeId, Value)>",
-          "type_info": "RecordArray"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Int4"
-        ]
-      },
-      "nullable": [
-        false,
-        false,
-        true,
-        true,
-        null,
-        true,
-        true,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        true,
-        false,
-        false,
-        false,
-        false,
-        false,
-        true,
-        false,
-        false,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
       ]
     }
   },
@@ -5794,158 +5946,6 @@
       },
       "nullable": [
         false
-      ]
-    }
-  },
-  "fb3f4d66c3d07ab3acfb41032c91e0d837ce63ccc4cb6596a7b022f790a20632": {
-    "query": "\nselect id,\n       display_name                                                                  as \"display_name!\",\n       updated_at,\n       language                                                                      as \"language!\",\n       description                                                                   as \"description!\",\n       direction                                                                     as \"direction!: TextDirection\",\n       display_score                                                                 as \"display_score!\",\n       track_assessments                                                             as \"track_assessments!\",\n       drag_assist                                                                   as \"drag_assist!\",\n       theme                                                                         as \"theme!: ThemeId\",\n       audio_background                                                              as \"audio_background!: Option<AudioBackground>\",\n       array(select row (unnest(audio_feedback_positive)))                           as \"audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>\",\n       array(select row (unnest(audio_feedback_negative)))                           as \"audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>\",\n       array(\n               select row (jig_data_module.id, kind)\n               from jig_data_module\n               where jig_data_id = jig_data.id\n               order by \"index\"\n           )                                               as \"modules!: Vec<(ModuleId, ModuleKind)>\",\n       array(select row (goal_id)\n             from jig_data_goal\n             where jig_data_id = jig_data.id)     as \"goals!: Vec<(GoalId,)>\",\n       array(select row (category_id)\n             from jig_data_category\n             where jig_data_id = jig_data.id)     as \"categories!: Vec<(CategoryId,)>\",\n       array(select row (affiliation_id)\n             from jig_data_affiliation\n             where jig_data_id = jig_data.id)     as \"affiliations!: Vec<(AffiliationId,)>\",\n       array(select row (age_range_id)\n             from jig_data_age_range\n             where jig_data_id = jig_data.id)     as \"age_ranges!: Vec<(AgeRangeId,)>\",\n       array(\n                select row (jdar.id, jdar.display_name, resource_type_id, resource_content)\n                from jig_data_additional_resource \"jdar\"\n                where jdar.jig_data_id = jig_data.id\n            )                                               as \"additional_resource!: Vec<(AddId, String, TypeId, Value)>\",\n       privacy_level                              as \"privacy_level!: PrivacyLevel\",\n       locked                                     as \"locked!\",\n       other_keywords                             as \"other_keywords!\",\n       translated_keywords                        as \"translated_keywords!\"\nfrom jig_data\n         inner join unnest($1::uuid[])\n    with ordinality t(id, ord) using (id)\nwhere draft_or_live is not null\norder by t.ord\n",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 1,
-          "name": "display_name!",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 2,
-          "name": "updated_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 3,
-          "name": "language!",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 4,
-          "name": "description!",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 5,
-          "name": "direction!: TextDirection",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 6,
-          "name": "display_score!",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 7,
-          "name": "track_assessments!",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 8,
-          "name": "drag_assist!",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 9,
-          "name": "theme!: ThemeId",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 10,
-          "name": "audio_background!: Option<AudioBackground>",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 11,
-          "name": "audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 12,
-          "name": "audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 13,
-          "name": "modules!: Vec<(ModuleId, ModuleKind)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 14,
-          "name": "goals!: Vec<(GoalId,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 15,
-          "name": "categories!: Vec<(CategoryId,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 16,
-          "name": "affiliations!: Vec<(AffiliationId,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 17,
-          "name": "age_ranges!: Vec<(AgeRangeId,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 18,
-          "name": "additional_resource!: Vec<(AddId, String, TypeId, Value)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 19,
-          "name": "privacy_level!: PrivacyLevel",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 20,
-          "name": "locked!",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 21,
-          "name": "other_keywords!",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 22,
-          "name": "translated_keywords!",
-          "type_info": "Text"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "UuidArray"
-        ]
-      },
-      "nullable": [
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true
       ]
     }
   },

--- a/backend/api/src/error.rs
+++ b/backend/api/src/error.rs
@@ -561,6 +561,7 @@ impl Into<actix_web::Error> for UserRecentImage {
 pub enum JigCloneDraft {
     ResourceNotFound,
     UnprocessableEntity,
+    IncompleteModules,
     Conflict,
     Forbidden,
     InternalServerError(anyhow::Error),
@@ -594,6 +595,12 @@ impl Into<actix_web::Error> for JigCloneDraft {
             Self::UnprocessableEntity => BasicError::with_message(
                 http::StatusCode::UNPROCESSABLE_ENTITY,
                 "Called method not allowed on this jig".to_owned(),
+            )
+            .into(),
+
+            Self::IncompleteModules => BasicError::with_message(
+                http::StatusCode::BAD_REQUEST,
+                "No activities exist or activities with missing content".to_owned(),
             )
             .into(),
 

--- a/backend/api/tests/integration/jig.rs
+++ b/backend/api/tests/integration/jig.rs
@@ -490,3 +490,49 @@ async fn update_and_publish() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[actix_rt::test]
+async fn update_and_publish_incomplete_modules() -> anyhow::Result<()> {
+    let app = initialize_server(
+        &[
+            Fixture::MetaKinds,
+            Fixture::User,
+            Fixture::Jig,
+            Fixture::CategoryOrdering,
+        ],
+        &[],
+    )
+    .await;
+
+    let port = app.port();
+
+    let client = reqwest::Client::new();
+
+    // Test no modules on JIG returns HTTP 400
+    let resp = client
+        .put(&format!(
+            "http://0.0.0.0:{}/v1/jig/3a71522a-cd77-11eb-8dc1-af3e35f7c743/draft/publish",
+            port
+        ))
+        .login()
+        .send()
+        .await?;
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+    // Test no modules on JIG returns HTTP 400
+    let resp = client
+        .put(&format!(
+            "http://0.0.0.0:{}/v1/jig/0cc084bc-7c83-11eb-9f77-e3218dffb008/draft/publish",
+            port
+        ))
+        .login()
+        .send()
+        .await?;
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+    app.stop(false).await;
+
+    Ok(())
+}

--- a/backend/api/tests/integration/jig.rs
+++ b/backend/api/tests/integration/jig.rs
@@ -377,7 +377,7 @@ async fn update_and_publish() -> anyhow::Result<()> {
 
     let resp = client
         .get(&format!(
-            "http://0.0.0.0:{}/v1/jig/3a71522a-cd77-11eb-8dc1-af3e35f7c743/draft",
+            "http://0.0.0.0:{}/v1/jig/19becb2b-bff7-4c1b-bb2c-16f2e098d3d3/draft",
             port
         ))
         .login()
@@ -387,11 +387,17 @@ async fn update_and_publish() -> anyhow::Result<()> {
 
     let body: serde_json::Value = resp.json().await?;
 
-    insta::assert_json_snapshot!(body);
+    insta::assert_json_snapshot!(
+        body, {
+            ".**.lastEdited" => "[last_edited]",
+            ".**.feedbackPositive" => "[audio]",
+            ".**.feedbackNegative" => "[audio]",
+        }
+    );
 
     let resp = client
         .patch(&format!(
-            "http://0.0.0.0:{}/v1/jig/3a71522a-cd77-11eb-8dc1-af3e35f7c743",
+            "http://0.0.0.0:{}/v1/jig/19becb2b-bff7-4c1b-bb2c-16f2e098d3d3",
             port
         ))
         .json(&json!({
@@ -408,21 +414,7 @@ async fn update_and_publish() -> anyhow::Result<()> {
 
     let resp = client
         .get(&format!(
-            "http://0.0.0.0:{}/v1/jig/3a71522a-cd77-11eb-8dc1-af3e35f7c743/draft",
-            port
-        ))
-        .login()
-        .send()
-        .await?
-        .error_for_status()?;
-
-    let body: serde_json::Value = resp.json().await?;
-
-    insta::assert_json_snapshot!(body, {".**.lastEdited" => "[timestamp]"});
-
-    let resp = client
-        .get(&format!(
-            "http://0.0.0.0:{}/v1/jig/3a71522a-cd77-11eb-8dc1-af3e35f7c743/live",
+            "http://0.0.0.0:{}/v1/jig/19becb2b-bff7-4c1b-bb2c-16f2e098d3d3/draft",
             port
         ))
         .login()
@@ -436,23 +428,13 @@ async fn update_and_publish() -> anyhow::Result<()> {
         body, {
             ".**.lastEdited" => "[last_edited]",
             ".**.feedbackPositive" => "[audio]",
-            ".**.feedbackNegative" => "[audio]"
+            ".**.feedbackNegative" => "[audio]",
         }
     );
 
-    let _resp = client
-        .put(&format!(
-            "http://0.0.0.0:{}/v1/jig/3a71522a-cd77-11eb-8dc1-af3e35f7c743/draft/publish",
-            port
-        ))
-        .login()
-        .send()
-        .await?
-        .error_for_status()?;
-
     let resp = client
         .get(&format!(
-            "http://0.0.0.0:{}/v1/jig/3a71522a-cd77-11eb-8dc1-af3e35f7c743/live",
+            "http://0.0.0.0:{}/v1/jig/19becb2b-bff7-4c1b-bb2c-16f2e098d3d3/live",
             port
         ))
         .login()
@@ -464,6 +446,39 @@ async fn update_and_publish() -> anyhow::Result<()> {
 
     insta::assert_json_snapshot!(
         body, {
+            ".**.lastEdited" => "[last_edited]",
+            ".**.feedbackPositive" => "[audio]",
+            ".**.feedbackNegative" => "[audio]",
+        }
+    );
+
+    let _resp = client
+        .put(&format!(
+            "http://0.0.0.0:{}/v1/jig/19becb2b-bff7-4c1b-bb2c-16f2e098d3d3/draft/publish",
+            port
+        ))
+        .login()
+        .send()
+        .await?
+        .error_for_status()?;
+
+    let resp = client
+        .get(&format!(
+            "http://0.0.0.0:{}/v1/jig/19becb2b-bff7-4c1b-bb2c-16f2e098d3d3/live",
+            port
+        ))
+        .login()
+        .send()
+        .await?
+        .error_for_status()?;
+
+    let body: serde_json::Value = resp.json().await?;
+
+    insta::assert_json_snapshot!(
+        body, {
+            // Really just need to redact the module ID because it is recreated for the live data,
+            // but I couldn't get a selector working correctly... So redacting all IDs.
+            ".**.id" => "[id]",
             ".**.lastEdited" => "[last_edited]",
             ".**.publishedAt" => "[published_at]",
             ".**.feedbackPositive" => "[audio]",

--- a/backend/api/tests/integration/jig/snapshots/integration__jig__cover__update_no_modules_changes.snap
+++ b/backend/api/tests/integration/jig/snapshots/integration__jig__cover__update_no_modules_changes.snap
@@ -18,15 +18,18 @@ expression: body
     "modules": [
       {
         "id": "a6b24a06-1dd7-11ec-8426-635a3a7ea572",
-        "kind": "Cover"
+        "kind": "Cover",
+        "is_complete": false
       },
       {
         "id": "a6b24a42-1dd7-11ec-8426-a7165f9281a2",
-        "kind": "Flashcards"
+        "kind": "Flashcards",
+        "is_complete": false
       },
       {
         "id": "a6b24a88-1dd7-11ec-8426-57525d09b22c",
-        "kind": "Memory"
+        "kind": "Memory",
+        "is_complete": false
       }
     ],
     "ageRanges": [],

--- a/backend/api/tests/integration/snapshots/integration__jig__browse_own_simple.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__browse_own_simple.snap
@@ -64,15 +64,18 @@ expression: body
         "modules": [
           {
             "id": "a6b24a06-1dd7-11ec-8426-635a3a7ea572",
-            "kind": "Cover"
+            "kind": "Cover",
+            "is_complete": false
           },
           {
             "id": "a6b24a42-1dd7-11ec-8426-a7165f9281a2",
-            "kind": "Flashcards"
+            "kind": "Flashcards",
+            "is_complete": false
           },
           {
             "id": "a6b24a88-1dd7-11ec-8426-57525d09b22c",
-            "kind": "Memory"
+            "kind": "Memory",
+            "is_complete": false
           }
         ],
         "ageRanges": [],
@@ -94,6 +97,56 @@ expression: body
             "link": "url://url.url.url/url/s"
           }
         ],
+        "description": "test description",
+        "lastEdited": "[last_edited]",
+        "defaultPlayerSettings": {
+          "direction": "ltr",
+          "displayScore": true,
+          "trackAssessments": true,
+          "dragAssist": true
+        },
+        "theme": "Blank",
+        "audioBackground": null,
+        "audioEffects": {
+          "feedbackPositive": "[audio]",
+          "feedbackNegative": "[audio]"
+        },
+        "privacyLevel": "unlisted",
+        "locked": false,
+        "otherKeywords": "",
+        "translatedKeywords": ""
+      },
+      "adminData": {
+        "rating": null,
+        "blocked": false,
+        "curated": false
+      }
+    },
+    {
+      "id": "19becb2b-bff7-4c1b-bb2c-16f2e098d3d3",
+      "publishedAt": null,
+      "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
+      "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
+      "authorName": "Bobby Tables",
+      "likes": 0,
+      "plays": 0,
+      "jigFocus": "modules",
+      "jigData": {
+        "draftOrLive": "draft",
+        "displayName": "name",
+        "modules": [
+          {
+            "id": "56841805-d762-478b-8f07-e263917058b9",
+            "kind": "Cover",
+            "is_complete": true
+          }
+        ],
+        "ageRanges": [],
+        "affiliations": [],
+        "goals": [],
+        "language": "en",
+        "categories": [],
+        "additionalResources": [],
         "description": "test description",
         "lastEdited": "[last_edited]",
         "defaultPlayerSettings": {
@@ -178,15 +231,18 @@ expression: body
         "modules": [
           {
             "id": "a6b248f8-1dd7-11ec-8426-975953035335",
-            "kind": "Cover"
+            "kind": "Cover",
+            "is_complete": false
           },
           {
             "id": "a6b24970-1dd7-11ec-8426-57136b411853",
-            "kind": "Flashcards"
+            "kind": "Flashcards",
+            "is_complete": false
           },
           {
             "id": "a6b249c0-1dd7-11ec-8426-f77e58fd17c6",
-            "kind": "Memory"
+            "kind": "Memory",
+            "is_complete": false
           }
         ],
         "ageRanges": [],
@@ -232,8 +288,58 @@ expression: body
         "blocked": false,
         "curated": false
       }
+    },
+    {
+      "id": "19becb2b-bff7-4c1b-bb2c-16f2e098d3d3",
+      "publishedAt": null,
+      "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
+      "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
+      "authorName": "Bobby Tables",
+      "likes": 0,
+      "plays": 0,
+      "jigFocus": "modules",
+      "jigData": {
+        "draftOrLive": "live",
+        "displayName": "name",
+        "modules": [
+          {
+            "id": "865eeae6-f081-49bb-87bb-827296a8a82b",
+            "kind": "Cover",
+            "is_complete": true
+          }
+        ],
+        "ageRanges": [],
+        "affiliations": [],
+        "goals": [],
+        "language": "en",
+        "categories": [],
+        "additionalResources": [],
+        "description": "test description",
+        "lastEdited": "[last_edited]",
+        "defaultPlayerSettings": {
+          "direction": "ltr",
+          "displayScore": true,
+          "trackAssessments": true,
+          "dragAssist": true
+        },
+        "theme": "Blank",
+        "audioBackground": null,
+        "audioEffects": {
+          "feedbackPositive": "[audio]",
+          "feedbackNegative": "[audio]"
+        },
+        "privacyLevel": "public",
+        "locked": false,
+        "otherKeywords": "",
+        "translatedKeywords": ""
+      },
+      "adminData": {
+        "rating": null,
+        "blocked": false,
+        "curated": false
+      }
     }
   ],
   "pages": 1,
-  "totalJigCount": 2
+  "totalJigCount": 3
 }

--- a/backend/api/tests/integration/snapshots/integration__jig__browse_simple.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__browse_simple.snap
@@ -20,15 +20,18 @@ expression: body
         "modules": [
           {
             "id": "a6b24a06-1dd7-11ec-8426-635a3a7ea572",
-            "kind": "Cover"
+            "kind": "Cover",
+            "is_complete": false
           },
           {
             "id": "a6b24a42-1dd7-11ec-8426-a7165f9281a2",
-            "kind": "Flashcards"
+            "kind": "Flashcards",
+            "is_complete": false
           },
           {
             "id": "a6b24a88-1dd7-11ec-8426-57525d09b22c",
-            "kind": "Memory"
+            "kind": "Memory",
+            "is_complete": false
           }
         ],
         "ageRanges": [],
@@ -120,6 +123,56 @@ expression: body
       }
     },
     {
+      "id": "19becb2b-bff7-4c1b-bb2c-16f2e098d3d3",
+      "publishedAt": null,
+      "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
+      "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
+      "authorName": "Bobby Tables",
+      "likes": 0,
+      "plays": 0,
+      "jigFocus": "modules",
+      "jigData": {
+        "draftOrLive": "draft",
+        "displayName": "name",
+        "modules": [
+          {
+            "id": "56841805-d762-478b-8f07-e263917058b9",
+            "kind": "Cover",
+            "is_complete": true
+          }
+        ],
+        "ageRanges": [],
+        "affiliations": [],
+        "goals": [],
+        "language": "en",
+        "categories": [],
+        "additionalResources": [],
+        "description": "test description",
+        "lastEdited": "[last_edited]",
+        "defaultPlayerSettings": {
+          "direction": "ltr",
+          "displayScore": true,
+          "trackAssessments": true,
+          "dragAssist": true
+        },
+        "theme": "Blank",
+        "audioBackground": null,
+        "audioEffects": {
+          "feedbackPositive": "[audio]",
+          "feedbackNegative": "[audio]"
+        },
+        "privacyLevel": "unlisted",
+        "locked": false,
+        "otherKeywords": "",
+        "translatedKeywords": ""
+      },
+      "adminData": {
+        "rating": null,
+        "blocked": false,
+        "curated": false
+      }
+    },
+    {
       "id": "0cc084bc-7c83-11eb-9f77-e3218dffb008",
       "publishedAt": null,
       "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
@@ -134,15 +187,18 @@ expression: body
         "modules": [
           {
             "id": "a6b248f8-1dd7-11ec-8426-975953035335",
-            "kind": "Cover"
+            "kind": "Cover",
+            "is_complete": false
           },
           {
             "id": "a6b24970-1dd7-11ec-8426-57136b411853",
-            "kind": "Flashcards"
+            "kind": "Flashcards",
+            "is_complete": false
           },
           {
             "id": "a6b249c0-1dd7-11ec-8426-f77e58fd17c6",
-            "kind": "Memory"
+            "kind": "Memory",
+            "is_complete": false
           }
         ],
         "ageRanges": [],
@@ -232,8 +288,58 @@ expression: body
         "blocked": false,
         "curated": false
       }
+    },
+    {
+      "id": "19becb2b-bff7-4c1b-bb2c-16f2e098d3d3",
+      "publishedAt": null,
+      "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
+      "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
+      "authorName": "Bobby Tables",
+      "likes": 0,
+      "plays": 0,
+      "jigFocus": "modules",
+      "jigData": {
+        "draftOrLive": "live",
+        "displayName": "name",
+        "modules": [
+          {
+            "id": "865eeae6-f081-49bb-87bb-827296a8a82b",
+            "kind": "Cover",
+            "is_complete": true
+          }
+        ],
+        "ageRanges": [],
+        "affiliations": [],
+        "goals": [],
+        "language": "en",
+        "categories": [],
+        "additionalResources": [],
+        "description": "test description",
+        "lastEdited": "[last_edited]",
+        "defaultPlayerSettings": {
+          "direction": "ltr",
+          "displayScore": true,
+          "trackAssessments": true,
+          "dragAssist": true
+        },
+        "theme": "Blank",
+        "audioBackground": null,
+        "audioEffects": {
+          "feedbackPositive": "[audio]",
+          "feedbackNegative": "[audio]"
+        },
+        "privacyLevel": "public",
+        "locked": false,
+        "otherKeywords": "",
+        "translatedKeywords": ""
+      },
+      "adminData": {
+        "rating": null,
+        "blocked": false,
+        "curated": false
+      }
     }
   ],
   "pages": 1,
-  "totalJigCount": 2
+  "totalJigCount": 3
 }

--- a/backend/api/tests/integration/snapshots/integration__jig__count.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__count.snap
@@ -4,5 +4,5 @@ expression: body
 
 ---
 {
-  "totalCount": 2
+  "totalCount": 3
 }

--- a/backend/api/tests/integration/snapshots/integration__jig__get-2.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__get-2.snap
@@ -18,15 +18,18 @@ expression: body
     "modules": [
       {
         "id": "a6b248f8-1dd7-11ec-8426-975953035335",
-        "kind": "Cover"
+        "kind": "Cover",
+        "is_complete": false
       },
       {
         "id": "a6b24970-1dd7-11ec-8426-57136b411853",
-        "kind": "Flashcards"
+        "kind": "Flashcards",
+        "is_complete": false
       },
       {
         "id": "a6b249c0-1dd7-11ec-8426-f77e58fd17c6",
-        "kind": "Memory"
+        "kind": "Memory",
+        "is_complete": false
       }
     ],
     "ageRanges": [],

--- a/backend/api/tests/integration/snapshots/integration__jig__get.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__get.snap
@@ -18,15 +18,18 @@ expression: body
     "modules": [
       {
         "id": "a6b24a06-1dd7-11ec-8426-635a3a7ea572",
-        "kind": "Cover"
+        "kind": "Cover",
+        "is_complete": false
       },
       {
         "id": "a6b24a42-1dd7-11ec-8426-a7165f9281a2",
-        "kind": "Flashcards"
+        "kind": "Flashcards",
+        "is_complete": false
       },
       {
         "id": "a6b24a88-1dd7-11ec-8426-57525d09b22c",
-        "kind": "Memory"
+        "kind": "Memory",
+        "is_complete": false
       }
     ],
     "ageRanges": [],

--- a/backend/api/tests/integration/snapshots/integration__jig__update_and_publish-2.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__update_and_publish-2.snap
@@ -4,7 +4,7 @@ expression: body
 
 ---
 {
-  "id": "3a71522a-cd77-11eb-8dc1-af3e35f7c743",
+  "id": "19becb2b-bff7-4c1b-bb2c-16f2e098d3d3",
   "publishedAt": null,
   "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
   "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
@@ -14,8 +14,14 @@ expression: body
   "jigFocus": "modules",
   "jigData": {
     "draftOrLive": "draft",
-    "displayName": "draft name",
-    "modules": [],
+    "displayName": "name",
+    "modules": [
+      {
+        "id": "56841805-d762-478b-8f07-e263917058b9",
+        "kind": "Cover",
+        "is_complete": true
+      }
+    ],
     "ageRanges": [],
     "affiliations": [],
     "goals": [],
@@ -26,18 +32,18 @@ expression: body
     ],
     "additionalResources": [],
     "description": "asdasdasd",
-    "lastEdited": "[timestamp]",
+    "lastEdited": "[last_edited]",
     "defaultPlayerSettings": {
-      "direction": "rtl",
-      "displayScore": false,
-      "trackAssessments": false,
-      "dragAssist": false
+      "direction": "ltr",
+      "displayScore": true,
+      "trackAssessments": true,
+      "dragAssist": true
     },
-    "theme": "Jigzi",
-    "audioBackground": "funForKids",
+    "theme": "Blank",
+    "audioBackground": null,
     "audioEffects": {
-      "feedbackPositive": [],
-      "feedbackNegative": []
+      "feedbackPositive": "[audio]",
+      "feedbackNegative": "[audio]"
     },
     "privacyLevel": "unlisted",
     "locked": false,

--- a/backend/api/tests/integration/snapshots/integration__jig__update_and_publish-3.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__update_and_publish-3.snap
@@ -4,7 +4,7 @@ expression: body
 
 ---
 {
-  "id": "3a71522a-cd77-11eb-8dc1-af3e35f7c743",
+  "id": "19becb2b-bff7-4c1b-bb2c-16f2e098d3d3",
   "publishedAt": null,
   "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
   "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
@@ -15,7 +15,13 @@ expression: body
   "jigData": {
     "draftOrLive": "live",
     "displayName": "name",
-    "modules": [],
+    "modules": [
+      {
+        "id": "865eeae6-f081-49bb-87bb-827296a8a82b",
+        "kind": "Cover",
+        "is_complete": true
+      }
+    ],
     "ageRanges": [],
     "affiliations": [],
     "goals": [],

--- a/backend/api/tests/integration/snapshots/integration__jig__update_and_publish-4.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__update_and_publish-4.snap
@@ -4,7 +4,7 @@ expression: body
 
 ---
 {
-  "id": "3a71522a-cd77-11eb-8dc1-af3e35f7c743",
+  "id": "[id]",
   "publishedAt": "[published_at]",
   "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
   "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
@@ -14,8 +14,14 @@ expression: body
   "jigFocus": "modules",
   "jigData": {
     "draftOrLive": "live",
-    "displayName": "draft name",
-    "modules": [],
+    "displayName": "name",
+    "modules": [
+      {
+        "id": "[id]",
+        "kind": "Cover",
+        "is_complete": false
+      }
+    ],
     "ageRanges": [],
     "affiliations": [],
     "goals": [],
@@ -28,13 +34,13 @@ expression: body
     "description": "asdasdasd",
     "lastEdited": "[last_edited]",
     "defaultPlayerSettings": {
-      "direction": "rtl",
-      "displayScore": false,
-      "trackAssessments": false,
-      "dragAssist": false
+      "direction": "ltr",
+      "displayScore": true,
+      "trackAssessments": true,
+      "dragAssist": true
     },
-    "theme": "Jigzi",
-    "audioBackground": "funForKids",
+    "theme": "Blank",
+    "audioBackground": null,
     "audioEffects": {
       "feedbackPositive": "[audio]",
       "feedbackNegative": "[audio]"

--- a/backend/api/tests/integration/snapshots/integration__jig__update_and_publish.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__update_and_publish.snap
@@ -4,7 +4,7 @@ expression: body
 
 ---
 {
-  "id": "3a71522a-cd77-11eb-8dc1-af3e35f7c743",
+  "id": "19becb2b-bff7-4c1b-bb2c-16f2e098d3d3",
   "publishedAt": null,
   "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
   "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
@@ -14,27 +14,33 @@ expression: body
   "jigFocus": "modules",
   "jigData": {
     "draftOrLive": "draft",
-    "displayName": "draft name",
-    "modules": [],
+    "displayName": "name",
+    "modules": [
+      {
+        "id": "56841805-d762-478b-8f07-e263917058b9",
+        "kind": "Cover",
+        "is_complete": true
+      }
+    ],
     "ageRanges": [],
     "affiliations": [],
     "goals": [],
-    "language": "he",
+    "language": "en",
     "categories": [],
     "additionalResources": [],
-    "description": "draft test description",
-    "lastEdited": "2021-03-06T00:46:26.134651Z",
+    "description": "test description",
+    "lastEdited": "[last_edited]",
     "defaultPlayerSettings": {
-      "direction": "rtl",
-      "displayScore": false,
-      "trackAssessments": false,
-      "dragAssist": false
+      "direction": "ltr",
+      "displayScore": true,
+      "trackAssessments": true,
+      "dragAssist": true
     },
-    "theme": "Jigzi",
-    "audioBackground": "funForKids",
+    "theme": "Blank",
+    "audioBackground": null,
     "audioEffects": {
-      "feedbackPositive": [],
-      "feedbackNegative": []
+      "feedbackPositive": "[audio]",
+      "feedbackNegative": "[audio]"
     },
     "privacyLevel": "unlisted",
     "locked": false,

--- a/frontend/apps/crates/components/src/module/_common/edit/post_preview/actions.rs
+++ b/frontend/apps/crates/components/src/module/_common/edit/post_preview/actions.rs
@@ -64,6 +64,7 @@ impl PostPreview {
                     let module = LiteModule {
                         id: module_id,
                         kind: target_kind,
+                        is_complete: raw_data.is_complete(),
                     };
 
                     let msg = IframeAction::new(ModuleToJigEditorMessage::AppendModule(module));

--- a/frontend/apps/crates/entry/jig/edit/src/edit/publish/dom/mod.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/publish/dom/mod.rs
@@ -68,8 +68,26 @@ impl Publish {
 }
 
 fn render_page(state: Rc<Publish>) -> Dom {
+    let (has_modules, invalid_module) = {
+        let modules = state.jig.modules.lock_ref();
+
+        let has_modules = !modules.is_empty();
+
+        let invalid_module = modules.iter().find(|module| !module.is_complete);
+        (has_modules, invalid_module.map(|module| module.clone()))
+    };
+
     html!("jig-edit-publish", {
         .property("jigFocus", state.jig.jig_focus.as_str())
+        .apply_if(state.jig.jig_focus.is_resources(), |dom| {
+            // TODO set content for no activities and content for incomplete activities.
+            if !has_modules {
+                // TODO
+            } else if let Some(_invalid_module) = invalid_module {
+                // TODO
+            }
+            dom
+        })
         .children(&mut [
             ModuleThumbnail::render_live(
                 Rc::new(ModuleThumbnail {

--- a/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/copy_paste_module.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/copy_paste_module.rs
@@ -39,10 +39,8 @@ pub fn paste_module(state: Rc<State>) {
         None => log::warn!("No module to paste"),
         Some((jig_id, module_id)) => {
             state.loader.load(clone!(state => async move {
-
                 let module = super::module_cloner::clone_module(&jig_id, &module_id, &state.jig.id).await.unwrap_ji();
-                state.modules.lock_mut().push_cloned(Rc::new(Some(module)));
-
+                state.modules.lock_mut().push_cloned(Rc::new(Some(module.into())));
             }));
         }
     }

--- a/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/debug.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/debug.rs
@@ -40,18 +40,22 @@ pub fn get_jig() -> JigResponse {
                 LiteModule {
                     id: module_id,
                     kind: ModuleKind::Cover,
+                    is_complete: true,
                 },
                 LiteModule {
                     id: module_id,
                     kind: ModuleKind::Memory,
+                    is_complete: true,
                 },
                 LiteModule {
                     id: module_id,
                     kind: ModuleKind::Memory,
+                    is_complete: true,
                 },
                 LiteModule {
                     id: module_id,
                     kind: ModuleKind::TappingBoard,
+                    is_complete: true,
                 },
             ],
             age_ranges: Vec::new(),

--- a/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/menu/dom.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/menu/dom.rs
@@ -6,10 +6,10 @@ use crate::edit::sidebar::{
         actions::{self, MoveTarget},
         state::State as ModuleState,
     },
-    state::State as SidebarState,
+    state::{State as SidebarState, Module},
 };
 use dominator::{clone, html, Dom, EventOptions};
-use shared::domain::jig::{module::ModuleId, LiteModule, ModuleKind};
+use shared::domain::jig::{module::ModuleId, ModuleKind};
 use std::rc::Rc;
 use utils::events;
 
@@ -65,11 +65,11 @@ fn menu_items(state: &Rc<State>, module_state: &Rc<ModuleState>) -> Vec<Dom> {
                 if module_state.is_last_module() {
                     v.push(item_move_down(state, module_state));
                 }
-                v.push(item_duplicate(state, &module_state.sidebar, module.id));
+                v.push(item_duplicate(state, &module_state.sidebar, *module.id()));
             }
             v.push(item_delete(state, module_state));
             if let Some(module) = &*module_state.module {
-                v.push(item_copy(state, &module_state.sidebar, module.id));
+                v.push(item_copy(state, &module_state.sidebar, *module.id()));
                 v.push(item_duplicate_as(state, &module_state.sidebar, module));
             }
             v
@@ -163,15 +163,15 @@ fn item_paste(state: &Rc<State>, sidebar_state: &Rc<SidebarState>) -> Dom {
 fn item_duplicate_as(
     state: &Rc<State>,
     sidebar_state: &Rc<SidebarState>,
-    module: &LiteModule,
+    module: &Module,
 ) -> Dom {
-    let is_card = CARD_KINDS.contains(&module.kind);
+    let is_card = CARD_KINDS.contains(&module.kind());
 
     html!("empty-fragment", {
         .property("slot", "advanced")
         .apply_if(is_card, |dom| {
-            let card_kinds = CARD_KINDS.into_iter().filter(|kind| &module.kind != kind);
-            let module_id = module.id;
+            let card_kinds = CARD_KINDS.into_iter().filter(|kind| module.kind() != kind);
+            let module_id = module.id();
 
             dom.child(html!("menu-line", {
                 .property("customLabel", STR_DUPLICATE_AS)

--- a/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/module/state.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/module/state.rs
@@ -1,9 +1,6 @@
-use crate::edit::sidebar::state::State as SidebarState;
+use crate::edit::sidebar::state::{State as SidebarState, Module};
 use dominator::clone;
-use futures_signals::{
-    signal::{Mutable, Signal, SignalExt},
-};
-use shared::domain::jig::LiteModule;
+use futures_signals::signal::{Mutable, Signal, SignalExt};
 use std::cell::RefCell;
 use std::rc::Rc;
 use utils::drag::Drag;
@@ -11,7 +8,7 @@ use utils::routes::JigEditRoute;
 use web_sys::HtmlElement;
 
 pub struct State {
-    pub module: Rc<Option<LiteModule>>,
+    pub module: Rc<Option<Module>>,
     pub tried_module_at_cover: Mutable<bool>,
     pub sidebar: Rc<SidebarState>,
     pub drag: Mutable<Option<Drag>>,
@@ -26,7 +23,7 @@ impl State {
         sidebar: Rc<SidebarState>,
         index: usize,
         total_len: usize,
-        module: Rc<Option<LiteModule>>,
+        module: Rc<Option<Module>>,
     ) -> Self {
         Self {
             module,
@@ -43,7 +40,7 @@ impl State {
     pub fn kind_str(&self) -> &'static str {
         match &*self.module {
             None => "",
-            Some(module) => module.kind.as_str(),
+            Some(module) => module.kind().as_str(),
         }
     }
 
@@ -57,7 +54,7 @@ impl State {
                 None => return "empty",
                 Some(this_module) => {
                     match route {
-                        JigEditRoute::Module(active_module_id) if active_module_id == &this_module.id => return "active",
+                        JigEditRoute::Module(active_module_id) if active_module_id == this_module.id() => return "active",
                         _ => return "thumbnail",
                     }
                 }

--- a/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/module_cloner.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/module_cloner.rs
@@ -24,6 +24,7 @@ pub async fn clone_module(
     Ok(LiteModule {
         id: id,
         kind: module.body.kind(),
+        is_complete: module.is_complete,
     })
 }
 

--- a/frontend/apps/crates/utils/src/iframe.rs
+++ b/frontend/apps/crates/utils/src/iframe.rs
@@ -187,4 +187,6 @@ pub enum ModuleToJigPlayerMessage {
 pub enum ModuleToJigEditorMessage {
     AppendModule(LiteModule),
     Next,
+    /// Whenever a module is marked as complete, i.e. has the minimum required content.
+    Completed(ModuleId),
 }

--- a/frontend/elements/src/entry/jig/_common/sidebar-modules/module.ts
+++ b/frontend/elements/src/entry/jig/_common/sidebar-modules/module.ts
@@ -53,11 +53,21 @@ export class _ extends LitElement {
                 :host([collapsed]) section {
                     cursor: pointer;
                 }
-                section.selected {
+
+                :host([selected]) section {
                     border-color: #e7f0fd;
                     background-color: #f8f9fd;
                     border-left-color: var(--main-blue);
                 }
+
+                :host([incomplete]) section {
+                    border-left-color: var(--light-red-1);
+                }
+
+                :host([incomplete][selected]) section {
+                    border-left-color: var(--light-red-4);
+                }
+
                 :host([collapsed]) section {
                     height: 136px;
                     width: 72px;
@@ -199,8 +209,11 @@ export class _ extends LitElement {
         ];
     }
 
-    @property({ type: Boolean })
+    @property({ type: Boolean, reflect: true })
     selected: boolean = false;
+
+    @property({ type: Boolean, reflect: true })
+    incomplete: boolean = false;
 
     // Should be the raw index in the JIG's module list
     // Will be bumped by 1 for display purposes
@@ -252,7 +265,7 @@ export class _ extends LitElement {
 
     renderModuleImg() {
         const { collapsed, module } = this;
-        
+
         if (!collapsed && module === "") return nothing;
 
         const iconPath = `entry/jig/modules/small/${module || "empty"}.svg`;
@@ -262,11 +275,11 @@ export class _ extends LitElement {
             </div>
         `;
     }
-    
-    render() {
-        const { selected, index, dragging, module } = this;
 
-        const sectionClasses = classMap({ selected, dragging });
+    render() {
+        const { index, dragging, module } = this;
+
+        const sectionClasses = classMap({ dragging });
         const addContainerClasses = classMap({
             ["add-container"]: true,
             dragging,

--- a/shared/rust/src/domain/jig/module.rs
+++ b/shared/rust/src/domain/jig/module.rs
@@ -189,6 +189,10 @@ pub struct LiteModule {
 
     /// Which kind of module this is.
     pub kind: ModuleKind,
+
+    /// Whether this module is completed.
+    #[serde(default)]
+    pub is_complete: bool,
 }
 
 /// Over the wire representation of a module.


### PR DESCRIPTION
Part of #2216 

This is a large-ish change that required some updates to some endpoints (@RickyLB) and a fair amount of frontend updates (@MendyBerger @mastapegs):

- Updates JIG endpoints to return the jig_data_module.is_complete field;
- Updates the publish endpoint so that it checks whether a JIG has modules and whether all modules have content set;
- Updates and adds new backend integration tests;
- Includes visual indicators in the sidebar for modules which have not had their content set;
- Includes unimplemented child function to apply warning content when attempting to publish a JIG with no modules or incomplete modules.

**Does not include** visual changes to the publish page or logic to fix the error during preview JIG when viewing an activity without content.

Screenshots of logic working using sidebar colors temporarily:

### Sidebar open, _incomplete_ activity selected:

![Screenshot from 2022-01-18 10-23-36](https://user-images.githubusercontent.com/4161106/149900980-9f455802-a5c2-49ad-bf75-f7e7b36ee0e1.png)

### Sidebar open, _complete_ activity selected:

![Screenshot from 2022-01-18 10-23-20](https://user-images.githubusercontent.com/4161106/149900996-06748d0c-f042-49c0-bf81-874c2f6b78c3.png)

### Sidebar closed, _incomplete_ activity selected

![Screenshot from 2022-01-18 10-23-05](https://user-images.githubusercontent.com/4161106/149901002-6ad1b5d4-94e4-40df-afa6-c881ef1739ae.png)

### Sidebar closed, _complete_ activity selected

![Screenshot from 2022-01-18 10-22-53](https://user-images.githubusercontent.com/4161106/149901004-df5e39d5-591c-4118-a643-e3600130b088.png)
