### PR TITLE
feat(fe/module/edit): Add confirm modal to remove/delete actions on card games

### DIFF
--- a/frontend/apps/crates/components/src/module/_groups/cards/edit/main/pair/card/state.rs
+++ b/frontend/apps/crates/components/src/module/_groups/cards/edit/main/pair/card/state.rs
@@ -6,6 +6,39 @@ use shared::domain::jig::module::body::_groups::cards::Step;
 use std::{cell::RefCell, rc::Rc};
 use web_sys::HtmlElement;
 
+/// Used for passing it's contents as properties to the modal-confirm element
+#[derive(Clone)]
+pub struct ModalAction {
+    /// Title of the modal
+    pub title: &'static str,
+    /// Content of the modal
+    pub content: &'static str,
+    /// Confirm button text
+    pub confirm: &'static str,
+    /// Cancel button text
+    pub cancel: &'static str,
+    /// Callback handler called when the confirm button is clicked
+    pub handler: Rc<dyn Fn()>,
+}
+
+impl ModalAction {
+    pub fn new(
+        title: &'static str,
+        content: &'static str,
+        confirm: &'static str,
+        cancel: &'static str,
+        handler: Rc<dyn Fn()>
+    ) -> Self {
+        Self {
+            title,
+            content,
+            confirm,
+            cancel,
+            handler,
+        }
+    }
+}
+
 pub struct MainCard<RawData: RawDataExt, E: ExtraExt> {
     pub base: Rc<CardsBase<RawData, E>>,
     pub step: Step,
@@ -17,8 +50,12 @@ pub struct MainCard<RawData: RawDataExt, E: ExtraExt> {
     pub editing_active: Mutable<bool>,
     pub is_image: bool,
     pub is_hovering: Mutable<bool>,
+    /// Whether the context menu is currently open
     pub menu_open: Mutable<bool>,
+    /// A reference to the HtmlElement which holds the context menu items
     pub menu_container_elem: Mutable<Option<HtmlElement>>,
+    /// A signal to render the confirm modal with the provided properties
+    pub confirm_action: Mutable<Option<Rc<ModalAction>>>,
     pub callbacks: CardCallbacks,
 }
 
@@ -56,6 +93,7 @@ impl<RawData: RawDataExt, E: ExtraExt> MainCard<RawData, E> {
             is_hovering: Mutable::new(false),
             menu_open: Mutable::new(false),
             menu_container_elem: Mutable::new(None),
+            confirm_action: Mutable::new(None),
             callbacks,
         })
     }

--- a/frontend/elements/src/_bundles/_sub-bundles/module/_groups/cards/edit.ts
+++ b/frontend/elements/src/_bundles/_sub-bundles/module/_groups/cards/edit.ts
@@ -1,3 +1,4 @@
+import "@elements/core/modals/confirm";
 import "@elements/module/_groups/cards/_common/main-empty";
 import "@elements/module/_groups/cards/edit/header/button-add";
 import "@elements/module/_groups/cards/edit/main/main";


### PR DESCRIPTION
Part of #2280

- Adds confirm modals for removing images and audio from cards and for deleting card pairs.

![Screenshot from 2022-01-31 08-17-04](https://user-images.githubusercontent.com/4161106/151747733-4190579e-d49b-4e47-90b8-22f562aedfca.png)
![Screenshot from 2022-01-31 08-16-47](https://user-images.githubusercontent.com/4161106/151747736-0d41f112-e334-42cd-90bf-d9fc22b3b1cc.png)
