### PR TITLE
chore(be): Add indexes to improve jig_data lookups

### DIFF
--- a/backend/api/migrations/20220228083216_add_jig_data_related_indexes.sql
+++ b/backend/api/migrations/20220228083216_add_jig_data_related_indexes.sql
@@ -1,0 +1,8 @@
+create index jig_live_id on jig(live_id);
+create index jig_draft_id on jig(draft_id);
+create index jig_data_module_jig_data_id_idx on jig_data_module(jig_data_id);
+create index jig_data_goal_jig_data_id_idx on jig_data_goal(jig_data_id);
+create index jig_data_category_jig_data_id_idx on jig_data_category(jig_data_id);
+create index jig_data_affiliation_jig_data_id_idx on jig_data_affiliation(jig_data_id);
+create index jig_data_additional_resource_jig_data_id_idx on jig_data_additional_resource(jig_data_id);
+create index jig_data_age_range_jig_data_id_idx on jig_data_age_range(jig_data_id);


### PR DESCRIPTION
Part of #2139

- Adds indexes to a number of lookup tables so that performance when fetching jig-related data is improved.
  - Improves perf at the expense of storage which should be minimal tbh, the data is quite small.

The improvement is substantial, but the response times are still higher than what I feel that should be.

**Note** I struggled way too much trying to get Sentry tracing to work reliably. As a workaround I plugged otel tracing into my local install and shipped to Honeycomb so that I can get pretty reporting.

## Results for the `get_one` query

Based on running 1000 requests with 200 concurrent requests at a time.

### Before/After 

![Screenshot from 2022-02-28 10-54-00](https://user-images.githubusercontent.com/4161106/155953549-dcc834b7-b673-4deb-a33a-1269342499f2.png)

### Before Trace

![Screenshot from 2022-02-28 10-54-24](https://user-images.githubusercontent.com/4161106/155953601-c77f1b8d-84ff-4d62-a2be-b266087f7132.png)

### After Trace

![Screenshot from 2022-02-28 10-54-32](https://user-images.githubusercontent.com/4161106/155953613-2aaa71d7-2efe-4ef3-80d3-5879a78e1aed.png)
