### PR TITLE
feat(fe/jig/edit): Show once-off onboarding video

### DIFF
--- a/frontend/apps/crates/entry/jig/edit/src/edit/actions.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/actions.rs
@@ -1,0 +1,9 @@
+use utils::{storage, unwrap::UnwrapJiExt};
+use super::state::*;
+
+impl State {
+    pub fn set_permanently_closed(&self) {
+        let _ = storage::get_local_storage().unwrap_ji().set_item("onboarding", "hidden");
+        self.show_onboarding.set_neq(false);
+    }
+}

--- a/frontend/apps/crates/entry/jig/edit/src/edit/dom.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/dom.rs
@@ -8,11 +8,13 @@ use super::{
     selection::dom::SelectionDom,
     sidebar::dom::SidebarDom,
 };
-use components::player_popup::{PlayerPopup, PreviewPopupCallbacks};
+use components::{player_popup::{PlayerPopup, PreviewPopupCallbacks}, overlay::handle::OverlayHandle};
 use dominator::{clone, html, Dom};
 use futures_signals::signal::SignalExt;
 use shared::domain::jig::{JigId, JigFocus};
 use utils::prelude::*;
+
+const STR_YT_VIDEO_ID: &str = "x4FYtTpQAt0";
 
 pub struct EditPage {}
 
@@ -64,6 +66,24 @@ impl EditPage {
                         JigEditRoute::PostPublish => {
                             Some(render_post_publish(jig_id.clone(), Rc::clone(&state)))
                         }
+                    }
+                })))
+                .child_signal(state.show_onboarding.signal_cloned().map(clone!(state => move |show| {
+                    if show {
+                        Some(html!("empty-fragment", {
+                            .apply(OverlayHandle::lifecycle(clone!(state => move || {
+                                html!("empty-fragment", {
+                                    .child(html!("modal-video", {
+                                        .property("videoId", STR_YT_VIDEO_ID)
+                                        .event(clone!(state => move |_evt: events::Close| {
+                                            state.set_permanently_closed();
+                                        }))
+                                    }))
+                                })
+                            })))
+                        }))
+                    } else {
+                        None
                     }
                 })))
             }))

--- a/frontend/apps/crates/entry/jig/edit/src/edit/mod.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/mod.rs
@@ -1,4 +1,5 @@
 pub mod dom;
+pub mod actions;
 pub(super) mod iframe;
 pub(super) mod post_publish;
 pub(super) mod publish;

