### PR TITLE
Incomplete error tooltip

### DIFF
--- a/frontend/apps/crates/entry/jig/edit/Cargo.toml
+++ b/frontend/apps/crates/entry/jig/edit/Cargo.toml
@@ -27,7 +27,7 @@ web-sys = { version = "0.3.55", features = [
     'Response',
     'RequestMode',
     'Headers',
-    'Document', 
+    'Document',
     'DocumentFragment',
     'HtmlTemplateElement',
     'Window',
@@ -45,7 +45,9 @@ web-sys = { version = "0.3.55", features = [
     'MouseEvent',
     'FileList',
     'File',
-    'DomRect'
+    'DomRect',
+    'ScrollIntoViewOptions',
+    'ScrollBehavior'
 ] }
 wasm-bindgen-futures = "0.4.28"
 htmlescape = "0.3.1"

--- a/frontend/apps/crates/entry/jig/edit/src/edit/publish/dom/mod.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/publish/dom/mod.rs
@@ -240,7 +240,12 @@ fn render_page(state: Rc<Publish>) -> Dom {
                     .child(html!("button-rect", {
                         .text(STR_PUBLISH)
                         .text(state.jig.focus_display())
-                        .property("disabled", state.jig.modules.lock_ref().iter().find(|m| !m.is_complete).is_some())
+                        .property(
+                            "disabled",
+                            state.jig.jig_focus.is_modules()
+                            && (state.jig.modules.lock_ref().len() == 0 // Disabled
+                                || state.jig.modules.lock_ref().iter().find(|m| !m.is_complete).is_some())
+                        )
                         .child(html!("fa-icon", {
                             .property("icon", "fa-light fa-rocket-launch")
                             .style("color", "var(--main-yellow)")
@@ -250,6 +255,7 @@ fn render_page(state: Rc<Publish>) -> Dom {
                         }))
                     }))
                     .child_signal(state.show_missing_info_popup.signal().map(clone!(state, elem => move |show_popup| {
+
                         if show_popup {
                             let on_close = clone!(state => move|| {
                                 state.show_missing_info_popup.set(false);

--- a/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/actions.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/actions.rs
@@ -54,6 +54,20 @@ pub fn navigate_to_publish(state: Rc<State>) {
     )));
 }
 
+pub fn set_highlight_modules(state: &Rc<State>, highlight: bool) {
+    if highlight {
+        let idx = state.modules.lock_ref().iter()
+            .position(|module| match &**module {
+                    Some(module) => !module.is_complete.get_cloned(),
+                    None => false,
+                }
+            );
+        state.highlight_modules.set_neq(idx);
+    } else {
+        state.highlight_modules.set_neq(None);
+    }
+}
+
 pub async fn update_jig(jig_id: &JigId, req: JigUpdateDraftDataRequest) -> Result<(), EmptyError> {
     let path = endpoints::jig::UpdateDraftData::PATH.replace("{id}", &jig_id.0.to_string());
     api_with_auth_empty::<EmptyError, _>(&path, endpoints::jig::UpdateDraftData::METHOD, Some(req))

--- a/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/actions.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/actions.rs
@@ -56,13 +56,23 @@ pub fn navigate_to_publish(state: Rc<State>) {
 
 pub fn set_highlight_modules(state: &Rc<State>, highlight: bool) {
     if highlight {
-        let idx = state.modules.lock_ref().iter()
-            .position(|module| match &**module {
-                    Some(module) => !module.is_complete.get_cloned(),
-                    None => false,
-                }
-            );
-        state.highlight_modules.set_neq(idx);
+        let modules = state.modules.lock_ref();
+
+        if modules.iter().filter(|module| module.is_some()).count() == 0 {
+            state.highlight_modules.set_neq(Some(ModuleHighlight::Publish))
+        } else {
+            let idx = modules.iter()
+                .position(|module| match &**module {
+                        Some(module) => !module.is_complete.get_cloned(),
+                        None => false,
+                    }
+                );
+            match idx {
+                Some(idx) => state.highlight_modules.set_neq(Some(ModuleHighlight::Module(idx))),
+                None => state.highlight_modules.set_neq(None),
+            }
+        }
+
     } else {
         state.highlight_modules.set_neq(None);
     }

--- a/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/dom.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/dom.rs
@@ -94,7 +94,11 @@ impl SidebarDom {
                         matches!(route, JigEditRoute::Publish)
                     }))
                     .event(clone!(state => move |_ :events::Click| {
-                        actions::navigate_to_publish(state.clone());
+                        if state.can_publish() {
+                            actions::navigate_to_publish(state.clone());
+                        } else {
+                            actions::set_highlight_modules(&state, true);
+                        }
                     }))
                     .child(html!("menu-kebab", {
                         .property("slot", "menu")

--- a/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/module/actions.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/module/actions.rs
@@ -17,6 +17,9 @@ pub fn on_module_kind_drop(state: Rc<State>, module_kind: ModuleKind) {
     if state.module.is_none() {
         assign_kind(state.clone(), module_kind);
     }
+
+    // Remove module highlights whenever a new module is added to the list.
+    state.sidebar.highlight_modules.set_neq(None);
 }
 
 pub async fn update_module(

--- a/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/module/dom.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/module/dom.rs
@@ -5,7 +5,7 @@ use web_sys::{HtmlElement, Node, ScrollIntoViewOptions, ScrollBehavior};
 
 use super::super::menu::dom as MenuDom;
 use super::{actions, state::*};
-use crate::edit::sidebar::state::{State as SidebarState, Module};
+use crate::edit::sidebar::state::{State as SidebarState, Module, ModuleHighlight};
 use components::module::_common::thumbnail::ModuleThumbnail;
 use futures_signals::signal::{SignalExt, Mutable};
 use shared::domain::jig::ModuleKind;
@@ -46,7 +46,6 @@ impl ModuleDom {
                 .signal_cloned(),
             let highlight_modules = sidebar_state.highlight_modules.signal_cloned()
                 => {
-                    log::info!("is_complete {:?}, highlight {:?}", is_complete, highlight_modules);
                     !is_complete && highlight_modules.is_some()
                 }
         };
@@ -165,7 +164,7 @@ impl ModuleDom {
                         })))
                         .child_signal(state.sidebar.highlight_modules.signal_cloned().map(clone!(state, elem => move |highlight| {
                             match highlight {
-                                Some(idx) => {
+                                Some(ModuleHighlight::Module(idx)) => {
                                     if idx == state.index {
                                         // Make sure that the module window is visible to the
                                         // teacher.
@@ -191,7 +190,7 @@ impl ModuleDom {
                                         None
                                     }
                                 },
-                                None => None,
+                                _ => None,
                             }
                         })))
                         .apply(OverlayHandle::lifecycle(clone!(state => move || {

--- a/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/module/dom.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/module/dom.rs
@@ -1,7 +1,7 @@
 use components::overlay::handle::OverlayHandle;
 use dominator::{Dom, EventOptions, clone, html, with_node, DomBuilder};
 use futures_signals::map_ref;
-use web_sys::{HtmlElement, Node};
+use web_sys::{HtmlElement, Node, ScrollIntoViewOptions, ScrollBehavior};
 
 use super::super::menu::dom as MenuDom;
 use super::{actions, state::*};
@@ -167,6 +167,9 @@ impl ModuleDom {
                             match highlight {
                                 Some(idx) => {
                                     if idx == state.index {
+                                        // Make sure that the module window is visible to the
+                                        // teacher.
+                                        elem.scroll_into_view_with_scroll_into_view_options(ScrollIntoViewOptions::new().behavior(ScrollBehavior::Smooth));
                                         Some(html!("empty-fragment", {
                                             .apply(OverlayHandle::lifecycle(clone!(state, elem => move || {
                                                 html!("overlay-tooltip-error", {
@@ -178,9 +181,9 @@ impl ModuleDom {
                                                     .property("closeable", true)
                                                     .property("strategy", "track")
                                                     .style("width", "350px")
-                                                    /* .event(clone!(state => move |_:events::Close| {
-                                                        state.tried_module_at_cover.set(false);
-                                                    })) */
+                                                    .event(clone!(state => move |_:events::Close| {
+                                                        state.sidebar.highlight_modules.set_neq(None);
+                                                    }))
                                                 })
                                             })))
                                         }))

--- a/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/state.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/state.rs
@@ -5,7 +5,7 @@ use futures_signals::{
     signal::{Mutable, Signal, SignalExt},
     signal_vec::MutableVec,
 };
-use shared::domain::jig::{JigResponse, LiteModule, ModuleKind, module::body::BodyExt};
+use shared::domain::jig::{JigResponse, LiteModule, ModuleKind};
 use std::rc::Rc;
 use utils::math::PointI32;
 

--- a/frontend/elements/src/core/overlays/tooltip/container.ts
+++ b/frontend/elements/src/core/overlays/tooltip/container.ts
@@ -94,7 +94,7 @@ export class _ extends LitElement {
                     stroke: var(--tooltip-border-color);
                 }
 
-                /* arrow offsets 
+                /* arrow offsets
                 :host([arrowAnchor="tr"]) > .main {
                     margin-right: ${TRIANGLE_HEIGHT}px;
                 }

--- a/frontend/elements/src/core/overlays/tooltip/error.ts
+++ b/frontend/elements/src/core/overlays/tooltip/error.ts
@@ -39,7 +39,7 @@ export class _ extends LitElement {
                 article {
                     display: flex;
                     gap: 16px;
-                    align-items: center;
+                    align-items: flex-start;
                 }
             `,
         ];

--- a/frontend/elements/src/entry/jig/_common/sidebar-modules/module.ts
+++ b/frontend/elements/src/entry/jig/_common/sidebar-modules/module.ts
@@ -60,14 +60,6 @@ export class _ extends LitElement {
                     border-left-color: var(--main-blue);
                 }
 
-                :host([incomplete]) section {
-                    border-left-color: var(--light-red-1);
-                }
-
-                :host([incomplete][selected]) section {
-                    border-left-color: var(--light-red-4);
-                }
-
                 :host([collapsed]) section {
                     height: 136px;
                     width: 72px;
@@ -211,9 +203,6 @@ export class _ extends LitElement {
 
     @property({ type: Boolean, reflect: true })
     selected: boolean = false;
-
-    @property({ type: Boolean, reflect: true })
-    incomplete: boolean = false;
 
     // Should be the raw index in the JIG's module list
     // Will be bumped by 1 for display purposes

--- a/frontend/elements/src/entry/jig/edit/sidebar/module/window.ts
+++ b/frontend/elements/src/entry/jig/edit/sidebar/module/window.ts
@@ -44,11 +44,15 @@ export class _ extends LitElement {
                     background-color: var(--light-orange-1);
                 }
                 :host([state="active"]) .wrapper {
-                    background-color: var(--light-blue-5);
+                    border: solid var(--light-blue-5) 3px;
+                }
+                :host([incomplete]) .wrapper {
+                    border: solid var(--light-red-4) 3px;
                 }
                 :host([state="active"]) img-ui {
                     height: 100px;
                 }
+
                 slot[name="thumbnail"] {
                     display: none;
                 }
@@ -57,6 +61,9 @@ export class _ extends LitElement {
                 }
                 ::slotted([slot="thumbnail"]) {
                     border-radius: 16px;
+                }
+                :host([incomplete]) ::slotted([slot="thumbnail"]) {
+                    border: none;
                 }
 
                 .drag-here-text {
@@ -81,6 +88,9 @@ export class _ extends LitElement {
 
     @property()
     publishedThumbnail: string = "";
+
+    @property({ type: Boolean, reflect: true })
+    incomplete: boolean = false;
 
     @query(".wrapper")
     wrapper!: HTMLElement;


### PR DESCRIPTION
Closes #2216 

- Adds error tooltip to the first incomplete module in a JIG when the teacher clicks publish but has incomplete modules;
- Highlights incomplete modules in red;
- Scrolls to first incomplete module when clicking publish;
- Adds error tooltip to Publish window in the sidebar if the teacher clicks publish without adding any activities or a cover;
- Disables the publish button on the publish screen if the teacher hasn't added any activities or a cover.

Outstanding:
- [ ] ~Work out how to get the left-pointing arrow to show up;~
  - Currently only the up and down arrows show up when tracking the position of the module in the sidebar.
  - I have a draft PR with a POC refactor of tooltips to make them more practical: #2322 
- [x] Close the tooltip when the teacher clicks anywhere (or worst-case, just on the tooltip itself).

### Current progress:

![image](https://user-images.githubusercontent.com/4161106/150742300-b7ffaabc-6fa9-40cf-b7f8-2886126c213d.png)

