### PR TITLE
Tooltip refactor POC

### DIFF
--- a/frontend/elements/package-lock.json
+++ b/frontend/elements/package-lock.json
@@ -9,6 +9,7 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
+                "@floating-ui/dom": "^0.2.0",
                 "@fortawesome/pro-solid-svg-icons": "6.0.0-beta1",
                 "draft-js": "^0.11.7",
                 "lit-element": "^2.4.0",
@@ -642,6 +643,19 @@
             },
             "engines": {
                 "node": ">=0.1.95"
+            }
+        },
+        "node_modules/@floating-ui/core": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-0.4.0.tgz",
+            "integrity": "sha512-99Pnb5T2S7PSE8rKHD5fZWWnXE3a2xG9E8eQm8SIMYWJyJoHDJIt0b9SK3UjetWFcepxVG+ZMDxcfbamyx+HSg=="
+        },
+        "node_modules/@floating-ui/dom": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-0.2.0.tgz",
+            "integrity": "sha512-hNhTbImiJ8SH9rHsP0qcE9IVxn/maMhwWA5d17p7EkEzVdciayB664Qy2Vxa8RxY/8avE8iVKkfE8sIeg34J0g==",
+            "dependencies": {
+                "@floating-ui/core": "^0.4.0"
             }
         },
         "node_modules/@fluent/bundle": {
@@ -9650,6 +9664,19 @@
             "requires": {
                 "exec-sh": "^0.3.2",
                 "minimist": "^1.2.0"
+            }
+        },
+        "@floating-ui/core": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-0.4.0.tgz",
+            "integrity": "sha512-99Pnb5T2S7PSE8rKHD5fZWWnXE3a2xG9E8eQm8SIMYWJyJoHDJIt0b9SK3UjetWFcepxVG+ZMDxcfbamyx+HSg=="
+        },
+        "@floating-ui/dom": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-0.2.0.tgz",
+            "integrity": "sha512-hNhTbImiJ8SH9rHsP0qcE9IVxn/maMhwWA5d17p7EkEzVdciayB664Qy2Vxa8RxY/8avE8iVKkfE8sIeg34J0g==",
+            "requires": {
+                "@floating-ui/core": "^0.4.0"
             }
         },
         "@fluent/bundle": {

--- a/frontend/elements/package.json
+++ b/frontend/elements/package.json
@@ -16,6 +16,7 @@
     "author": "",
     "license": "MIT",
     "dependencies": {
+        "@floating-ui/dom": "^0.2.0",
         "@fortawesome/pro-solid-svg-icons": "6.0.0-beta1",
         "draft-js": "^0.11.7",
         "lit-element": "^2.4.0",

--- a/frontend/elements/src/core/overlays/tooltip/error-tooltip.ts
+++ b/frontend/elements/src/core/overlays/tooltip/error-tooltip.ts
@@ -1,0 +1,235 @@
+import { LitElement, html, css, customElement, property } from "lit-element";
+import { nothing } from "lit-html";
+import { styleMap } from "lit-html/directives/style-map";
+import {computePosition, shift, flip, arrow, offset, getScrollParents} from '@floating-ui/dom';
+import "@elements/core/overlays/container";
+import "@elements/core/overlays/content";
+import {
+    TrackerProp,
+    ZLayer,
+    Anchor,
+    ContentAnchor,
+    MoveStrategy,
+} from "@elements/core/overlays/content";
+import "@elements/core/buttons/icon";
+import "./container";
+import { Color } from "./container";
+
+@customElement("overlay-tooltip-error")
+export class _ extends LitElement {
+    static get styles() {
+        return [
+            css`
+                :host {
+                    font-family: Poppins;
+                    box-shadow: 0 3px 40px 0 rgba(0, 0, 0, 0.08);
+                    display: inline-block;
+
+                    --tooltip-bg-color: var(--light-red-1);
+                    --tooltip-border-color: var(--light-red-4);
+                }
+
+                .body {
+                }
+                div[role="tooltip"] {
+                    position: absolute;
+                    display: flex;
+                    gap: 16px;
+                    align-items: center;
+                    background-color: var(--tooltip-bg-color);
+                    border: solid 3px var(--tooltip-border-color);
+                    font-size: 16px;
+                    color: var(--dark-gray-6);
+                    border-radius: 25px;
+                    padding: 12px 24px;
+                }
+
+                div[role="tooltip"]::before, div[role="tooltip"]::after {
+                    content: '';
+                    position: absolute;
+                    border-color: background: transparent black transparent transparent;
+                    width: 0;
+                    height: 0;
+                    border-top: 8px solid transparent;
+                    border-bottom: 8px solid transparent;
+                    border-right: 8px solid red;
+                    transform: translateX(-33px);
+                }
+
+                div[role="tooltip"]::before {
+                    border-right: 8px solid var(--tooltip-border-color);
+                }
+
+                div[role="tooltip"]::after {
+                    border-right: 8px solid var(--tooltip-bg-color);
+                    transform: translateX(-29px);
+                }
+
+                div[role="tooltip"] #arrow {
+                    position: absolute;
+                    background: var(--tooltip-bg-color);
+                    width: 8px;
+                    height: 8px;
+                    transform: rotate(45deg);
+                }
+            `,
+        ];
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        window.addEventListener("mousedown", this.onGlobalMouseDown);
+    }
+    disconnectedCallback() {
+        super.disconnectedCallback();
+        window.removeEventListener("mousedown", this.onGlobalMouseDown);
+    }
+
+    onConfirm = () => {
+        this.dispatchEvent(new Event("accept"));
+    };
+    onCancel = () => {
+        this.dispatchEvent(new Event("close"));
+    };
+    onGlobalMouseDown = (evt: MouseEvent) => {
+        if (
+            !evt
+                .composedPath()
+                .includes(this.shadowRoot?.getElementById("tooltip") as any)
+        ) {
+            this.onCancel();
+        }
+    };
+
+    @property({ type: Number })
+    maxWidth: number = -1;
+
+    //internal
+    @property()
+    currContentAnchor: ContentAnchor = "oppositeH";
+
+    @property()
+    currTargetAnchor: Anchor = "tr";
+
+    //pass through
+    @property()
+    container: TrackerProp | undefined = window;
+
+    @property()
+    target: TrackerProp | undefined;
+
+    @property()
+    strategy: MoveStrategy = "";
+
+    @property({ reflect: true })
+    zLayer: ZLayer | undefined = "tooltip";
+
+    @property()
+    contentAnchor: ContentAnchor = "oppositeH";
+
+    @property()
+    targetAnchor: Anchor = "tr";
+
+    @property({ type: Number })
+    marginX: number = 0;
+
+    @property({ type: Number })
+    marginY: number = 0;
+
+    @property()
+    color: Color = "red";
+
+    @property({ type: Number })
+    arrowNudge: number = 0;
+
+    updatePosition() {
+        let tooltip = this.shadowRoot.querySelector("div[role='tooltip']");
+        let target = document.querySelector(this.target);
+        let arrowElement = this.shadowRoot.querySelector("#arrow");
+
+        return () => {
+            computePosition(target, tooltip, {
+                placement: 'right-start',
+                middleware: [
+                    shift(),
+                    offset(24),
+                    flip(),
+                    arrow({
+                        element: arrowElement,
+                        padding: 25,
+                    }),
+                ],
+            }).then(({x, y, placement, middlewareData}) => {
+                tooltip.style.left = `${x}px`;
+                tooltip.style.top = `${y}px`;
+
+                let {x: arrowX, y: arrowY} = middlewareData.arrow;
+
+                const staticSide = {
+                    top: 'bottom',
+                    right: 'left',
+                    bottom: 'top',
+                    left: 'right',
+                }[placement.split('-')[0]];
+
+                Object.assign(arrowElement.style, {
+                    left: arrowX != null ? `${arrowX}px` : '',
+                    top: arrowY != null ? `${arrowY}px` : '',
+                    right: '',
+                    bottom: '',
+                    [staticSide]: '-6px',
+                });
+            })
+        }
+    }
+
+    firstUpdated() {
+        let updatePosition = this.updatePosition();
+        updatePosition();
+
+        this.addEventListener("scroll", updatePosition);
+        this.addEventListener("resize", updatePosition);
+
+        let tooltip = this.shadowRoot.querySelector("div[role='tooltip']");
+        let target = document.querySelector(this.target);
+
+        [
+            ...getScrollParents(target),
+            ...getScrollParents(tooltip),
+        ].forEach((element) => {
+            element.addEventListener("scroll", updatePosition);
+            element.addEventListener("resize", updatePosition);
+        })
+    }
+
+    render() {
+        const {
+            container,
+            target,
+            strategy,
+            zLayer,
+            marginX,
+            marginY,
+            contentAnchor,
+            targetAnchor,
+            maxWidth,
+            arrowNudge,
+        } = this;
+
+        const bodyStyles: any = {};
+
+        if (maxWidth !== -1) {
+            bodyStyles.maxWidth = `${maxWidth}px`;
+        }
+
+
+        return html`
+            <div role="tooltip">
+                <img-ui path="core/tooltips/alert.svg"></img-ui>
+                <div class="body" style="${styleMap(bodyStyles)}">
+                    <slot></slot>
+                </div>
+            </div>
+        `;
+    }
+}

--- a/frontend/storybook/package-lock.json
+++ b/frontend/storybook/package-lock.json
@@ -9,6 +9,7 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
+                "@floating-ui/dom": "^0.2.0",
                 "@fortawesome/pro-solid-svg-icons": "6.0.0-beta1",
                 "lit-element": "^2.4.0",
                 "lit-html": "^1.3.0",
@@ -1953,6 +1954,19 @@
             "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
             "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==",
             "dev": true
+        },
+        "node_modules/@floating-ui/core": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-0.4.0.tgz",
+            "integrity": "sha512-99Pnb5T2S7PSE8rKHD5fZWWnXE3a2xG9E8eQm8SIMYWJyJoHDJIt0b9SK3UjetWFcepxVG+ZMDxcfbamyx+HSg=="
+        },
+        "node_modules/@floating-ui/dom": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-0.2.0.tgz",
+            "integrity": "sha512-hNhTbImiJ8SH9rHsP0qcE9IVxn/maMhwWA5d17p7EkEzVdciayB664Qy2Vxa8RxY/8avE8iVKkfE8sIeg34J0g==",
+            "dependencies": {
+                "@floating-ui/core": "^0.4.0"
+            }
         },
         "node_modules/@fluent/bundle": {
             "version": "0.16.1",
@@ -19322,6 +19336,19 @@
             "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
             "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==",
             "dev": true
+        },
+        "@floating-ui/core": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-0.4.0.tgz",
+            "integrity": "sha512-99Pnb5T2S7PSE8rKHD5fZWWnXE3a2xG9E8eQm8SIMYWJyJoHDJIt0b9SK3UjetWFcepxVG+ZMDxcfbamyx+HSg=="
+        },
+        "@floating-ui/dom": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-0.2.0.tgz",
+            "integrity": "sha512-hNhTbImiJ8SH9rHsP0qcE9IVxn/maMhwWA5d17p7EkEzVdciayB664Qy2Vxa8RxY/8avE8iVKkfE8sIeg34J0g==",
+            "requires": {
+                "@floating-ui/core": "^0.4.0"
+            }
         },
         "@fluent/bundle": {
             "version": "0.16.1",

--- a/frontend/storybook/package.json
+++ b/frontend/storybook/package.json
@@ -34,6 +34,7 @@
         "webpack-livereload-plugin": "^2.3.0"
     },
     "dependencies": {
+        "@floating-ui/dom": "^0.2.0",
         "@fortawesome/pro-solid-svg-icons": "6.0.0-beta1",
         "lit-element": "^2.4.0",
         "lit-html": "^1.3.0",

--- a/frontend/storybook/src/components/core/tooltips/example.ts
+++ b/frontend/storybook/src/components/core/tooltips/example.ts
@@ -4,7 +4,7 @@ import "@elements/core/overlays/content";
 import "@elements/core/overlays/tooltip/confirm";
 import "@elements/core/overlays/tooltip/bubble";
 import "@elements/core/overlays/tooltip/info";
-import "@elements/core/overlays/tooltip/error";
+import "@elements/core/overlays/tooltip/error-tooltip";
 import {
     Anchor,
     ContentAnchor,
@@ -52,8 +52,8 @@ export const Example = (props?: Args) => {
             </overlay-tooltip-bubble>`;
     };
     const renderError = () => {
-        return `<overlay-tooltip-error target=".target" arrowNudge="${props.arrowNudge}" targetAnchor="${props.targetAnchor}" contentAnchor=${props.contentAnchor} strategy="${props.strategy}" marginX="${props.marginX}" marginY="${props.marginY}" ">
-            Body here
+        return `<overlay-tooltip-error target=".target" arrowNudge="${props.arrowNudge}" targetAnchor="${props.targetAnchor}" contentAnchor=${props.contentAnchor} strategy="${props.strategy}" marginX="${props.marginX}" marginY="${props.marginY}" maxWidth="200">
+            Body here Body here Body here Body here
             </overlay-tooltip-error>`;
     };
     return `<div class="target" style="position: absolute; top: 30vh; left: 50vw; width: 100rem; height: 100rem; background-color: black; color: white">
@@ -62,19 +62,17 @@ export const Example = (props?: Args) => {
                 <div style="position: absolute; top: 50rem; left: 0px; width: 100rem; height: 1px; background-color: yellow"></div>
             </div>
         </div>
-        <overlay-container>
-            ${
-                kind == "confirm"
-                    ? renderConfirm()
-                    : kind == "bubble"
-                    ? renderBubble()
-                    : kind == "info"
-                    ? renderInfo()
-                    : kind == "error"
-                    ? renderError()
-                    : ""
-            }
-        </overlay-container>
+        ${
+            kind == "confirm"
+                ? renderConfirm()
+                : kind == "bubble"
+                ? renderBubble()
+                : kind == "info"
+                ? renderInfo()
+                : kind == "error"
+                ? renderError()
+                : ""
+        }
 
     </div>`;
 };


### PR DESCRIPTION
@MendyBerger This POC work largely stems from my frustration trying to have the error tooltip work correctly with #2317.

This work should _not_ be merged in it's current state, it serves only as a proof of concept.

- Updates only the error tooltip so that it uses [floating-ui](https://floating-ui.com) functions to calculate placement, etc
  - floating-ui is a tiny library and using that instead of running the calculations ourselves makes the overall element saner to read and update.
  - It is functional
- Instead of drawing and rendering an svg, it uses css only to render the arrow, box and borders
- Currently the arrow positioning logic works, but isn't actually hooked up to the arrow in CSS (it is from when I used an arrow element before switching to css for borders)
- Removes all custom calculations in favor of floating-ui's functions
- max width works consistently for me now

### Illustrating tooltip with correct border

![image](https://user-images.githubusercontent.com/4161106/150741165-14781b32-3fa9-469e-a2c6-4e159d2fa444.png)
