### PR TITLE
feat(fe/module/play): Play card audio for card games

### DIFF
--- a/frontend/apps/crates/components/src/module/_groups/cards/play/card/dom/dom.rs
+++ b/frontend/apps/crates/components/src/module/_groups/cards/play/card/dom/dom.rs
@@ -1,10 +1,10 @@
-use crate::{module::_groups::cards::lookup::Side, audio::mixer::{AUDIO_MIXER, AudioPath}};
+use crate::module::_groups::cards::lookup::Side;
 use dominator::{html, Dom, DomBuilder};
 use shared::domain::jig::module::body::{
     ModeExt,
     _groups::cards::{Card, Mode},
 };
-use utils::{events, prelude::*};
+use utils::prelude::*;
 use web_sys::HtmlElement;
 
 use super::common::*;
@@ -132,11 +132,6 @@ where
         })
         .apply_if(mixin.is_some(), |dom| {
             (mixin.unwrap_ji()) (dom)
-        })
-        .event(move |_evt: events::CustomCardFlipped| {
-            AUDIO_MIXER.with(|mixer| {
-                mixer.play_oneshot(AudioPath::new_cdn(super::FLIPPED_AUDIO_EFFECT.to_string()))
-            });
         })
     })
 }

--- a/frontend/apps/crates/entry/module/card-quiz/play/src/base/game/dom.rs
+++ b/frontend/apps/crates/entry/module/card-quiz/play/src/base/game/dom.rs
@@ -43,10 +43,6 @@ impl Game {
                                 children.push(render_card_mixin(options, |dom| {
                                     dom
                                         .property_signal(
-                                            "eventOnFlipped",
-                                            phase.signal().map(clone!(state => move |_| is_incorrect_choice(&state, &pair_id)))
-                                        )
-                                        .property_signal(
                                             "effect",
                                             phase.signal().map(move |phase| {
                                                 match phase {

--- a/frontend/apps/crates/entry/module/flashcards/play/src/base/game/dom.rs
+++ b/frontend/apps/crates/entry/module/flashcards/play/src/base/game/dom.rs
@@ -64,7 +64,6 @@ fn flip_controller(
 ) -> impl FnOnce(DomBuilder<HtmlElement>) -> DomBuilder<HtmlElement> {
     move |dom| {
         dom
-            .property_signal("eventOnFlipped", state.gate.signal().map(move |gate| gate == Gate::Flipping))
             .property_signal("flipped", state.gate.signal().map(move |gate| {
                 if gate == Gate::Waiting || gate == Gate::FinishingFlip {
                     initial

--- a/frontend/apps/crates/entry/module/matching/play/src/base/game/card/actions.rs
+++ b/frontend/apps/crates/entry/module/matching/play/src/base/game/card/actions.rs
@@ -1,6 +1,11 @@
 use super::{super::state::*, state::*};
 use std::rc::Rc;
-use components::audio::mixer::{play_random_positive, play_random_negative};
+use components::audio::mixer::{
+    play_random_positive,
+    play_random_negative,
+    AudioSourceExt,
+    AUDIO_MIXER
+};
 use utils::math::BoundsF64;
 use web_sys::HtmlElement;
 
@@ -82,5 +87,11 @@ pub fn start_drag(state: Rc<CardBottom>, elem: HtmlElement, x: i32, y: i32) {
         current
             .drag
             .set(Some(Rc::new(CardDrag::new((*state).clone(), elem, x, y))));
+
+        if let Some(audio) = &state.card.audio {
+            AUDIO_MIXER.with(|mixer| {
+                mixer.play_oneshot(audio.as_source())
+            });
+        }
     }
 }

--- a/frontend/apps/crates/entry/module/memory/play/src/base/stage/game/dom.rs
+++ b/frontend/apps/crates/entry/module/memory/play/src/base/stage/game/dom.rs
@@ -35,7 +35,6 @@ fn render_main_card(state: Rc<Base>, card_state: Rc<CardState>) -> Dom {
     render_card_mixin(options, |dom| {
         dom
             .style_signal("visibility", card_state.is_found().map(|found| if found { "hidden" } else { "visible" }))
-            .property_signal("eventOnFlipped", state.flip_state.signal_ref(|flip_state| matches!(flip_state, FlipState::One(_))))
             .property_signal("flipped", card_state.is_flipped(&state))
             .event(clone!(state, card_id => move |_evt:events::Click| {
                 if let Some((id_1, id_2)) = super::actions::card_click(state.clone(), card_id) {

--- a/frontend/apps/crates/utils/src/events.rs
+++ b/frontend/apps/crates/utils/src/events.rs
@@ -235,16 +235,6 @@ make_custom_event_serde!(
     CustomCancelData
 );
 
-// Custom Card Flipped
-#[derive(Deserialize, Debug)]
-pub struct CustomCardFlippedData;
-
-make_custom_event_serde!(
-    "custom-card-flipped",
-    CustomCardFlipped,
-    CustomCardFlippedData
-);
-
 // Custom Rating
 #[derive(Deserialize, Debug)]
 pub struct CustomRatingData {

--- a/frontend/elements/src/module/_groups/cards/play/card/card.ts
+++ b/frontend/elements/src/module/_groups/cards/play/card/card.ts
@@ -107,14 +107,6 @@ export class _ extends LitElement {
     @property({ type: Boolean, reflect: true })
     flipped: boolean = false;
 
-    // whether to dispatch an event when a card is flipped
-    // Note: This is an interim **workaround**. The code that interfaces with this
-    // element uses references with non-static lifetimes which makes it tricky to
-    // run logic inside card-flipped event handler because of the 'static
-    // requirement.
-    @property({ type: Boolean })
-    eventOnFlipped: boolean = false;
-
     // required for styling
     @property()
     theme: ThemeId = "blank";
@@ -149,14 +141,6 @@ export class _ extends LitElement {
 
     @property({ reflect: true })
     effect?: Effect = null;
-
-    updated(changedProperties: Map<string, unknown>) {
-        if (changedProperties.get('flipped') !== undefined && this.eventOnFlipped) {
-            this.dispatchEvent(
-                new CustomEvent("custom-card-flipped", {})
-            );
-        }
-    }
 
     connectedCallback() {
         super.connectedCallback();


### PR DESCRIPTION
Part of #2280 

- Plays a cards audio based on the following rules:
  - **Flashcards** - Play sound for card that appears, when a card is clicked, it plays the feedback sound and then the cards sound;
  - **Memory cards** - Plays the flipping card sound and then the cards sound;
  - **Matching** - Plays the card sound when the student starts dragging a card;
  - **Quiz game** - When choosing a card, plays the feedback sound and then the cards sound.

Extra work included:
- Removes `eventOnFlipped` property introduced in #2134 and instead, each game type plays it's relevant sounds when appropriate.