### PR TITLE
chore(be): Add instrumentation for browse endpoint

### DIFF
--- a/backend/api/src/db/jig.rs
+++ b/backend/api/src/db/jig.rs
@@ -533,6 +533,7 @@ where draft_or_live is not null
     Ok(v)
 }
 
+#[instrument(skip_all)]
 pub async fn browse(
     db: &sqlx::Pool<sqlx::Postgres>,
     author_id: Option<Uuid>,
@@ -568,6 +569,7 @@ pub async fn browse(
         blocked,
     )
     .fetch_all(&mut txn)
+    .instrument(tracing::info_span!("query jigs"))
     .await?;
 
     let jig_data_ids: Vec<Uuid> = jig.iter().map(|it| it.id).collect();
@@ -651,7 +653,9 @@ limit $3
         page,
         page_limit as i32
     )
-        .fetch_all(&mut txn).await?;
+        .fetch_all(&mut txn)
+        .instrument(tracing::info_span!("query jig_data"))
+        .await?;
 
     let v: Vec<_> = jig_data
         .into_iter()
@@ -1007,6 +1011,7 @@ where creator_id is not distinct from $1
 }
 
 // `None` here means do not filter.
+#[instrument(skip_all)]
 pub async fn filtered_count(
     db: &PgPool,
     privacy_level: Vec<PrivacyLevel>,

--- a/backend/api/src/db/jig.rs
+++ b/backend/api/src/db/jig.rs
@@ -167,7 +167,7 @@ impl From<serde_json::Error> for CreateJigError {
     }
 }
 
-#[instrument(skip_all)]
+#[instrument(skip(pool))]
 pub async fn get_one(
     pool: &PgPool,
     id: JigId,
@@ -335,7 +335,7 @@ from jig_data
     Ok(jig)
 }
 
-#[instrument(skip_all)]
+#[instrument(skip(db))]
 pub async fn get_by_ids(
     db: &PgPool,
     ids: &[Uuid],
@@ -533,7 +533,7 @@ where draft_or_live is not null
     Ok(v)
 }
 
-#[instrument(skip_all)]
+#[instrument(skip(db))]
 pub async fn browse(
     db: &sqlx::Pool<sqlx::Postgres>,
     author_id: Option<Uuid>,
@@ -1011,7 +1011,7 @@ where creator_id is not distinct from $1
 }
 
 // `None` here means do not filter.
