### PR TITLE
fix(fe/jig/edit): Only request a screenshot once a modules content has been marked as complete

### DIFF
--- a/frontend/apps/crates/components/src/module/_common/edit/entry/actions.rs
+++ b/frontend/apps/crates/components/src/module/_common/edit/entry/actions.rs
@@ -160,14 +160,17 @@ pub fn save<RawData, Mode, Step>(
             index: None,
             body: Some(body),
         });
-        let _ = api_with_auth_empty::<EmptyError, _>(&path, Update::METHOD, req).await; //.expect_ji("error saving module!");
+        let _ = api_with_auth_empty::<EmptyError, _>(&path, Update::METHOD, req).await;
 
         // Update the sidebar with this modules completion status
         let _ = IframeAction::new(ModuleToJigEditorMessage::Complete(module_id, is_complete)).try_post_message_to_editor();
 
-        screenshot_loader.load(async move {
-            call_screenshot_service(jig_id, module_id, RawData::kind()).await;
-        });
+        if is_complete {
+            // Only generate a screenshot if the module has the minimum required content.
+            screenshot_loader.load(async move {
+                call_screenshot_service(jig_id, module_id, RawData::kind()).await;
+            });
+        }
     });
 }
 

--- a/frontend/apps/crates/components/src/module/_common/thumbnail/dom.rs
+++ b/frontend/apps/crates/components/src/module/_common/thumbnail/dom.rs
@@ -61,12 +61,20 @@ impl ModuleThumbnail {
             .apply_if(slot.is_some(), |dom| {
                 dom.property("slot", slot.unwrap_ji())
             })
-            .event(clone!(state => move |_evt:events::ImageError| {
-                spawn_local(clone!(state => async move {
-                    if let Some(module) = &state.module {
-                        call_screenshot_service(state.jig_id, module.id, module.kind).await;
+            .event(clone!(state => move |_evt: events::ImageError| {
+                if let Some(module) = &state.module {
+                    // We need to ensure that the screenshot is only generated for activities which
+                    // have their content set, otherwise it will render a possible error page.
+                    if module.is_complete {
+                        spawn_local(clone!(state => async move {
+                                // Don't need to clone module, we can fetch it out of state. Also,
+                                // unwrapping is fine here as we've already validated that it is
+                                // Some.
+                                let module = state.module.as_ref().unwrap_ji();
+                                call_screenshot_service(state.jig_id, module.id, module.kind).await;
+                        }))
                     }
-                }))
+                }
             }))
             .property("jigId", state.jig_id.0.to_string())
             .apply(clone!(state => move |dom| {


### PR DESCRIPTION
@corinnewo @GaliShapira This change prevents a screenshot from being requested until the activity has had the minimum required content set. When no screenshot exists, it already defaulted to "thumb-placeholder.svg".

#### Before

![Screenshot from 2022-01-21 09-45-51](https://user-images.githubusercontent.com/4161106/150487452-fb05e019-b206-49db-8db2-6254228be771.png)

#### After

![Screenshot from 2022-01-21 09-46-51](https://user-images.githubusercontent.com/4161106/150487484-845db35c-54ba-442b-8dcc-c091f99e9243.png)

