### PR TITLE
fix(be/jig/search): change author to author_id in algolia

### DIFF
--- a/backend/api/src/algolia.rs
+++ b/backend/api/src/algolia.rs
@@ -830,7 +830,7 @@ impl Client {
 
             and_filters.filters.push(Box::new(CommonFilter {
                 filter: FacetFilter {
-                    facet_name: "author".to_owned(),
+                    facet_name: "author_id".to_owned(),
                     value: author_id.to_string(),
                 },
                 invert: false,

--- a/backend/api/src/http/endpoints/jig.rs
+++ b/backend/api/src/http/endpoints/jig.rs
@@ -331,10 +331,6 @@ async fn search(
             UserOrMe::User(id) => id,
         });
 
-        db::jig::authz_list(&*db, user.0.user_id, author_id)
-            .await
-            .map_err(|_| error::Service::Forbidden)?;
-
         author_id
     } else {
         let author_id = query.author_id.map(|it| match it {

--- a/shared/rust/src/domain/jig.rs
+++ b/shared/rust/src/domain/jig.rs
@@ -812,7 +812,7 @@ pub struct JigSearchQuery {
 
     /// Optionally filter by author's id
     #[serde(default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    // #[serde(skip_serializing_if = "Option::is_none")]
     pub author_id: Option<UserOrMe>,
 
     /// Optionally filter by the author's name


### PR DESCRIPTION
closes #2362 

Fix for mismatch `author_id` algolia  field