-#[instrument(skip_all)]
+#[instrument(skip(db))]
 pub async fn filtered_count(
     db: &PgPool,
     privacy_level: Vec<PrivacyLevel>,

--- a/backend/api/src/db/meta.rs
+++ b/backend/api/src/db/meta.rs
@@ -5,8 +5,10 @@ use shared::domain::meta::{
 };
 use shared::media::MediaGroupKind;
 use sqlx::{postgres::PgDatabaseError, PgPool};
+use tracing::instrument;
 use uuid::Uuid;
 
+#[instrument(skip(db))]
 pub async fn get_image_styles(db: &PgPool) -> sqlx::Result<Vec<ImageStyle>> {
     sqlx::query_as!(
         ImageStyle,
@@ -24,6 +26,7 @@ order by index
     .await
 }
 
+#[instrument(skip(db))]
 pub async fn get_animation_styles(db: &PgPool) -> sqlx::Result<Vec<AnimationStyle>> {
     sqlx::query_as!(
         AnimationStyle,
@@ -41,6 +44,7 @@ order by index
     .await
 }
 
+#[instrument(skip(db))]
 pub async fn get_age_ranges(db: &PgPool) -> sqlx::Result<Vec<AgeRange>> {
     sqlx::query_as!(
         AgeRange,
@@ -53,6 +57,7 @@ pub async fn get_age_ranges(db: &PgPool) -> sqlx::Result<Vec<AgeRange>> {
     .await
 }
 
+#[instrument(skip(db))]
 pub async fn get_affiliations(db: &PgPool) -> sqlx::Result<Vec<Affiliation>> {
     sqlx::query_as!(
         Affiliation,
@@ -65,6 +70,7 @@ pub async fn get_affiliations(db: &PgPool) -> sqlx::Result<Vec<Affiliation>> {
     .await
 }
 
+#[instrument(skip(db))]
 pub async fn get_subjects(db: &PgPool) -> sqlx::Result<Vec<Subject>> {
     sqlx::query_as!(
         Subject,
@@ -77,6 +83,7 @@ pub async fn get_subjects(db: &PgPool) -> sqlx::Result<Vec<Subject>> {
     .await
 }
 
+#[instrument(skip(db))]
 pub async fn get_goals(db: &PgPool) -> sqlx::Result<Vec<Goal>> {
     sqlx::query_as!(
         Goal,
@@ -89,6 +96,7 @@ order by index
     .await
 }
 
+#[instrument(skip(db))]
 pub async fn get_additional_resources(db: &PgPool) -> sqlx::Result<Vec<ResourceType>> {
     sqlx::query_as!(
         ResourceType,
@@ -101,6 +109,7 @@ order by index
     .await
 }
 
+#[instrument(skip(db))]
 pub async fn get_image_tags(db: &PgPool) -> sqlx::Result<Vec<ImageTag>> {
     sqlx::query_as!(
         ImageTag,

--- a/backend/api/src/http/endpoints/jig.rs
+++ b/backend/api/src/http/endpoints/jig.rs
@@ -450,7 +450,7 @@ async fn play(db: Data<PgPool>, path: web::Path<JigId>) -> Result<HttpResponse, 
     Ok(HttpResponse::NoContent().finish())
 }
 
-#[instrument(skip_all)]
+#[instrument]
 async fn page_limit(page_limit: Option<u32>) -> anyhow::Result<u32> {
     if let Some(limit) = page_limit {
         match limit > 0 && limit <= MAX_PAGE_LIMIT {
@@ -462,7 +462,7 @@ async fn page_limit(page_limit: Option<u32>) -> anyhow::Result<u32> {
     }
 }
 
-#[instrument(skip_all)]
+#[instrument(skip(db, claims))]
 async fn auth_claims(
     db: &PgPool,
     claims: Option<TokenUser>,

--- a/backend/api/src/http/endpoints/jig.rs
+++ b/backend/api/src/http/endpoints/jig.rs
@@ -200,6 +200,7 @@ async fn delete_all(
     Ok(HttpResponse::NoContent().finish())
 }
 
+#[instrument(skip_all)]
 async fn browse(
     db: Data<PgPool>,
     claims: Option<TokenUser>,
@@ -449,6 +450,7 @@ async fn play(db: Data<PgPool>, path: web::Path<JigId>) -> Result<HttpResponse, 
     Ok(HttpResponse::NoContent().finish())
 }
 
+#[instrument(skip_all)]
 async fn page_limit(page_limit: Option<u32>) -> anyhow::Result<u32> {
     if let Some(limit) = page_limit {
         match limit > 0 && limit <= MAX_PAGE_LIMIT {
@@ -460,6 +462,7 @@ async fn page_limit(page_limit: Option<u32>) -> anyhow::Result<u32> {
     }
 }
 
+#[instrument(skip_all)]
 async fn auth_claims(
     db: &PgPool,
     claims: Option<TokenUser>,

--- a/backend/api/src/http/endpoints/meta.rs
+++ b/backend/api/src/http/endpoints/meta.rs
@@ -1,23 +1,37 @@
 use actix_web::web::{Data, Json, ServiceConfig};
+use futures::try_join;
 use shared::{
     api::{endpoints::meta::Get, ApiEndpoint},
     domain::meta::MetadataResponse,
 };
 use sqlx::PgPool;
+use tracing::instrument;
 
 use crate::{db, error};
 
 // TODO: Should have cache headers
 /// Get a list of all available metadata of all kinds (sans categories)
+#[instrument(skip(db))]
 async fn get(db: Data<PgPool>) -> Result<Json<<Get as ApiEndpoint>::Res>, error::Server> {
-    let affiliations = db::meta::get_affiliations(&db).await?;
-    let resource_types = db::meta::get_additional_resources(&db).await?;
-    let age_ranges = db::meta::get_age_ranges(&db).await?;
-    let subjects = db::meta::get_subjects(&db).await?;
-    let goals = db::meta::get_goals(&db).await?;
-    let image_tags = db::meta::get_image_tags(&db).await?;
-    let image_styles = db::meta::get_image_styles(&db).await?;
-    let animation_styles = db::meta::get_animation_styles(&db).await?;
+    let (
+        affiliations,
+        resource_types,
+        age_ranges,
+        subjects,
+        goals,
+        image_tags,
+        image_styles,
+        animation_styles,
+    ) = try_join!(
+        db::meta::get_affiliations(&db),
+        db::meta::get_additional_resources(&db),
+        db::meta::get_age_ranges(&db),
+        db::meta::get_subjects(&db),
+        db::meta::get_goals(&db),
+        db::meta::get_image_tags(&db),
+        db::meta::get_image_styles(&db),
+        db::meta::get_animation_styles(&db),
+    )?;
 
     Ok(Json(MetadataResponse {
         affiliations,


### PR DESCRIPTION
Part of #2139 

- Adds more instrumentation to endpoints and database functions;
- Attempts to optimize metadata endpoint by running all the db queries at the same time instead of consecutively.
	- Probably unnecessary at this stage, but I was in the code.

## Current performance of /metadata:

![image](https://user-images.githubusercontent.com/4161106/157184474-9d570ff9-3f91-4533-b1d2-7da9ed5f8272.png)
