### PR TITLE
feat(fe/jig/edit): Add load more button to the JIG edit gallery page

### DIFF
--- a/backend/api/sqlx-data.json
+++ b/backend/api/sqlx-data.json
@@ -1045,6 +1045,225 @@
       ]
     }
   },
+  "20c2bc654eb469dddbcae498b2dfc5b6d0cd357ff5374bc51cdecbd142e4ba3b": {
+    "query": "\nwith cte as (\n    select * from unnest($1::uuid[]) with ordinality t(id, ord) order by ord desc\n)\nselect  jig.id                                              as \"jig_id: JigId\",\n        privacy_level                                       as \"privacy_level: PrivacyLevel\",\n        jig_focus                                           as \"jig_focus!: JigFocus\",\n        creator_id,\n        author_id,\n        (select given_name || ' '::text || family_name\n         from user_profile\n         where user_profile.user_id = author_id)            as \"author_name\",\n        published_at,\n        liked_count,\n        (\n             select play_count\n             from jig_play_count\n             where jig_play_count.jig_id = jig.id\n        )                                                   as \"play_count!\",\n       display_name                                                                  as \"display_name!\",\n       updated_at,\n       language                                                                      as \"language!\",\n       description                                                                   as \"description!\",\n       direction                                                                     as \"direction!: TextDirection\",\n       display_score                                                                 as \"display_score!\",\n       track_assessments                                                             as \"track_assessments!\",\n       drag_assist                                                                   as \"drag_assist!\",\n       theme                                                                         as \"theme!: ThemeId\",\n       audio_background                                                              as \"audio_background!: Option<AudioBackground>\",\n       draft_or_live                                                                 as \"draft_or_live!: DraftOrLive\",\n       array(select row (unnest(audio_feedback_positive)))                           as \"audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>\",\n       array(select row (unnest(audio_feedback_negative)))                           as \"audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>\",\n       array(\n               select row (jig_data_module.id, kind, is_complete)\n               from jig_data_module\n               where jig_data_id = jig_data.id\n               order by \"index\"\n           )                                               as \"modules!: Vec<(ModuleId, ModuleKind, bool)>\",\n       array(select row (goal_id)\n             from jig_data_goal\n             where jig_data_id = jig_data.id)     as \"goals!: Vec<(GoalId,)>\",\n       array(select row (category_id)\n             from jig_data_category\n             where jig_data_id = jig_data.id)     as \"categories!: Vec<(CategoryId,)>\",\n       array(select row (affiliation_id)\n             from jig_data_affiliation\n             where jig_data_id = jig_data.id)     as \"affiliations!: Vec<(AffiliationId,)>\",\n       array(select row (age_range_id)\n             from jig_data_age_range\n             where jig_data_id = jig_data.id)     as \"age_ranges!: Vec<(AgeRangeId,)>\",\n       array(\n                select row (jdar.id, jdar.display_name, resource_type_id, resource_content)\n                from jig_data_additional_resource \"jdar\"\n                where jdar.jig_data_id = jig_data.id\n            )                                               as \"additional_resource!: Vec<(AddId, String, TypeId, Value)>\",\n       locked                                     as \"locked!\",\n       other_keywords                             as \"other_keywords!\",\n       translated_keywords                        as \"translated_keywords!\",\n       rating                                     as \"rating!: Option<JigRating>\",\n       blocked                                    as \"blocked!\",\n       curated                                    as \"curated!\"\nfrom jig_data\n    inner join cte on cte.id = jig_data.id\n    inner join jig on jig_data.id = jig.draft_id or jig_data.id = jig.live_id\n    inner join jig_admin_data \"admin\" on admin.jig_id = jig.id\nwhere cte.ord > (20 * $2)\norder by ord asc\nlimit 20\n",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "jig_id: JigId",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 1,
+          "name": "privacy_level: PrivacyLevel",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 2,
+          "name": "jig_focus!: JigFocus",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 3,
+          "name": "creator_id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 4,
+          "name": "author_id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 5,
+          "name": "author_name",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 6,
+          "name": "published_at",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 7,
+          "name": "liked_count",
+          "type_info": "Int8"
+        },
+        {
+          "ordinal": 8,
+          "name": "play_count!",
+          "type_info": "Int8"
+        },
+        {
+          "ordinal": 9,
+          "name": "display_name!",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 10,
+          "name": "updated_at",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 11,
+          "name": "language!",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 12,
+          "name": "description!",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 13,
+          "name": "direction!: TextDirection",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 14,
+          "name": "display_score!",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 15,
+          "name": "track_assessments!",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 16,
+          "name": "drag_assist!",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 17,
+          "name": "theme!: ThemeId",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 18,
+          "name": "audio_background!: Option<AudioBackground>",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 19,
+          "name": "draft_or_live!: DraftOrLive",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 20,
+          "name": "audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 21,
+          "name": "audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 22,
+          "name": "modules!: Vec<(ModuleId, ModuleKind, bool)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 23,
+          "name": "goals!: Vec<(GoalId,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 24,
+          "name": "categories!: Vec<(CategoryId,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 25,
+          "name": "affiliations!: Vec<(AffiliationId,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 26,
+          "name": "age_ranges!: Vec<(AgeRangeId,)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 27,
+          "name": "additional_resource!: Vec<(AddId, String, TypeId, Value)>",
+          "type_info": "RecordArray"
+        },
+        {
+          "ordinal": 28,
+          "name": "locked!",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 29,
+          "name": "other_keywords!",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 30,
+          "name": "translated_keywords!",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 31,
+          "name": "rating!: Option<JigRating>",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 32,
+          "name": "blocked!",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 33,
+          "name": "curated!",
+          "type_info": "Bool"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "UuidArray",
+          "Int4"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        true,
+        true,
+        null,
+        true,
+        false,
+        null,
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false
+      ]
+    }
+  },
   "228687aa01cb6d5780d804f5ddf78a5e070fc552dbb3b3f8e5224b8a6a9e9b18": {
     "query": "\nselect id as \"id: ImageId\", kind as \"kind: ImageKind\"\nfrom user_image_library\n         join user_image_upload\n              on user_image_library.id = user_image_upload.image_id\nwhere processing_result is true\n  and user_id = $1\n  and (kind is not distinct from $2 or $2 is null)\norder by created_at desc\n",
     "describe": {
@@ -2030,225 +2249,6 @@
         ]
       },
       "nullable": []
