### PR TITLE
feat(fe/cards): Use tabs for all step 1 of all card games

### DIFF
--- a/frontend/apps/crates/components/src/tabs/state.rs
+++ b/frontend/apps/crates/components/src/tabs/state.rs
@@ -48,6 +48,7 @@ pub enum MenuTabKind {
     Question,
     Select,
     Text,
+    DualList,
     Theme,
     Tooltip,
     Video,
@@ -69,6 +70,7 @@ impl MenuTabKind {
             Self::Question => "question",
             Self::Select => "select",
             Self::Text => "text",
+            Self::DualList => "text", // Same str value as Self::Text
             Self::Theme => "theme",
             Self::Tooltip => "tooltip",
             Self::Video => "video",


### PR DESCRIPTION
Part of #2280 

- Updates Step 1 of card games so that it uses tabs regardless of use case so that we can add in the new Audio tab for card games.

### Before

![image](https://user-images.githubusercontent.com/4161106/150933760-349ede8c-a2f1-43a6-8349-ecbff98aeca8.png)

### After

![Screenshot from 2022-01-25 09-44-18](https://user-images.githubusercontent.com/4161106/150933463-8d7bba32-f69a-4916-8ad8-e49fec37772c.png)
