### PR TITLE
feat(fe/jig/edit): Add show onboarding button to jiggling help text

### DIFF
--- a/backend/pages/Cargo.lock
+++ b/backend/pages/Cargo.lock
@@ -2329,6 +2329,8 @@ dependencies = [
  "serde_repr",
  "serde_with",
  "sqlx",
+ "strum",
+ "strum_macros",
  "thiserror",
  "url",
  "uuid",
@@ -2562,6 +2564,24 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7ac893c7d471c8a21f31cfe213ec4f6d9afeed25537c772e08ef3f005f8729e"
+
+[[package]]
+name = "strum_macros"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339f799d8b549e3744c7ac7feb216383e4005d94bdb22561b3ab8f3b808ae9fb"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "subtle"

--- a/frontend/apps/crates/components/src/module/_common/edit/entry/base/dom/regular.rs
+++ b/frontend/apps/crates/components/src/module/_common/edit/entry/base/dom/regular.rs
@@ -165,7 +165,7 @@ where
                         body,
                         "module-header"
                     )
-                    .render(Some("help"))
+                    .render(Some("help"), Rc::new(None::<fn() -> Dom>))
                 )
             } else {
                 None

--- a/frontend/apps/crates/entry/jig/edit/src/edit/dom.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/dom.rs
@@ -53,7 +53,7 @@ impl EditPage {
                     match route {
                         JigEditRoute::Landing => {
                             match jig_focus {
-                                JigFocus::Modules => Some(SelectionDom::render()),
+                                JigFocus::Modules => Some(SelectionDom::render(state.clone())),
                                 JigFocus::Resources => Some(Publish::render(Rc::clone(&state))),
                             }
                         },

--- a/frontend/apps/crates/entry/jig/edit/src/edit/selection/dom.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/selection/dom.rs
@@ -1,8 +1,12 @@
+use std::rc::Rc;
+
 use components::jigzi_help::JigziHelp;
-use dominator::{html, Dom};
+use dominator::{clone, html, Dom};
 
 use super::module::dom::ModuleDom;
+use super::super::state::State;
 use shared::domain::jig::ModuleKind;
+use utils::events;
 
 static MODULE_KINDS: &[ModuleKind] = &[
     ModuleKind::Cover,
@@ -21,11 +25,12 @@ static MODULE_KINDS: &[ModuleKind] = &[
 const STR_TOOLTIP_TITLE: &str = "Let's build your JIG!";
 const STR_TOOLTIP_BODY: &str =
     "Select an activity and drag it to the body of your JIG. You can change the order at any time.";
+const STR_SHOW_ONBOARDING: &str = "Show onboarding";
 
 pub struct SelectionDom {}
 
 impl SelectionDom {
-    pub fn render() -> Dom {
+    pub fn render(state: Rc<State>) -> Dom {
         html!("jig-edit-selection", {
             .property("slot", "main")
             .children(
@@ -42,7 +47,19 @@ impl SelectionDom {
                     STR_TOOLTIP_BODY.to_string(),
                     "module-select"
                 )
-                .render(Some("help"))
+                .render(
+                    Some("help"),
+                    Rc::new(Some(move || {
+                        html!("button-rect", {
+                            .property("kind", "text")
+                            .property("color", "lightBlue")
+                            .text(STR_SHOW_ONBOARDING)
+                            .event(clone!(state => move |_evt: events::Click| {
+                                state.show_onboarding.set_neq(true);
+                            }))
+                        })
+                    }))
+                )
             )
         })
     }

--- a/frontend/apps/crates/utils/src/events.rs
+++ b/frontend/apps/crates/utils/src/events.rs
@@ -14,7 +14,6 @@ temp_make_event!(Ready, "ready" => web_sys::Event);
 
 temp_make_event!(Open, "open" => web_sys::Event);
 temp_make_event!(Close, "close" => web_sys::Event);
-temp_make_event!(PermanentlyClose, "permanently-close" => web_sys::Event);
 
 temp_make_event!(Submit, "submit" => web_sys::Event);
 

--- a/frontend/elements/src/core/buttons/rectangle.ts
+++ b/frontend/elements/src/core/buttons/rectangle.ts
@@ -1,7 +1,7 @@
 import { LitElement, html, css, customElement, property } from "lit-element";
 import { ifDefined } from "lit-html/directives/if-defined";
 
-export type Color = "red" | "blue" | "green" | "darkGray";
+export type Color = "red" | "blue" | "green" | "darkGray" | "lightBlue";
 export type Size = "small" | "medium" | "large";
 export type Kind = "filled" | "text" | "outline";
 
@@ -63,6 +63,12 @@ export class _ extends LitElement {
                 :host([color="blue"]:hover),
                 :host([hoverColor="blue"]:hover) {
                     --color: #387af4;
+                }
+                :host([color="lightBlue"]) {
+                    --color: var(--light-blue-4);
+                }
+                :host([color="lightBlue"]:hover) {
+                    --color: var(--light-blue-3);
                 }
                 :host([color="green"]) {
                     --color: #71cf92;

--- a/frontend/elements/src/core/overlays/tooltip/info.ts
+++ b/frontend/elements/src/core/overlays/tooltip/info.ts
@@ -11,8 +11,6 @@ import "@elements/core/buttons/icon";
 import "./container";
 import { Color } from "./container";
 
-const STR_NO_SHOW_AGAIN = "Don’t show tips again";
-
 @customElement("overlay-tooltip-info")
 export class _ extends LitElement {
     static get styles() {
@@ -77,14 +75,13 @@ export class _ extends LitElement {
                     width: 304px;
                     margin: 8px 0 36px 0;
                 }
-                .noshow {
-                    background: transparent;
-                    border: none;
-                    font-size: 13px;
-                    font-weight: 500;
-                    color: var(--light-blue-4);
-                    cursor: pointer;
-                    align-self: flex-end;
+                .actions {
+                    display: flex;
+                    flex-direction: row;
+                    justify-content: space-between;
+                }
+                .actions :last-child {
+                    margin-left: auto;
                 }
             `,
         ];
@@ -127,9 +124,6 @@ export class _ extends LitElement {
 
     @property()
     body: string = "";
-
-    @property({ type: Boolean })
-    showPermanentlyClose: boolean = false;
 
     @property({ type: Boolean })
     closeable: boolean = false;
@@ -188,20 +182,6 @@ export class _ extends LitElement {
         `;
     }
 
-    renderPermanentlyClose() {
-        if (!this.showPermanentlyClose) {
-            return nothing;
-        }
-
-        const onClick = () => {
-            this.dispatchEvent(new Event("permanently-close"));
-            this.onClose();
-        };
-        return html`
-            <button @click=${onClick} class="noshow">${STR_NO_SHOW_AGAIN}</button>
-        `;
-    }
-
     render() {
         const {
             container,
@@ -253,7 +233,9 @@ export class _ extends LitElement {
                         ${body !== ""
                             ? html`<section class="body">${body}</section>`
                             : nothing}
-                        ${this.renderPermanentlyClose()}
+                        <div class="actions">
+                            <slot name="actions"></slot>
+                        </div>
                     </section>
                 </tooltip-container>
             </overlay-content>


### PR DESCRIPTION
Closes #1773

- Adds a "Show onboarding" button to the Jiggling text on the Add an Activity screen:

![image](https://user-images.githubusercontent.com/4161106/153810151-1cd3a3e9-dcdf-4d5f-8c19-70598e8a7a9d.png)
