### PR TITLE
Export data UI

### DIFF
--- a/backend/api/sqlx-data.json
+++ b/backend/api/sqlx-data.json
@@ -1261,28 +1261,6 @@
       ]
     }
   },
-  "1fecc2613bdeb1cb5ef0e88661eb5a43f995623a28c26cf77cb01e50a7c9ebb7": {
-    "query": "select exists(select 1 from \"user_scope\" where user_id = $1 and (scope = $2 or scope = $3)) as \"exists!\"",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "exists!",
-          "type_info": "Bool"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Int2",
-          "Int2"
-        ]
-      },
-      "nullable": [
-        null
-      ]
-    }
-  },
   "228687aa01cb6d5780d804f5ddf78a5e070fc552dbb3b3f8e5224b8a6a9e9b18": {
     "query": "\nselect id as \"id: ImageId\", kind as \"kind: ImageKind\"\nfrom user_image_library\n         join user_image_upload\n              on user_image_library.id = user_image_upload.image_id\nwhere processing_result is true\n  and user_id = $1\n  and (kind is not distinct from $2 or $2 is null)\norder by created_at desc\n",
     "describe": {
@@ -5150,6 +5128,28 @@
         ]
       },
       "nullable": []
+    }
+  },
+  "a9996186c133f11e9d24a68f2f686c99b5f65fc97b4de1ea89411b16b333afb5": {
+    "query": "select exists(\n            select 1\n            from \"user_scope\"\n            where\n                user_id = $1 and\n                (scope = $2 or scope = $3)\n        ) as \"exists!\"",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "exists!",
+          "type_info": "Bool"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Int2",
+          "Int2"
+        ]
+      },
+      "nullable": [
+        null
+      ]
     }
   },
   "ab605fef6d23ea4a74e80999574296f7b4fce2ed0029455be3d6541ee379d329": {

--- a/backend/api/src/http/endpoints/admin.rs
+++ b/backend/api/src/http/endpoints/admin.rs
@@ -22,7 +22,7 @@ use uuid::Uuid;
 
 use crate::{
     db, error,
-    extractor::{ScopeAdmin, TokenUserWithScope},
+    extractor::{ScopeAdmin, TokenUserNoCsrfWithScope, TokenUserWithScope},
     image_ops::{regenerate_images, MediaKind},
     service::{s3, ServiceData},
     token::{create_auth_token, SessionMask},
@@ -258,7 +258,7 @@ async fn list_media(
 }
 
 async fn export_data(
-    _auth: TokenUserWithScope<ScopeAdmin>,
+    _auth: TokenUserNoCsrfWithScope<ScopeAdmin>,
     req: HttpRequest,
     db: Data<PgPool>,
     query: Query<<admin::ExportData as ApiEndpoint>::Req>,

--- a/frontend/apps/Cargo.lock
+++ b/frontend/apps/Cargo.lock
@@ -23,6 +23,8 @@ version = "0.1.0"
 dependencies = [
  "awsm_web 0.32.0",
  "cfg-if 1.0.0",
+ "chrono",
+ "chrono-tz",
  "components",
  "console_error_panic_hook",
  "discard",

--- a/frontend/apps/crates/entry/admin/Cargo.toml
+++ b/frontend/apps/crates/entry/admin/Cargo.toml
@@ -18,6 +18,8 @@ crate-type = ["cdylib"]
 utils = {path = "../../utils"}
 shared = {path = "../../../../../shared/rust", features = ["wasm"]}
 components = {path = "../../components"}
+chrono = { version = "0.4.19", features = ["serde"] }
+chrono-tz = { version = "0.6.0", features = ["serde"] }
 wasm-logger = { version = "0.2.0", optional = true }
 wee_alloc = { version = "0.4.5", optional = true }
 console_error_panic_hook = { version = "0.1.7", optional = true }
@@ -30,7 +32,7 @@ web-sys = { version = "0.3.55", features = [
     'Response',
     'RequestMode',
     'Headers',
-    'Document', 
+    'Document',
     'DocumentFragment',
     'HtmlTemplateElement',
     'Window',

--- a/frontend/apps/crates/entry/admin/src/export/actions.rs
+++ b/frontend/apps/crates/entry/admin/src/export/actions.rs
@@ -1,0 +1,19 @@
+use chrono::{DateTime, Utc, TimeZone};
+use futures_signals::signal::Mutable;
+use utils::unwrap::UnwrapJiExt;
+use wasm_bindgen::JsValue;
+
+use super::Export;
+
+impl Export {
+    pub fn set_date(&self, date: &Mutable<Option<DateTime<Utc>>>, value: &JsValue) {
+        let js_date = js_sys::Date::new(value);
+        let datetime = chrono::Utc.datetime_from_str(
+            &js_date.to_iso_string().as_string().unwrap_ji(),
+            "%Y-%m-%dT%H:%M:%S%Z"
+        );
+        if let Ok(datetime) = datetime {
+            date.set(Some(datetime));
+        }
+    }
+}

--- a/frontend/apps/crates/entry/admin/src/export/dom.rs
+++ b/frontend/apps/crates/entry/admin/src/export/dom.rs
@@ -1,0 +1,99 @@
+use chrono::TimeZone;
+use dominator::{clone, html, Dom, with_node, text_signal};
+use futures_signals::{signal::SignalExt, map_ref};
+use shared::{
+    api::{ApiEndpoint, endpoints::admin::ExportData},
+    domain::admin::ExportType
+};
+use strum::IntoEnumIterator;
+use utils::{init::settings::SETTINGS, events, unwrap::UnwrapJiExt};
+use std::{rc::Rc, convert::AsRef};
+use web_sys::{HtmlInputElement, HtmlElement};
+use wasm_bindgen::prelude::*;
+use super::Export;
+
+impl Export {
+    pub fn render(self: &Rc<Self>) -> Dom {
+        let state = self;
+
+        html!("admin-export", {
+            .child(html!("input-select", {
+                .property("label", "Data to export")
+                .property("multiple", false)
+                .property_signal("value", state.export_type.signal_cloned().map(|export_type| {
+                    match export_type {
+                        None => JsValue::NULL,
+                        Some(export_type) => JsValue::from_str(&format!("{}", export_type)),
+                    }
+                }))
+                .children(ExportType::iter().map(|export_type| {
+                    html!("input-select-option", {
+                        .text(&format!("{}", export_type))
+                        .property_signal("selected", state.export_type.signal_cloned().map(clone!(export_type => move |current_type| {
+                            match current_type {
+                                Some(current_type) => export_type == current_type,
+                                None => false,
+                            }
+                        })))
+                        .event(clone!(state => move |_: events::CustomSelectedChange| {
+                            state.export_type.set(Some(export_type.clone()));
+                        }))
+                    })
+                }))
+            }))
+            .child(html!("input-wrapper" => HtmlElement, {
+                .with_node!(wrapper => {
+                    .property("label", "From date")
+                    .child(html!("input" => HtmlInputElement, {
+                        .property("type", "date")
+                        .property("pattern", "\\d{4}-\\d{2}-\\d{2}")
+                        .with_node!(input => {
+                            .event(clone!(state => move |_: events::Input| {
+                                state.set_date(&state.from_date, &input.value().into());
+                            }))
+                        })
+                    }))
+                })
+            }))
+            .child(html!("input-wrapper" => HtmlElement, {
+                .with_node!(wrapper => {
+                    .property("label", "To date")
+                    .child(html!("input" => HtmlInputElement, {
+                        .property("type", "date")
+                        .property("pattern", "\\d{4}-\\d{2}-\\d{2}")
+                        .with_node!(input => {
+                            .event(clone!(state => move |_: events::Input| {
+                                state.set_date(&state.to_date, &input.value().into());
+                            }))
+                        })
+                    }))
+                })
+            }))
+            .child(html!("button-rect", {
+                .property("kind", "filled")
+                .property("color", "blue")
+                .property_signal("disabled", state.export_type.signal_cloned().map(|export_type| export_type.is_none()))
+                .property_signal("href", map_ref! {
+                    let export_type = state.export_type.signal_cloned(),
+                    let from_date = state.from_date.signal_cloned(),
+                    let to_date = state.to_date.signal_cloned()
+                        => {
+                            let mut params = Vec::new();
+                            if let Some(export_type) = export_type {
+                                params.push(format!("export_type={}", export_type).to_lowercase());
+                            }
+                            if let Some(from_date) = from_date {
+                                params.push(format!("from_date={}", from_date.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)));
+                            }
+                            if let Some(to_date) = to_date {
+                                params.push(format!("to_date={}", to_date.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)));
+                            }
+                            let remote = SETTINGS.get().unwrap_ji().remote_target.api_url();
+                            format!("{}{}?{}", remote, ExportData::PATH, params.join("&"))
+                        }
+                })
+                .text("Export")
+            }))
+        })
+    }
+}

--- a/frontend/apps/crates/entry/admin/src/export/mod.rs
+++ b/frontend/apps/crates/entry/admin/src/export/mod.rs
@@ -1,0 +1,6 @@
+mod state;
+mod dom;
+mod actions;
+
+pub use state::*;
+pub use dom::*;

--- a/frontend/apps/crates/entry/admin/src/export/state.rs
+++ b/frontend/apps/crates/entry/admin/src/export/state.rs
@@ -1,0 +1,21 @@
+use std::rc::Rc;
+use chrono::{DateTime, Utc};
+
+use futures_signals::signal::Mutable;
+use shared::domain::admin::ExportType;
+
+pub struct Export {
+    pub export_type: Mutable<Option<ExportType>>,
+    pub from_date: Mutable<Option<DateTime<Utc>>>,
+    pub to_date: Mutable<Option<DateTime<Utc>>>,
+}
+
+impl Export {
+    pub fn new() -> Rc<Self> {
+        Rc::new(Self {
+            export_type: Mutable::new(Some(ExportType::Profiles)),
+            from_date: Mutable::new(None),
+            to_date: Mutable::new(None),
+        })
+    }
+}

--- a/frontend/apps/crates/entry/admin/src/lib.rs
+++ b/frontend/apps/crates/entry/admin/src/lib.rs
@@ -6,6 +6,7 @@
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
 mod categories;
+mod export;
 mod images;
 mod locale;
 mod router;

--- a/frontend/apps/crates/entry/admin/src/router.rs
+++ b/frontend/apps/crates/entry/admin/src/router.rs
@@ -24,6 +24,7 @@ use crate::{
     locale::{dom::LocalePage, state::LoaderState as LocaleLoaderState},
     sidebar::Sidebar,
     curation::Curation,
+    export::Export,
 };
 use std::cell::RefCell;
 pub struct Router {
@@ -104,6 +105,7 @@ impl Router {
                                                 AdminRoute::ImageSearch(query) => Some(state.with_child(route, ImageSearchPage::render(query))),
                                                 AdminRoute::ImageTags => Some(state.with_child(route, ImageTags::render(ImageTags::new()))),
                                                 AdminRoute::Curation(curation_route) => Some(state.with_child(route, Curation::new(curation_route).render())),
+                                                AdminRoute::Export => Some(state.with_child(route, Export::new().render())),
                                                 _ => Some(state.with_child(route, html!("empty-fragment"))),
                                             }
                                         }

--- a/frontend/apps/crates/entry/admin/src/sidebar/state.rs
+++ b/frontend/apps/crates/entry/admin/src/sidebar/state.rs
@@ -32,6 +32,7 @@ impl Sidebar {
                     SidebarItem::new(AdminRoute::Curation(AdminCurationRoute::Table), profile, &curr_route),
                     SidebarItem::new(AdminRoute::Categories, profile, &curr_route),
                     SidebarItem::new(AdminRoute::Locale, profile, &curr_route),
+                    SidebarItem::new(AdminRoute::Export, profile, &curr_route),
                 ],
             })
             .to_signal_vec()
@@ -59,6 +60,7 @@ impl SidebarItem {
             AdminRoute::ImageMeta(_, _) => "image-search",
             AdminRoute::ImageSearch(_) => "image-search",
             AdminRoute::Curation(_) => "curation",
+            AdminRoute::Export => "export",
             AdminRoute::Landing => "",
         };
 

--- a/frontend/apps/crates/utils/src/routes.rs
+++ b/frontend/apps/crates/utils/src/routes.rs
@@ -71,6 +71,7 @@ pub enum AdminRoute {
     ImageAdd,
     ImageTags,
     ImageMeta(ImageId, bool), //flag is for if it's a new image
+    Export,
 }
 
 impl AdminRoute {
@@ -86,7 +87,8 @@ impl AdminRoute {
             Self::Curation(_) => scopes.contains(&UserScope::AdminJig),
             Self::ImageSearch(_) | Self::ImageAdd | Self::ImageTags | Self::ImageMeta(_, _) => {
                 scopes.contains(&UserScope::ManageImage)
-            }
+            },
+            Self::Export => scopes.contains(&UserScope::Admin),
         }
     }
 }
