### PR TITLE
feat(fe/page-header): Add beta button and tooltip to page header

### DIFF
--- a/frontend/apps/crates/components/src/page_header/state.rs
+++ b/frontend/apps/crates/components/src/page_header/state.rs
@@ -10,6 +10,7 @@ const TARGET_BLANK: &str = "_blank";
 pub struct State {
     pub logged_in: Mutable<LoggedInState>,
     pub loader: AsyncLoader,
+    pub beta_tooltip: Mutable<bool>,
 }
 
 impl State {
@@ -17,6 +18,7 @@ impl State {
         Self {
             logged_in: Mutable::new(LoggedInState::Loading),
             loader: AsyncLoader::new(),
+            beta_tooltip: Mutable::new(false),
         }
     }
 }

--- a/frontend/apps/crates/entry/admin/src/router.rs
+++ b/frontend/apps/crates/entry/admin/src/router.rs
@@ -78,6 +78,7 @@ impl Router {
                                 Rc::new(components::page_header::state::State::new()),
                                 None,
                                 None,
+                                false,
                             ));
 
                             if let Some(profile) = profile {

--- a/frontend/apps/crates/entry/home/src/home/dom/mod.rs
+++ b/frontend/apps/crates/entry/home/src/home/dom/mod.rs
@@ -22,7 +22,7 @@ use iframe::Iframe;
 pub fn render(state: Rc<State>, auto_search: bool) -> Dom {
     html!("home-full", {
         .child_signal(state.mode.signal_ref(|mode| {
-            Some(page_header::dom::render(Rc::new(page_header::state::State::new()), None, Some(PageLinks::from(mode))))
+            Some(page_header::dom::render(Rc::new(page_header::state::State::new()), None, Some(PageLinks::from(mode)), true))
         }))
         .children(&mut [
             search_section::render(state.clone(), auto_search),

--- a/frontend/apps/crates/entry/jig/edit/src/gallery/dom.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/gallery/dom.rs
@@ -54,7 +54,7 @@ impl JigGallery {
         };
 
         html!("empty-fragment", {
-            .child(page_header::dom::render(Rc::new(page_header::state::State::new()), None, Some(PageLinks::Create)))
+            .child(page_header::dom::render(Rc::new(page_header::state::State::new()), None, Some(PageLinks::Create), true))
             .child_signal(state.confirm_delete.signal().map(clone!(state => move |confirm_delete| {
                 confirm_delete.map(|jig_id| {
                     html!("modal-confirm", {

--- a/frontend/apps/crates/entry/user/src/profile/dom/mod.rs
+++ b/frontend/apps/crates/entry/user/src/profile/dom/mod.rs
@@ -45,7 +45,7 @@ impl ProfilePage {
         actions::load_initial_data(state.clone());
 
         html!("user-profile", {
-            .child(page_header::dom::render(Rc::new(page_header::state::State::new()), Some("page-header"), None))
+            .child(page_header::dom::render(Rc::new(page_header::state::State::new()), Some("page-header"), None, true))
             .property_signal("email", state.user.email.signal_cloned())
             .property_signal("name", full_name_signal(Rc::clone(&state)))
             .children(&mut [

--- a/frontend/elements/src/_bundles/_sub-bundles/page/header.ts
+++ b/frontend/elements/src/_bundles/_sub-bundles/page/header.ts
@@ -1,3 +1,5 @@
+import "@elements/core/page-header/beta-button";
+import "@elements/core/page-header/beta-tooltip-content";
 import "@elements/core/page-header/page-header";
 import "@elements/core/page-header/page-header-link";
 import "@elements/core/page-header/page-header-profile";

--- a/frontend/elements/src/core/overlays/tooltip/container.ts
+++ b/frontend/elements/src/core/overlays/tooltip/container.ts
@@ -19,7 +19,7 @@ import {
     getAnchors,
 } from "@elements/core/overlays/content";
 
-export type Color = "blue" | "red" | "green";
+export type Color = "blue" | "red" | "green" | "light-orange";
 
 const TRIANGLE_WIDTH = 18;
 const TRIANGLE_HEIGHT = 10;
@@ -78,6 +78,10 @@ export class _ extends LitElement {
                 :host([color="red"]) {
                     --tooltip-bg-color: var(--light-red-1);
                     --tooltip-border-color: var(--light-red-1);
+                }
+                :host([color="light-orange"]) {
+                    --tooltip-bg-color: var(--light-orange-1);
+                    --tooltip-border-color: var(--light-orange-1);
                 }
 
                 .main {

--- a/frontend/elements/src/core/overlays/tooltip/info.ts
+++ b/frontend/elements/src/core/overlays/tooltip/info.ts
@@ -75,6 +75,9 @@ export class _ extends LitElement {
                     width: 304px;
                     margin: 8px 0 36px 0;
                 }
+                :host([color="light-orange"]) .body {
+                    color: var(--dark-gray-6);
+                }
                 .actions {
                     display: flex;
                     flex-direction: row;
@@ -232,7 +235,7 @@ export class _ extends LitElement {
                             : nothing}
                         ${body !== ""
                             ? html`<section class="body">${body}</section>`
-                            : nothing}
+                            : html`<section class="body"><slot name="body"></slot></section>`}
                         <div class="actions">
                             <slot name="actions"></slot>
                         </div>

--- a/frontend/elements/src/core/page-header/beta-button.ts
+++ b/frontend/elements/src/core/page-header/beta-button.ts
@@ -1,0 +1,63 @@
+import {
+    LitElement,
+    html,
+    css,
+    customElement,
+    property,
+    internalProperty
+} from "lit-element";
+
+@customElement("beta-button")
+export class _ extends LitElement {
+    static get styles() {
+        return [
+            css`
+                :host {
+                    display: inline-block;
+                    height: 100%;
+                    position: relative;
+                }
+                button {
+                    margin: 0;
+                    padding: 0 24px;
+                    background: none;
+                    border: none;
+                    line-height: 34px;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 13px;
+                    font-weight: 600;
+                }
+
+                button div {
+                    display: flex;
+                    flex-direction: row;
+                }
+
+                img-ui {
+                    display: flex;
+                    margin-left: 8px;
+                }
+            `,
+        ];
+    }
+
+    @internalProperty()
+    private open = false;
+
+    private toggleOpen() {
+        this.open = !this.open;
+    }
+
+    render() {
+        return html`
+            <button class="anchor" @click=${this.toggleOpen}>
+                <div>
+                    <span>Beta version</span>
+                    <img-ui path="core/page-header/nav-icon-about.svg"></img-ui>
+                </div>
+            </button>
+        `;
+    }
+}
+

--- a/frontend/elements/src/core/page-header/beta-tooltip-content.ts
+++ b/frontend/elements/src/core/page-header/beta-tooltip-content.ts
@@ -1,0 +1,52 @@
+import {
+    LitElement,
+    html,
+    css,
+    customElement,
+    property,
+    internalProperty
+} from "lit-element";
+
+const HUBSPOT_LINK = "https://share.hsforms.com/1pCg45ADPSlCFSiL0NzOYIQ1kii1";
+
+@customElement("beta-tooltip-content")
+export class _ extends LitElement {
+    static get styles() {
+        return [
+            css`
+                :host {
+                    display: flex;
+                    flex-direction: column;
+                    align-items: center;
+                    font-family: Poppins;
+                    color: var(--dark-gray-6);
+                }
+
+                h1 {
+                    font-size: 20px;
+                    font-weight: 500;
+                    line-height: 2;
+                    text-align: center;
+                }
+                div.content {
+                    margin: 16px 24px;
+                    font-size: 16px;
+                    line-height: 1.5;
+                    text-align: center;
+                }
+            `,
+        ];
+    }
+
+    render() {
+        return html`
+            <h1>You are using the beta version</h1>
+            <img-ui path="core/page-header/illustration-beta.png"></img-ui>
+            <div class="content">Your feedback will help us improve our platform.</div>
+            <button-rect kind="text" color="blue" bold href="${HUBSPOT_LINK}" target="_blank">
+                Tell us what you think!
+            </button-rect>
+        `;
+    }
+}
+

--- a/frontend/elements/src/core/page-header/page-header.ts
+++ b/frontend/elements/src/core/page-header/page-header.ts
@@ -6,6 +6,7 @@ export class _ extends LitElement {
         return [
             css`
                 :host {
+                    position: relative;
                     display: grid;
                     grid-template-columns: repeat(5, auto);
                     justify-content: space-between;
@@ -47,6 +48,16 @@ export class _ extends LitElement {
                     height: 100%;
                     align-items: center;
                 }
+                .beta {
+                    position: absolute;
+                    background-color: var(--dark-blue-5);
+                    color: #ffffff;
+                    left: 0;
+                    bottom: 0;
+                    transform: translateY(100%);
+                    border-radius: 0 0 12px 12px;
+                    margin-left: 1em;
+                }
             `,
         ];
     }
@@ -68,6 +79,9 @@ export class _ extends LitElement {
             <div class="user">
                 <slot name="user"></slot>
             </div>
+            <span class="beta">
+                <slot name="beta"></slot>
+            </span>
         `;
     }
 }


### PR DESCRIPTION
Closes #2365

- Adds a beta button to the page header;
- Adds a tooltip when the button is clicked.

![image](https://user-images.githubusercontent.com/4161106/154889474-c407aca4-d312-4d3c-a838-47153d0253e6.png)