-    }
-  },
-  "54d64693aedfaecebe7e07fe11fa6fb0275efe352abef2e80cf8eba780941133": {
-    "query": "\nwith cte as (\n    select * from unnest($1::uuid[]) with ordinality t(id, ord) order by ord desc\n)\nselect  jig.id                                              as \"jig_id: JigId\",\n        privacy_level                                       as \"privacy_level: PrivacyLevel\",\n        jig_focus                                           as \"jig_focus!: JigFocus\",\n        creator_id,\n        author_id,\n        (select given_name || ' '::text || family_name\n         from user_profile\n         where user_profile.user_id = author_id)            as \"author_name\",\n        published_at,\n        liked_count,\n        (\n             select play_count\n             from jig_play_count\n             where jig_play_count.jig_id = jig.id\n        )                                                   as \"play_count!\",\n       display_name                                                                  as \"display_name!\",\n       updated_at,\n       language                                                                      as \"language!\",\n       description                                                                   as \"description!\",\n       direction                                                                     as \"direction!: TextDirection\",\n       display_score                                                                 as \"display_score!\",\n       track_assessments                                                             as \"track_assessments!\",\n       drag_assist                                                                   as \"drag_assist!\",\n       theme                                                                         as \"theme!: ThemeId\",\n       audio_background                                                              as \"audio_background!: Option<AudioBackground>\",\n       draft_or_live                                                                 as \"draft_or_live!: DraftOrLive\",\n       array(select row (unnest(audio_feedback_positive)))                           as \"audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>\",\n       array(select row (unnest(audio_feedback_negative)))                           as \"audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>\",\n       array(\n               select row (jig_data_module.id, kind, is_complete)\n               from jig_data_module\n               where jig_data_id = jig_data.id\n               order by \"index\"\n           )                                               as \"modules!: Vec<(ModuleId, ModuleKind, bool)>\",\n       array(select row (goal_id)\n             from jig_data_goal\n             where jig_data_id = jig_data.id)     as \"goals!: Vec<(GoalId,)>\",\n       array(select row (category_id)\n             from jig_data_category\n             where jig_data_id = jig_data.id)     as \"categories!: Vec<(CategoryId,)>\",\n       array(select row (affiliation_id)\n             from jig_data_affiliation\n             where jig_data_id = jig_data.id)     as \"affiliations!: Vec<(AffiliationId,)>\",\n       array(select row (age_range_id)\n             from jig_data_age_range\n             where jig_data_id = jig_data.id)     as \"age_ranges!: Vec<(AgeRangeId,)>\",\n       array(\n                select row (jdar.id, jdar.display_name, resource_type_id, resource_content)\n                from jig_data_additional_resource \"jdar\"\n                where jdar.jig_data_id = jig_data.id\n            )                                               as \"additional_resource!: Vec<(AddId, String, TypeId, Value)>\",\n       locked                                     as \"locked!\",\n       other_keywords                             as \"other_keywords!\",\n       translated_keywords                        as \"translated_keywords!\",\n       rating                                     as \"rating!: Option<JigRating>\",\n       blocked                                    as \"blocked!\",\n       curated                                    as \"curated!\"\nfrom jig_data\n    inner join cte on cte.id = jig_data.id\n    inner join jig on jig_data.id = jig.draft_id or jig_data.id = jig.live_id\n    inner join jig_admin_data \"admin\" on admin.jig_id = jig.id\nwhere cte.ord >= (20 * $2)\norder by ord asc\nlimit 20\n",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "jig_id: JigId",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 1,
-          "name": "privacy_level: PrivacyLevel",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 2,
-          "name": "jig_focus!: JigFocus",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 3,
-          "name": "creator_id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 4,
-          "name": "author_id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 5,
-          "name": "author_name",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 6,
-          "name": "published_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 7,
-          "name": "liked_count",
-          "type_info": "Int8"
-        },
-        {
-          "ordinal": 8,
-          "name": "play_count!",
-          "type_info": "Int8"
-        },
-        {
-          "ordinal": 9,
-          "name": "display_name!",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 10,
-          "name": "updated_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 11,
-          "name": "language!",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 12,
-          "name": "description!",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 13,
-          "name": "direction!: TextDirection",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 14,
-          "name": "display_score!",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 15,
-          "name": "track_assessments!",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 16,
-          "name": "drag_assist!",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 17,
-          "name": "theme!: ThemeId",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 18,
-          "name": "audio_background!: Option<AudioBackground>",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 19,
-          "name": "draft_or_live!: DraftOrLive",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 20,
-          "name": "audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 21,
-          "name": "audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 22,
-          "name": "modules!: Vec<(ModuleId, ModuleKind, bool)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 23,
-          "name": "goals!: Vec<(GoalId,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 24,
-          "name": "categories!: Vec<(CategoryId,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 25,
-          "name": "affiliations!: Vec<(AffiliationId,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 26,
-          "name": "age_ranges!: Vec<(AgeRangeId,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 27,
-          "name": "additional_resource!: Vec<(AddId, String, TypeId, Value)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 28,
-          "name": "locked!",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 29,
-          "name": "other_keywords!",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 30,
-          "name": "translated_keywords!",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 31,
-          "name": "rating!: Option<JigRating>",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 32,
-          "name": "blocked!",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 33,
-          "name": "curated!",
-          "type_info": "Bool"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "UuidArray",
-          "Int4"
-        ]
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        true,
-        true,
-        null,
-        true,
-        false,
-        null,
-        false,
-        true,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        true,
-        true,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        false,
-        false,
-        false,
-        true,
-        false,
-        false
-      ]
     }
   },
   "55b8f1bdf37543b3640ae548b0a7d13643c5ed07418bd3e7fe4d9670331be807": {

--- a/backend/api/src/db/jig.rs
+++ b/backend/api/src/db/jig.rs
@@ -1,6 +1,5 @@
 use crate::translate::translate_text;
 use anyhow::Context;
-use serde::{Deserialize, Serialize};
 use serde_json::value::Value;
 use shared::domain::{
     category::CategoryId,
@@ -610,7 +609,7 @@ from jig_data
     inner join cte on cte.id = jig_data.id
     inner join jig on jig_data.id = jig.draft_id or jig_data.id = jig.live_id
     inner join jig_admin_data "admin" on admin.jig_id = jig.id
-where cte.ord >= (20 * $2)
+where cte.ord > (20 * $2)
 order by ord asc
 limit 20
 "#,

--- a/frontend/apps/crates/entry/jig/edit/src/gallery/state.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/gallery/state.rs
@@ -26,6 +26,10 @@ pub struct JigGallery {
     pub focus: JigFocus,
     pub loader: AsyncLoader,
     pub jigs: MutableVec<JigResponse>,
+    /// Total JIGs that can be fetched
+    pub total_jig_count: Mutable<Option<u64>>,
+    /// The next page to call when request a page of JIGs
+    pub next_page: Mutable<u32>,
     pub visible_jigs: Rc<Mutable<VisibleJigs>>,
     pub age_ranges: Mutable<Vec<AgeRange>>,
     pub confirm_delete: Mutable<Option<JigId>>,
@@ -37,6 +41,8 @@ impl JigGallery {
             focus,
             loader: AsyncLoader::new(),
             jigs: MutableVec::new(),
+            total_jig_count: Mutable::new(None),
+            next_page: Mutable::new(0),
             visible_jigs: Rc::new(Mutable::new(VisibleJigs::All)),
             age_ranges: Mutable::new(vec![]),
             confirm_delete: Mutable::new(None),

--- a/frontend/elements/src/entry/jig/gallery/gallery.ts
+++ b/frontend/elements/src/entry/jig/gallery/gallery.ts
@@ -172,6 +172,11 @@ export class _ extends LitElement {
                     gap: 34px;
                     justify-content: space-between;
                 }
+                .load-more {
+                    display: grid;
+                    grid-template-columns: auto;
+                    justify-content: center;
+                }
             `,
         ];
     }
@@ -274,6 +279,9 @@ export class _ extends LitElement {
                     </div>
                     <div class="recent-items">
                         <slot name="recent-items"></slot>
+                    </div>
+                    <div class="load-more">
+                        <slot name="load-more"></slot>
                     </div>
                 </div>
             </section>


### PR DESCRIPTION
Closes #2252

- Adds "See more" button to the JIG edit gallery page
- Updates /browse so that it returns the correct amount of records and no longer returns the last record from the previous page as the first record in the current page

![image](https://user-images.githubusercontent.com/4161106/150767293-1dea0770-7f94-491d-bbe6-feeeb7469344.png)
