### PR TITLE
fix(fe/cards): Update card audio to play before positive feedback effects

### DIFF
--- a/frontend/apps/crates/components/src/module/_groups/cards/edit/main/dom.rs
+++ b/frontend/apps/crates/components/src/module/_groups/cards/edit/main/dom.rs
@@ -29,6 +29,9 @@ where
                     } else {
                         html!("empty-fragment", {
                             .child_signal(state.base.step.signal_cloned().map(clone!(state => move |step| {
+                                // Reset card selection when changing step.
+                                state.base.selected_pair.set(None);
+
                                 Some(match step {
                                     Step::Three => {
                                         (state.render_settings) (Rc::new((state.get_settings) (state.base.clone())))

--- a/frontend/apps/crates/components/src/module/_groups/cards/edit/main/pair/card/actions.rs
+++ b/frontend/apps/crates/components/src/module/_groups/cards/edit/main/pair/card/actions.rs
@@ -125,6 +125,10 @@ impl<RawData: RawDataExt, E: ExtraExt> MainCard<RawData, E> {
     /// 1. If both cards are selected at the current index, select only the other card
     /// 1. If there is a selection at another index, deselect it
     pub fn toggle_selection(&self) {
+        if !self.can_select {
+            return;
+        }
+
         let current_idx = self.index.get_cloned().unwrap_or_default();
         let selected_pair = self.base.selected_pair.get_cloned();
 

--- a/frontend/apps/crates/components/src/module/_groups/cards/edit/main/pair/card/state.rs
+++ b/frontend/apps/crates/components/src/module/_groups/cards/edit/main/pair/card/state.rs
@@ -49,6 +49,8 @@ pub struct MainCard<RawData: RawDataExt, E: ExtraExt> {
     pub input_ref: Rc<RefCell<Option<HtmlElement>>>,
     pub editing_active: Mutable<bool>,
     pub is_image: bool,
+    /// Whether the card can be selected
+    pub can_select: bool,
     pub is_hovering: Mutable<bool>,
     /// Whether the context menu is currently open
     pub menu_open: Mutable<bool>,
@@ -90,6 +92,7 @@ impl<RawData: RawDataExt, E: ExtraExt> MainCard<RawData, E> {
             input_ref: Rc::new(RefCell::new(None)),
             editing_active: Mutable::new(false),
             is_image,
+            can_select: step == Step::One,
             is_hovering: Mutable::new(false),
             menu_open: Mutable::new(false),
             menu_container_elem: Mutable::new(None),

--- a/frontend/apps/crates/components/src/module/_groups/cards/edit/main/pair/dom.rs
+++ b/frontend/apps/crates/components/src/module/_groups/cards/edit/main/pair/dom.rs
@@ -8,25 +8,13 @@ use futures_signals::signal::SignalExt;
 use super::card::dom::render as render_card;
 use super::state::*;
 use crate::module::_groups::cards::edit::state::*;
-use shared::domain::jig::module::body::_groups::cards::Step;
 
 pub fn render<RawData: RawDataExt, E: ExtraExt>(state: Rc<MainPair<RawData, E>>) -> Dom {
-    if state.step == Step::One {
-        html!("main-card-pair", {
-            .property_signal("index", state.index.signal().map(|x| {
-                JsValue::from_f64(x.unwrap_or_default() as f64)
-            }))
-            .child(render_card(state.left.clone()))
-            .child(render_card(state.right.clone()))
-        })
-    } else {
-        html!("main-card-pair", {
-            .property("hoverable", false)
-            .property_signal("index", state.index.signal().map(|x| {
-                JsValue::from_f64(x.unwrap_or_default() as f64)
-            }))
-            .child(render_card(state.left.clone()))
-            .child(render_card(state.right.clone()))
-        })
-    }
+    html!("main-card-pair", {
+        .property_signal("index", state.index.signal().map(|x| {
+            JsValue::from_f64(x.unwrap_or_default() as f64)
+        }))
+        .child(render_card(state.left.clone()))
+        .child(render_card(state.right.clone()))
+    })
 }

--- a/frontend/apps/crates/entry/module/card-quiz/play/src/base/game/actions.rs
+++ b/frontend/apps/crates/entry/module/card-quiz/play/src/base/game/actions.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::Ordering;
 use components::{
     module::_common::play::prelude::*,
     module::_groups::cards::play::card::dom::FLIPPED_AUDIO_EFFECT,
-    audio::mixer::{AUDIO_MIXER, AudioPath, AudioSourceExt},
+    audio::mixer::{AUDIO_MIXER, AudioPath, AudioSourceExt, AudioMixer},
 };
 
 use crate::base::state::Phase;
@@ -83,14 +83,38 @@ impl Game {
     pub fn evaluate(state: Rc<Self>, pair_id: usize, phase: Mutable<CurrentPhase>) {
         if phase.get() == CurrentPhase::Waiting {
             spawn_local(clone!(state, pair_id, phase => async move {
-                let play_effect = |positive: bool| {
-                    AUDIO_MIXER.with(|mixer| {
-                        let audio_path: AudioPath<'_> = if positive {
-                            mixer.get_random_positive().into()
-                        } else {
-                            AudioPath::new_cdn(FLIPPED_AUDIO_EFFECT.to_string())
-                        };
+                if pair_id == state.current.lock_ref().as_ref().unwrap_ji().target.pair_id {
+                    let current = state.current.get_cloned();
+                    if let Some(current) = current {
+                        let card_id = current.others.iter().find(|card_id| card_id.pair_id == pair_id);
+                        if let Some(card_id) = card_id {
+                            let play_feedback = |mixer: &AudioMixer| {
+                                let audio_path: AudioPath<'_> = mixer.get_random_positive().into();
 
+                                mixer.play_oneshot(audio_path);
+                            };
+
+                            // Play the card audio first if it exists and then the feedback effect.
+                            if let Some(audio) = &card_id.card.audio {
+                                AUDIO_MIXER.with(move |mixer| {
+                                    mixer.play_oneshot_on_ended(audio.as_source(), move || {
+                                        AUDIO_MIXER.with(play_feedback);
+                                    })
+                                });
+                            } else {
+                                AUDIO_MIXER.with(play_feedback);
+                            }
+                        }
+                    }
+
+                    phase.set(CurrentPhase::Correct(pair_id));
+                    TimeoutFuture::new(crate::config::SUCCESS_TIME).await;
+                    Self::next(state);
+                } else {
+                    AUDIO_MIXER.with(|mixer| {
+                        let audio_path = AudioPath::new_cdn(FLIPPED_AUDIO_EFFECT.to_string());
+
+                        // Play the negative effect and then the card audio
                         mixer.play_oneshot_on_ended(audio_path, clone!(state => move || {
                             let current = state.current.get_cloned();
                             if let Some(current) = current {
@@ -105,16 +129,6 @@ impl Game {
                             }
                         }))
                     });
-                };
-
-                if pair_id == state.current.lock_ref().as_ref().unwrap_ji().target.pair_id {
-                    play_effect(true);
-
-                    phase.set(CurrentPhase::Correct(pair_id));
-                    TimeoutFuture::new(crate::config::SUCCESS_TIME).await;
-                    Self::next(state);
-                } else {
-                    play_effect(false);
                     phase.set(CurrentPhase::Wrong(pair_id));
                     // We should be able to safely assume that current is Some(_), but
                     // double-check here anyway because assumptions are bad.

--- a/frontend/elements/src/module/_groups/cards/edit/main/card-pair/pair.ts
+++ b/frontend/elements/src/module/_groups/cards/edit/main/card-pair/pair.ts
@@ -16,14 +16,6 @@ export class _ extends LitElement {
                     height: 236px;
                 }
 
-                section.hover {
-                    background-color: #deecff;
-                }
-
-                section.hover > .close {
-                    display: block;
-                }
-
                 .close {
                     display: none;
                     position: relative;
@@ -61,54 +53,14 @@ export class _ extends LitElement {
         ];
     }
 
-    updated(changed: any) {
-        if (typeof changed.get("hoverLock") === "boolean") {
-            if (!this.hoverLock) {
-                this.hover = false;
-            }
-        }
-
-        if (typeof changed.get("hover") === "boolean") {
-            const { hoverLock } = this;
-            if (hoverLock) {
-                this.hover = true;
-            }
-        }
-    }
-
-    onEnter() {
-        if (this.hoverable) {
-            this.hover = true;
-        }
-    }
-
-    onLeave() {
-        if (this.hoverable) {
-            this.hover = false;
-        }
-    }
-
-    @property({ type: Boolean })
-    hover: boolean = false;
-
     @property({ type: Number })
     index: number = 0;
 
-    @property({ type: Boolean })
-    hoverable: boolean = false;
-
-    @property({ type: Boolean })
-    hoverLock: boolean = false;
-
     render() {
-        const { hover, index } = this;
+        const { index } = this;
 
         return html`
-            <section
-                class="${classMap({ hover })}"
-                @mouseenter="${this.onEnter}"
-                @mouseleave="${this.onLeave}"
-            >
+            <section>
                 <div class="close"><slot name="close"></slot></div>
                 <div class="cards">
                     <div class="right"><slot name="right"></slot></div>


### PR DESCRIPTION
Closes #2280 

- Prevents selection from other tabs and clears selection when switching tabs;
- Memory game will play the card audio and then the negative/positive feedback sound;
- Card quiz will play the card audio and then the positive feedback sound.
  - Flip effect for incorrect choice still plays before the card audio.