### PR TITLE
feat(fe/jig/edit): Disable publish button in JIG edit when a JIG is incomplete

### DIFF
--- a/frontend/apps/crates/entry/jig/edit/src/edit/publish/dom/mod.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/publish/dom/mod.rs
@@ -240,6 +240,7 @@ fn render_page(state: Rc<Publish>) -> Dom {
                     .child(html!("button-rect", {
                         .text(STR_PUBLISH)
                         .text(state.jig.focus_display())
+                        .property("disabled", state.jig.modules.lock_ref().iter().find(|m| !m.is_complete).is_some())
                         .child(html!("fa-icon", {
                             .property("icon", "fa-light fa-rocket-launch")
                             .style("color", "var(--main-yellow)")


### PR DESCRIPTION
Part of #2216

![image](https://user-images.githubusercontent.com/4161106/150070113-30b4a6be-fd54-4c1a-9861-ef38449e097a.png)