@@ -256,7 +258,8 @@ impl Route {
             ["admin", "image-meta", id, flag] => {
                 let id = ImageId(Uuid::from_str(id).unwrap_ji());
                 Self::Admin(AdminRoute::ImageMeta(id, bool::from_str(flag).unwrap_ji()))
-            }
+            },
+            ["admin", "export"] => Self::Admin(AdminRoute::Export),
             ["admin"] => Self::Admin(AdminRoute::Landing),
             ["jig", "edit", "gallery"] => Self::Jig(JigRoute::Gallery),
             ["jig", "edit", "resource-gallery"] => Self::Jig(JigRoute::ResourceGallery),
@@ -444,6 +447,7 @@ impl From<&Route> for String {
                 AdminRoute::ImageMeta(id, is_new) => {
                     format!("/admin/image-meta/{}/{}", id.0.to_string(), is_new)
                 }
+                AdminRoute::Export => "/admin/export".to_string(),
             },
             Route::Jig(route) => match route {
                 JigRoute::Gallery => "/jig/edit/gallery".to_string(),

--- a/frontend/elements/src/_bundles/admin/imports.ts
+++ b/frontend/elements/src/_bundles/admin/imports.ts
@@ -25,6 +25,7 @@ import "@elements/entry/admin/locale/locale-select-columns-item";
 import "@elements/entry/admin/curation/table";
 import "@elements/entry/admin/curation/table-line";
 import "@elements/entry/admin/curation/jig-details";
+import "@elements/entry/admin/export/export";
 import "@elements/core/inputs/wrapper";
 import "@elements/core/inputs/composed/select/select";
 import "@elements/core/inputs/composed/select/option";

--- a/frontend/elements/src/entry/admin/export/export.ts
+++ b/frontend/elements/src/entry/admin/export/export.ts
@@ -1,0 +1,29 @@
+import { LitElement, html, css, customElement } from "lit-element";
+import "@elements/core/titles/variants/underlined-title";
+
+@customElement("admin-export")
+export class _ extends LitElement {
+    static styles = [
+        css`
+            :host {
+                padding: 40px;
+                margin-top: 40px;
+            }
+            .wrapper {
+                display: grid;
+                grid-template-columns: 300px;
+                padding-top: 40px;
+                grid-gap: 20px;
+            }
+        `
+    ];
+
+    render() {
+        return html`
+            <underlined-title title="Export data"></underlined-title>
+            <div class="wrapper">
+                <slot></slot>
+            </div>
+        `;
+    }
+}

--- a/frontend/elements/src/entry/admin/sidebar/item.ts
+++ b/frontend/elements/src/entry/admin/sidebar/item.ts
@@ -7,7 +7,8 @@ export type ID =
     | "image-search"
     | "curation"
     | "category"
-    | "image-tags";
+    | "image-tags"
+    | "export";
 
 const STR_LABEL_LOOKUP: { [key in ID]: string } = {
     "image-add": "Add image",
@@ -16,6 +17,7 @@ const STR_LABEL_LOOKUP: { [key in ID]: string } = {
     "curation": "Curation",
     "category": "Edit categories",
     "locale": "Localization",
+    "export": "Export",
 };
 
 @customElement("admin-sidebar-item")

--- a/shared/rust/src/domain/admin.rs
+++ b/shared/rust/src/domain/admin.rs
@@ -1,7 +1,7 @@
 //! Types for admin routes.
-
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use strum_macros::{Display, EnumIter};
 use uuid::Uuid;
 
 use crate::media::{MediaKind, MediaLibrary};
@@ -40,7 +40,7 @@ pub struct AdminMediaItem {
 }
 
 /// Type of data export to perform
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Display, EnumIter, Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum ExportType {
     /// Export user profiles


### PR DESCRIPTION
Closes #2353

- Adds a new extractor for claims so that a user can be authenticated with the csrf token - this is useful only for some edge cases like the downloading of a csv 👇 - shouldn't be used for auth on any endpoint which has side-effects;
- Adds a UI to the admin panel to export data as a csv - currently only Profiles can be exported.

![image](https://user-images.githubusercontent.com/4161106/153173944-5ff0d2b1-56f2-4231-8d1f-e82b9720cb6f.png)
