### PR TITLE
feat(fe/components/cards): Implement minimum requirements for card games

### DIFF
--- a/frontend/apps/crates/components/src/lists/dual/dom.rs
+++ b/frontend/apps/crates/components/src/lists/dual/dom.rs
@@ -33,25 +33,17 @@ pub fn render(state: Rc<State>) -> Dom {
                 }))
             }),
             html!("button-rect", {
-                .property_signal("color", state.is_valid_signal().map(|ready| {
-                    if ready.is_err() {
-                        "lightGray"
-                    } else {
-                        "red"
-                    }
-                }))
-                //.property_signal("disabled", state.is_valid_signal().map(|ready| ready.is_err()))
+                .property_signal("disabled", state.is_valid_signal().map(|valid| !valid))
                 .property("size", "small")
                 .property("iconAfter", "done")
                 .property("slot", "done-btn")
                 .text(super::strings::STR_DONE)
                 .event(clone!(state => move |_evt:events::Click| {
                     match state.derive_list() {
-                        Ok(list) => {
+                        Some(list) => {
                             (state.callbacks.replace_list) (list);
                         },
-                        Err(_err) => {
-
+                        None => {
                             (state.callbacks.set_tooltip_error) (Some(
                                     Rc::new(TooltipState::new(
                                         TooltipTarget::Element(

--- a/frontend/apps/crates/components/src/lists/dual/state.rs
+++ b/frontend/apps/crates/components/src/lists/dual/state.rs
@@ -132,8 +132,6 @@ impl State {
             .find(|(left, right)| (left.is_empty() || right.is_empty()) && !(left.is_empty() && right.is_empty()))
             .is_none();
 
-        log::info!("FOO contents_valid {}", contents_valid);
-
         if contents_valid {
             let list: Vec<(&str, &str)> = create_iter(left, right)
                 // At this point we know that the only rows with empty data are the prefilled rows,
@@ -143,7 +141,6 @@ impl State {
             // If the final list's length is less than the minimum or somehow there are more rows, the list
             // is invalid.
             let list_len = list.len();
-            log::info!("FOO list_len {}", list_len);
             if list_len >= self.opts.min_valid && list_len <= self.opts.max_rows {
                 Some(list)
             } else {

--- a/frontend/apps/crates/components/src/lists/dual/state.rs
+++ b/frontend/apps/crates/components/src/lists/dual/state.rs
@@ -2,6 +2,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use super::callbacks::Callbacks;
+use futures_signals::signal_vec::MutableVecLockRef;
 use futures_signals::{
     map_ref,
     signal::{Mutable, Signal},
@@ -59,72 +60,100 @@ impl State {
         }
     }
 
-    /// TODO - can derive_list and is_valid_signal be consolidated?
-    pub fn derive_list(&self) -> Result<Vec<(String, String)>, Error> {
-        let list: Vec<(String, String)> = self
-            .left
-            .lock_ref()
-            .iter()
-            .map(|mutable_string| mutable_string.get_cloned())
-            .filter(|x| !x.is_empty())
-            .zip(
-                self.right
-                    .lock_ref()
-                    .iter()
-                    .map(|mutable_string| mutable_string.get_cloned())
-                    .filter(|x| !x.is_empty()),
-            )
-            .collect();
+    pub fn derive_list(self: &Rc<Self>) -> Option<Vec<(String, String)>> {
+        let into_list = |vec: MutableVecLockRef<Mutable<String>>| {
+            vec.iter()
+                .map(|value| value.get_cloned())
+                .collect::<Vec<String>>()
+        };
 
-        if list.len() < self.opts.min_valid {
-            Err(Error::NumWords)
-        } else {
-            Ok(list)
-        }
+        // Create the left and right list without filtering the values. We need to be able to work
+        // out whether the actual _rows_ have valid data.
+        let left = into_list(self.left.lock_ref());
+        let right = into_list(self.right.lock_ref());
+
+        self.clone().filtered_list(&left, &right)
+            .map(|list| list.iter()
+                .map(|(left, right)| (left.to_string(), right.to_string()))
+                .collect()
+            )
     }
 
-    pub fn is_valid_signal(&self) -> impl Signal<Item = Result<(), Error>> {
-        let min_valid = self.opts.min_valid;
+    pub fn is_valid_signal(self: &Rc<Self>) -> impl Signal<Item = bool> {
+        let state = Rc::clone(self);
 
-        let left_sig = self
-            .left
-            .signal_vec_cloned()
-            .map_signal(|inner| inner.signal_cloned())
-            .to_signal_map(|x| {
-                x.iter()
-                    .filter(|x| !x.is_empty())
-                    .map(|_x| ())
-                    .collect::<Vec<()>>()
-            });
+        let into_signal = |signal_vec: &Rc<MutableVec<Mutable<String>>>| {
+            signal_vec
+                .signal_vec_cloned()
+                .map_signal(|inner| inner.signal_cloned())
+                .to_signal_map(|value| {
+                    value.iter()
+                        .map(|value| value.to_owned())
+                        .collect::<Vec<String>>()
+                })
+        };
 
-        let right_sig = self
-            .right
-            .signal_vec_cloned()
-            .map_signal(|inner| inner.signal_cloned())
-            .to_signal_map(|x| {
-                x.iter()
-                    .filter(|x| !x.is_empty())
-                    .map(|_x| ())
-                    .collect::<Vec<()>>()
-            });
+        // Create the left and right list without filtering the values. We need to be able to work
+        // out whether the actual _rows_ have valid data.
+        let left_sig = into_signal(&state.left);
+        let right_sig = into_signal(&state.right);
 
         map_ref! {
             let left = left_sig,
             let right = right_sig
                 => move {
-                    let count =
-                        left.iter()
-                            .zip(right.iter())
-                            .count();
-
-                    if count < min_valid {
-                        Err(Error::NumWords)
-                    } else {
-                        Ok(())
-                    }
+                    state.clone().filtered_list(&left, &right).is_some()
                 }
         }
     }
+
+    /// Compares the left and right lists and returns a zipped list _if_ left and right have the same
+    /// amount of values and their lengths are >= `min_valid` and <= `max_rows`.
+    ///
+    /// Note: an owned Rc<Self> is required because a caller can be inside a signals callback and
+    /// we need to guarantee that `self` remains valid.
+    fn filtered_list<'a>(self: Rc<Self>, left: &'a Vec<String>, right: &'a Vec<String>) -> Option<Vec<(&'a str, &'a str)>> {
+        // We need to recreate the iterator because it is consumed
+        let create_iter = |left: &'a Vec<String>, right: &'a Vec<String>| {
+            left.iter().zip(right.iter())
+                // Make sure that we won't be checking whether strings like "   " are empty. This also
+                // cleans up strings wrapped with whitespace.
+                .map(|(left, right)| (left.trim(), right.trim()))
+        };
+
+        // First ensure that each row has values for left and right. If we did a filter instead,
+        // then the filter would simply _remove_ invalid values which would be fine, but it
+        // would affect the UX - If a teacher added 6 words for the left, and only 5 on the right
+        // by accident, they'd have to recapture their entries again to correct the mistake.
+        let contents_valid = create_iter(left, right)
+            // Ensure that each row has both left and right values set.
+            // Because both lists are prefilled with empty strings, we need to check that either
+            // side is empty, but not both sides as that would be an empty row.
+            .find(|(left, right)| (left.is_empty() || right.is_empty()) && !(left.is_empty() && right.is_empty()))
+            .is_none();
+
+        log::info!("FOO contents_valid {}", contents_valid);
+
+        if contents_valid {
+            let list: Vec<(&str, &str)> = create_iter(left, right)
+                // At this point we know that the only rows with empty data are the prefilled rows,
+                // so we can safely filter them out.
+                .filter(|(left, right)| !left.is_empty() && !right.is_empty())
+                .collect();
+            // If the final list's length is less than the minimum or somehow there are more rows, the list
+            // is invalid.
+            let list_len = list.len();
+            log::info!("FOO list_len {}", list_len);
+            if list_len >= self.opts.min_valid && list_len <= self.opts.max_rows {
+                Some(list)
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    }
+
     pub fn clear(&self) {
         for mutable_string in self.left.lock_ref().iter() {
             mutable_string.set(String::default());
@@ -136,3 +165,4 @@ impl State {
         self.is_placeholder.set_neq(true);
     }
 }
+

--- a/frontend/apps/crates/components/src/lists/single/dom.rs
+++ b/frontend/apps/crates/components/src/lists/single/dom.rs
@@ -29,24 +29,17 @@ pub fn render(state: Rc<State>) -> Dom {
                 }))
             }),
             html!("button-rect", {
-                .property_signal("color", state.is_valid_signal().map(|ready| {
-                    if ready.is_err() {
-                        "lightGray"
-                    } else {
-                        "red"
-                    }
-                }))
-                //.property_signal("disabled", state.is_valid_signal().map(|ready| ready.is_err()))
+                .property_signal("disabled", state.is_valid_signal().map(|valid| !valid))
                 .property("size", "small")
                 .property("iconAfter", "done")
                 .property("slot", "done-btn")
                 .text(super::strings::STR_DONE)
                 .event(clone!(state => move |_evt:events::Click| {
                     match state.derive_list() {
-                        Ok(list) => {
+                        Some(list) => {
                             (state.callbacks.replace_list) (list);
                         },
-                        Err(_err) => {
+                        None => {
                             (state.callbacks.set_tooltip_error) (Some(
                                     Rc::new(TooltipState::new(
                                         TooltipTarget::Element(

--- a/frontend/apps/crates/components/src/module/_common/edit/entry/actions.rs
+++ b/frontend/apps/crates/components/src/module/_common/edit/entry/actions.rs
@@ -162,11 +162,8 @@ pub fn save<RawData, Mode, Step>(
         });
         let _ = api_with_auth_empty::<EmptyError, _>(&path, Update::METHOD, req).await; //.expect_ji("error saving module!");
 
-        if is_complete {
-            // Let the sidebar know that this module has been marked as completed so that it can
-            // update any relevant states.
-            let _ = IframeAction::new(ModuleToJigEditorMessage::Completed(module_id)).try_post_message_to_editor();
-        }
+        // Update the sidebar with this modules completion status
+        let _ = IframeAction::new(ModuleToJigEditorMessage::Complete(module_id, is_complete)).try_post_message_to_editor();
 
         screenshot_loader.load(async move {
             call_screenshot_service(jig_id, module_id, RawData::kind()).await;

--- a/frontend/apps/crates/components/src/module/_groups/cards/edit/config.rs
+++ b/frontend/apps/crates/components/src/module/_groups/cards/edit/config.rs
@@ -4,8 +4,6 @@ use serde::Deserialize;
 use shared::domain::jig::module::body::_groups::cards::Mode;
 use utils::prelude::*;
 
-pub const MAX_LIST_WORDS: usize = 14;
-
 pub static DUAL_LIST_CHAR_LIMIT: usize = 30;
 pub static SINGLE_LIST_CHAR_LIMIT: usize = 30;
 pub static CARD_TEXT_LIMIT_WIDTH: f64 = 150.0;

--- a/frontend/apps/crates/components/src/module/_groups/cards/edit/sidebar/step_1/state.rs
+++ b/frontend/apps/crates/components/src/module/_groups/cards/edit/sidebar/step_1/state.rs
@@ -19,7 +19,10 @@ use crate::{
 use dominator::clone;
 use futures_signals::signal::Mutable;
 use once_cell::sync::OnceCell;
-use shared::domain::jig::module::body::{Image, _groups::cards::Mode};
+use shared::{
+    domain::jig::module::body::{Image, _groups::cards::Mode},
+    config as shared_config,
+};
 use utils::unwrap::UnwrapJiExt;
 use std::rc::Rc;
 
@@ -139,8 +142,8 @@ fn make_single_list<RawData: RawDataExt, E: ExtraExt>(
     );
 
     let options = SingleListOptions {
-        max_rows: config::MAX_LIST_WORDS,
-        min_valid: 2,
+        max_rows: shared_config::MAX_LIST_WORDS,
+        min_valid: shared_config::MIN_LIST_WORDS,
     };
 
     SingleListState::new(options, callbacks)
@@ -165,14 +168,14 @@ fn make_dual_list<RawData: RawDataExt, E: ExtraExt>(
     );
 
     let options = DualListOptions {
-        max_rows: config::MAX_LIST_WORDS,
+        max_rows: shared_config::MAX_LIST_WORDS,
         cell_rows: {
             match state.base.mode {
                 Mode::Riddles => 2,
                 _ => 1,
             }
         },
-        min_valid: 2,
+        min_valid: shared_config::MIN_LIST_WORDS,
     };
 
     DualListState::new(options, callbacks)

--- a/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/actions.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/actions.rs
@@ -123,7 +123,7 @@ pub fn on_iframe_message(state: Rc<State>, message: ModuleToJigEditorMessage) {
         ModuleToJigEditorMessage::AppendModule(module) => {
             populate_added_module(Rc::clone(&state), module);
         }
-        ModuleToJigEditorMessage::Completed(module_id) => {
+        ModuleToJigEditorMessage::Complete(module_id, is_complete) => {
             let modules = state.modules.lock_ref();
             let module = modules.into_iter().find(|module| {
                 // Oh my.
@@ -133,10 +133,9 @@ pub fn on_iframe_message(state: Rc<State>, message: ModuleToJigEditorMessage) {
                 }
             });
 
-
             if let Some(module) = module {
                 if let Some(module) = &**module {
-                    module.is_complete.set_neq(true);
+                    module.is_complete.set_neq(is_complete);
                 }
             }
         }

--- a/frontend/apps/crates/utils/src/iframe.rs
+++ b/frontend/apps/crates/utils/src/iframe.rs
@@ -187,6 +187,6 @@ pub enum ModuleToJigPlayerMessage {
 pub enum ModuleToJigEditorMessage {
     AppendModule(LiteModule),
     Next,
-    /// Whenever a module is marked as complete, i.e. has the minimum required content.
-    Completed(ModuleId),
+    /// Whenever a modules completion status changes, i.e. meets the minimum required content.
+    Complete(ModuleId, bool),
 }

--- a/shared/rust/src/config.rs
+++ b/shared/rust/src/config.rs
@@ -11,6 +11,12 @@ pub const JIG_PLAYER_SESSION_VALID_DURATION_SECS: u32 = 60 * 60 * 24 * 14;
 /// means 0-9999 are possible. If this is changed then the DB's check constraint must also be updated.
 pub const JIG_PLAYER_SESSION_CODE_MAX: i16 = 9999;
 
+/// Minimum amount of words which should be added to a list for a game.
+pub const MIN_LIST_WORDS: usize = 2;
+
+/// Maximum amount of words which should be added to a list for a game.
+pub const MAX_LIST_WORDS: usize = 14;
+
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum RemoteTarget {
     Local,

--- a/shared/rust/src/domain/jig/module/body/_groups/cards.rs
+++ b/shared/rust/src/domain/jig/module/body/_groups/cards.rs
@@ -3,10 +3,8 @@
  * But the editor steps are identical except for 3
  */
 use crate::{
-    domain::jig::module::body::{
-        Background, Image, Instructions, ModeExt, StepExt, ThemeChoice,
-    },
     config,
+    domain::jig::module::body::{Background, Image, Instructions, ModeExt, StepExt, ThemeChoice},
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -131,26 +129,30 @@ impl Mode {
         match self {
             // Text/Image pairs
             Self::WordsAndImages => {
-                pairs.iter().find(|pair| {
-                    // Neither card should be empty; the first card should be a Text variant and
-                    // the 2nd card should be an Image variant.
-                    pair.0.is_empty()
-                        || pair.1.is_empty()
-                        || !matches!(pair.0, Card::Text(_))
-                        || !matches!(pair.1, Card::Image(_))
-                })
-                .is_none()
-            },
+                pairs
+                    .iter()
+                    .find(|pair| {
+                        // Neither card should be empty; the first card should be a Text variant and
+                        // the 2nd card should be an Image variant.
+                        pair.0.is_empty()
+                            || pair.1.is_empty()
+                            || !matches!(pair.0, Card::Text(_))
+                            || !matches!(pair.1, Card::Image(_))
+                    })
+                    .is_none()
+            }
             // Text/Text pairs
             _ => {
-                pairs.iter().find(|pair| {
-                    // Neither card should be empty, and both cards must be Image variants.
-                    pair.0.is_empty()
-                        || pair.1.is_empty()
-                        || !matches!(pair.0, Card::Text(_))
-                        || !matches!(pair.1, Card::Text(_))
-                })
-                .is_none()
+                pairs
+                    .iter()
+                    .find(|pair| {
+                        // Neither card should be empty, and both cards must be Image variants.
+                        pair.0.is_empty()
+                            || pair.1.is_empty()
+                            || !matches!(pair.0, Card::Text(_))
+                            || !matches!(pair.1, Card::Text(_))
+                    })
+                    .is_none()
             }
         }
     }

--- a/shared/rust/src/domain/jig/module/body/_groups/cards.rs
+++ b/shared/rust/src/domain/jig/module/body/_groups/cards.rs
@@ -2,8 +2,11 @@
  * The card modules not only share some base content
  * But the editor steps are identical except for 3
  */
-use crate::domain::jig::module::body::{
-    Background, Image, Instructions, ModeExt, StepExt, ThemeChoice,
+use crate::{
+    domain::jig::module::body::{
+        Background, Image, Instructions, ModeExt, StepExt, ThemeChoice,
+    },
+    config,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -38,6 +41,14 @@ impl BaseContent {
             ..Self::default()
         }
     }
+
+    /// Convenience method to determine whether pairs have been configured correctly
+    pub fn is_valid(&self) -> bool {
+        let pair_len = self.pairs.len();
+        pair_len >= config::MIN_LIST_WORDS
+            && pair_len <= config::MAX_LIST_WORDS
+            && self.mode.pairs_valid(&self.pairs)
+    }
 }
 
 /// Editor state
@@ -64,6 +75,17 @@ pub enum Card {
     // todo(@dakom): document this
     #[allow(missing_docs)]
     Image(Option<Image>),
+}
+
+impl Card {
+    /// Whether the variants value is empty
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Self::Text(value) if value.trim().len() == 0 => true,
+            Self::Image(None) => true,
+            _ => false,
+        }
+    }
 }
 
 /// What mode the module runs in.
@@ -101,6 +123,37 @@ pub enum Mode {
 
     /// Translate from one language to another.
     Translate = 7,
+}
+
+impl Mode {
+    /// Returns whether a list of card pairs are valid for the game mode
+    pub fn pairs_valid(&self, pairs: &Vec<CardPair>) -> bool {
+        match self {
+            // Text/Image pairs
+            Self::WordsAndImages => {
+                pairs.iter().find(|pair| {
+                    // Neither card should be empty; the first card should be a Text variant and
+                    // the 2nd card should be an Image variant.
+                    pair.0.is_empty()
+                        || pair.1.is_empty()
+                        || !matches!(pair.0, Card::Text(_))
+                        || !matches!(pair.1, Card::Image(_))
+                })
+                .is_none()
+            },
+            // Text/Text pairs
+            _ => {
+                pairs.iter().find(|pair| {
+                    // Neither card should be empty, and both cards must be Image variants.
+                    pair.0.is_empty()
+                        || pair.1.is_empty()
+                        || !matches!(pair.0, Card::Text(_))
+                        || !matches!(pair.1, Card::Text(_))
+                })
+                .is_none()
+            }
+        }
+    }
 }
 
 impl Default for Mode {

--- a/shared/rust/src/domain/jig/module/body/card_quiz.rs
+++ b/shared/rust/src/domain/jig/module/body/card_quiz.rs
@@ -59,7 +59,9 @@ impl BodyExt<Mode, Step> for ModuleData {
     }
 
     fn is_complete(&self) -> bool {
-        self.content.as_ref().map_or(false, |content| content.base.is_valid())
+        self.content
+            .as_ref()
+            .map_or(false, |content| content.base.is_valid())
     }
 
     fn kind() -> ModuleKind {

--- a/shared/rust/src/domain/jig/module/body/card_quiz.rs
+++ b/shared/rust/src/domain/jig/module/body/card_quiz.rs
@@ -59,7 +59,7 @@ impl BodyExt<Mode, Step> for ModuleData {
     }
 
     fn is_complete(&self) -> bool {
-        self.content.is_some()
+        self.content.as_ref().map_or(false, |content| content.base.is_valid())
     }
 
     fn kind() -> ModuleKind {

--- a/shared/rust/src/domain/jig/module/body/flashcards.rs
+++ b/shared/rust/src/domain/jig/module/body/flashcards.rs
@@ -71,7 +71,7 @@ impl BodyExt<Mode, Step> for ModuleData {
     }
 
     fn is_complete(&self) -> bool {
-        self.content.is_some()
+        self.content.as_ref().map_or(false, |content| content.base.is_valid())
     }
 
     fn kind() -> ModuleKind {

--- a/shared/rust/src/domain/jig/module/body/flashcards.rs
+++ b/shared/rust/src/domain/jig/module/body/flashcards.rs
@@ -71,7 +71,9 @@ impl BodyExt<Mode, Step> for ModuleData {
     }
 
     fn is_complete(&self) -> bool {
-        self.content.as_ref().map_or(false, |content| content.base.is_valid())
+        self.content
+            .as_ref()
+            .map_or(false, |content| content.base.is_valid())
     }
 
     fn kind() -> ModuleKind {

--- a/shared/rust/src/domain/jig/module/body/matching.rs
+++ b/shared/rust/src/domain/jig/module/body/matching.rs
@@ -62,7 +62,9 @@ impl BodyExt<Mode, Step> for ModuleData {
             .collect()
     }
     fn is_complete(&self) -> bool {
-        self.content.as_ref().map_or(false, |content| content.base.is_valid())
+        self.content
+            .as_ref()
+            .map_or(false, |content| content.base.is_valid())
     }
 
     fn kind() -> ModuleKind {

--- a/shared/rust/src/domain/jig/module/body/matching.rs
+++ b/shared/rust/src/domain/jig/module/body/matching.rs
@@ -62,7 +62,7 @@ impl BodyExt<Mode, Step> for ModuleData {
             .collect()
     }
     fn is_complete(&self) -> bool {
-        self.content.is_some()
+        self.content.as_ref().map_or(false, |content| content.base.is_valid())
     }
 
     fn kind() -> ModuleKind {

--- a/shared/rust/src/domain/jig/module/body/memory.rs
+++ b/shared/rust/src/domain/jig/module/body/memory.rs
@@ -35,7 +35,9 @@ impl BodyExt<Mode, Step> for ModuleData {
     }
 
     fn is_complete(&self) -> bool {
-        self.content.as_ref().map_or(false, |content| content.base.is_valid())
+        self.content
+            .as_ref()
+            .map_or(false, |content| content.base.is_valid())
     }
 
     fn kind() -> ModuleKind {

--- a/shared/rust/src/domain/jig/module/body/memory.rs
+++ b/shared/rust/src/domain/jig/module/body/memory.rs
@@ -35,7 +35,7 @@ impl BodyExt<Mode, Step> for ModuleData {
     }
 
     fn is_complete(&self) -> bool {
-        self.content.is_some()
+        self.content.as_ref().map_or(false, |content| content.base.is_valid())
     }
 
     fn kind() -> ModuleKind {


### PR DESCRIPTION
Part of #2216

- Implements rules for minimum requirements in card games:
  - Words and Images: at least 2 pairs (max of 14), text card must not have empty text and images must be set on both pairs;
  - All other card types: at least 2 pairs (max of 14) and cards may not have empty text.
- Update so that if a teacher wants to replace the word list, the state of the module is marked as incomplete (previously it would only mark as complete once and never update again);
- Moves MAX_LIST_WORDS to shared config; Adds MIN_LIST_WORDS to shared config (previously it was a magic number `2`).

Extra work included in this PR:
- Fixed dual and single lists so that their validation logic catches mismatched lists, empty text, etc.