### PR TITLE
optimize(be): Run browse and count queries concurrently

### DIFF
--- a/backend/api/Cargo.lock
+++ b/backend/api/Cargo.lock
@@ -935,9 +935,9 @@ checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
 name = "debugid"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91cf5a8c2f2097e2a32627123508635d47ce10563d999ec1a95addf08b502ba"
+checksum = "d6ee87af31d84ef885378aebca32be3d682b0e0dc119d5b4860a2c5bb5046730"
 dependencies = [
  "serde",
  "uuid",
@@ -2826,9 +2826,9 @@ dependencies = [
 
 [[package]]
 name = "sentry"
-version = "0.24.3"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "476c496f4b112059d58ba2871dd7bd0fb3743511975b3331e24af983628498a2"
+checksum = "f2d23af89cf3e40dffb53f974e9a21653353b3e21cf51633aa58006f2a0caf8a"
 dependencies = [
  "httpdate",
  "reqwest",
@@ -2843,9 +2843,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-anyhow"
-version = "0.24.3"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2892cd1aad861405aa3966e6b7088d982e9105f2d3900561f3634ca4c8ff3b6"
+checksum = "de88cf0967eb3d7247071a7e6753b06c0939d509f9db44607ec00aa4b4aefd04"
 dependencies = [
  "anyhow",
  "sentry-backtrace",
@@ -2854,9 +2854,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.24.3"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062d19e114079c0ac209c1d05c77ae0de709e1c9c1965cc43168f916b9691ad9"
+checksum = "8158a446429420acdf6a4f75192ee8929da16a0c41c89a1c34b2e0f1eaebcc02"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -2866,9 +2866,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-contexts"
-version = "0.24.3"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc7ffe5e38b3fe50e1f92db30cbf9f17318a1261aa74b779737e5d6940244e23"
+checksum = "5a3bda8a1e3213f1944da2d42f3081ea9f3717105bb2a6b0a8fe4f5e603010a3"
 dependencies = [
  "hostname",
  "libc",
@@ -2879,9 +2879,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.24.3"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41bbccac5904deebfd44f1bdedac78c73b606140904d8e7a60e74310ffe0a923"
+checksum = "56333f11be3a78131c67637f7611339df8af7ad9af831226585a457df75f9e3b"
 dependencies = [
  "lazy_static",
  "rand",
@@ -2892,9 +2892,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.24.3"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f37e172d427216eb45ada4cae81d29ab1cc10f73e0b9c531a4a902c321f6eb43"
+checksum = "b957b1965c450acd220a27806fe1f2dec998d393973ebae797936b12df1c7416"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -2902,9 +2902,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-tracing"
-version = "0.24.3"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9bbaa12aaf9bca94be6e4be421a62b0695e4b94acadb5c37d155f815ac71d3"
+checksum = "8a1b281efe225a8750e2011a325a5455b29a3e5cd40762337ef647a253e3213f"
 dependencies = [
  "sentry-core",
  "tracing-core",
@@ -2913,9 +2913,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.24.3"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd82ef59ae000f8502e3095508eb3e9606f1716f15394e539d6a5c24fd38484d"
+checksum = "825fd3382e2397007499a910e0184e55f7837cb0df4af30ae62bd2123e2ebcd6"
 dependencies = [
  "debugid",
  "getrandom",

--- a/backend/api/Cargo.toml
+++ b/backend/api/Cargo.toml
@@ -45,7 +45,7 @@ rgb = "0.8.27"
 rusoto_core = "0.47.0"
 rusoto_s3 = "0.47.0"
 rusoto_signature = "0.47.0"
-sentry-tracing = "0.24.3"
+sentry-tracing = "0.25.0"
 serde = {version = "1.0.130", features = ["derive"]}
 serde_derive = "1.0.130"
 serde_json = {version = "1.0.68", features = ["preserve_order"]}
@@ -69,7 +69,7 @@ version = "0.17.4"
 
 [dependencies.sentry]
 features = ["anyhow", "backtrace", "contexts", "panic", "tracing", "transport"]
-version = "0.24.3"
+version = "0.25.0"
 
 [dependencies.sqlx]
 default-features = false

--- a/backend/core/Cargo.toml
+++ b/backend/core/Cargo.toml
@@ -28,4 +28,4 @@ db = ["sqlx"]
 
 [dependencies.sentry]
 features = ["anyhow", "backtrace", "contexts", "panic", "transport"]
-version = "0.24.3"
+version = "0.25.0"


### PR DESCRIPTION
Part of #2139

- Updates Sentry SDK to 0.25.0
- Combines browse and count queries to run concurrently