--- a/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/dom.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/dom.rs
@@ -64,7 +64,7 @@ impl SidebarDom {
             .global_event(clone!(state => move |evt: Message| {
                 match evt.try_serde_data::<IframeAction<ModuleToJigEditorMessage>>() {
                     Err(_e) => {
-                        log::info!("{:?}", _e);
+
                     },
                     Ok(m) => {
                         actions::on_iframe_message(Rc::clone(&state), m.data)

--- a/frontend/apps/crates/entry/jig/edit/src/edit/state.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/state.rs
@@ -1,21 +1,34 @@
 use futures_signals::signal::Mutable;
 use shared::domain::jig::{JigId, JigFocus};
-use utils::{jig::JigPlayerOptions, routes::JigEditRoute};
+use utils::{
+    jig::JigPlayerOptions,
+    routes::JigEditRoute,
+    storage,
+    unwrap::UnwrapJiExt
+};
 
 pub struct State {
     pub route: Mutable<JigEditRoute>,
     pub jig_focus: JigFocus,
     pub jig_id: JigId,
     pub play_jig: Mutable<Option<JigPlayerOptions>>,
+    pub show_onboarding: Mutable<bool>,
 }
 
 impl State {
     pub fn new(jig_id: JigId, jig_focus: JigFocus, route: JigEditRoute) -> Self {
+        let show_onboarding = storage::get_local_storage()
+            .unwrap_ji()
+            .get_item("onboarding")
+            .unwrap_ji()
+            .is_none(); // We don't care about the value, only that the item is present
+
         Self {
             jig_id,
             jig_focus,
             route: Mutable::new(route),
             play_jig: Mutable::new(None),
+            show_onboarding: Mutable::new(show_onboarding),
         }
     }
 }

--- a/frontend/elements/src/_bundles/jig/edit/imports.ts
+++ b/frontend/elements/src/_bundles/jig/edit/imports.ts
@@ -66,3 +66,4 @@ import "@elements/entry/jig/edit/post-publish/post-publish-action";
 import "@elements/module/_groups/design/edit/sidebar/widgets/theme-selector/option";
 import "@elements/_bundles/_sub-bundles/hebrew-buttons";
 import "@elements/core/modals/confirm";
+import "@elements/core/modals/video";

--- a/frontend/elements/src/core/modals/video.ts
+++ b/frontend/elements/src/core/modals/video.ts
@@ -1,0 +1,116 @@
+import { LitElement, html, css, customElement, property } from "lit-element";
+import { BaseButton } from "@elements/_styles/buttons";
+import "@elements/core/buttons/icon";
+import "@elements/core/buttons/rectangle";
+import "@elements/module/video/youtube-player";
+
+const STR_NO_SHOW_AGAIN = "Don't show onboarding again";
+
+@customElement("modal-video")
+export class _ extends BaseButton {
+    static get styles() {
+        return [
+            css`
+                :host {
+                    --overlay-z-index: 300;
+                    --yt-iframe-position: absolute;
+                }
+
+                .overlay {
+                    position: fixed;
+                    top: 0;
+                    left: 0;
+                    display: flex;
+                    justify-content: center;
+                    align-items: center;
+                    width: 100vw;
+                    height: 100vh;
+                    opacity: 0.8;
+                    background-color: var(--light-blue-3);
+                    z-index: var(--overlay-z-index);
+                }
+                .section {
+                    position: fixed;
+                    top: 50%;
+                    left: 50%;
+                    transform: translate(-50%, -50%);
+                    z-index: var(--overlay-z-index);
+
+                    width: 75vw;
+                    height: auto;
+                    border-radius: 16px;
+                    -webkit-backdrop-filter: blur(30px);
+                    backdrop-filter: blur(30px);
+                    box-shadow: 0 3px 16px 0 rgba(0, 0, 0, 0.16);
+                    background-color: var(--white);
+                    opacity: 1;
+                    display: flex;
+                    flex-direction: column;
+                }
+
+                video-youtube-player {
+                    position: relative;
+                    width: 100%;
+                    height: 0;
+                    padding: 0 0 56.25%;
+                }
+
+                .close {
+                    align-self: flex-end;
+                    margin: .5em .5em 0 0;
+                }
+
+                .contents {
+                    display: flex;
+                    flex-direction: column;
+                    padding: 32px;
+                    flex: 1;
+                }
+
+                .noshow {
+                    background: transparent;
+                    border: none;
+                    font-size: 13px;
+                    font-weight: 500;
+                    color: var(--dark-blue-3);
+                    cursor: pointer;
+                    align-self: flex-end;
+                    padding-top: 32px;
+                }
+                `,
+        ];
+    }
+
+    @property({ type: String })
+    videoId!: string;
+
+    onAnyClick(evt: MouseEvent) {
+        const path = evt.composedPath();
+        // Makes sure that only clicking the overlay will trigger a close event.
+        if (!path.includes(this.shadowRoot?.getElementById("section") as any)) {
+            this.onClose();
+        }
+    }
+
+    onClose() {
+        this.dispatchEvent(new Event("close"));
+    }
+
+    render() {
+        return html`
+            <div class="overlay" @click=${this.onAnyClick}></div>
+            <div class="section">
+                <button-icon
+                    size="x-small"
+                    class="close"
+                    icon="x"
+                    @click=${this.onClose}
+                ></button-icon>
+                <div class="contents">
+                    <video-youtube-player videoid="${this.videoId}"></video-youtube-player>
+                </div>
+            </div>
+        `;
+    }
+}
+

--- a/frontend/elements/src/module/video/youtube-player.ts
+++ b/frontend/elements/src/module/video/youtube-player.ts
@@ -36,6 +36,7 @@ export class _ extends LitElement {
                     background-color: black;
                 }
                 iframe {
+                    position: var(--yt-iframe-position);
                     height: 100%;
                     width: 100%;
                 }


### PR DESCRIPTION
Part of #1773

- Adds a new modal-video element;
- Shows a video in a modal in the jig/edit screen. 
  - When the video is closed by the teacher, they won't see it again unless they use a different browser.
- The video used is https://www.youtube.com/watch?v=x4FYtTpQAt0

![image](https://user-images.githubusercontent.com/4161106/152122216-3eb00fcb-2caf-499d-9716-0aed9cbe750f.png)

