### PR TITLE
feat(fe/module/tapping-board): Add empty sidebar element when no area has been traced yet

### DIFF
--- a/frontend/apps/crates/components/src/module/_groups/cards/edit/sidebar/step_1/dom.rs
+++ b/frontend/apps/crates/components/src/module/_groups/cards/edit/sidebar/step_1/dom.rs
@@ -149,11 +149,6 @@ pub fn render<RawData: RawDataExt, E: ExtraExt>(state: Rc<Step1<RawData, E>>) ->
                                             } else {
                                                 Some(render_empty_audio())
                                             }
-                                            /* match audio {
-                                                Some(audio) => Some(AudioInput::render(audio.clone(), None)),
-                                                None => Some(render_empty_audio()),
-                                            } */
-                                            // None
                                         })))
                                     }))
                                 },
@@ -170,12 +165,16 @@ pub fn render<RawData: RawDataExt, E: ExtraExt>(state: Rc<Step1<RawData, E>>) ->
 fn render_empty_audio() -> Dom {
     html!("sidebar-empty", {
         .property("label", STR_EMPTY_AUDIO_SELECTION)
+        .property("imagePath", "module/_groups/cards/edit/sidebar/edit-words.svg")
+        .property("imageOffset", 32)
     })
 }
 
 fn render_non_empty<RawData: RawDataExt, E: ExtraExt>(state: Rc<Step1<RawData, E>>) -> Dom {
     html!("sidebar-empty", {
         .property("label", STR_NONEMPTY_LIST_LABEL)
+        .property("imagePath", "module/_groups/cards/edit/sidebar/edit-words.svg")
+        .property("imageOffset", 32)
         .child(
             html!("button-rect", {
                 .property("slot", "clear")

--- a/frontend/apps/crates/components/src/traces/svg/styles.rs
+++ b/frontend/apps/crates/components/src/traces/svg/styles.rs
@@ -114,6 +114,7 @@ pub static SVG_CLASS: Lazy<String> = Lazy::new(|| {
     class! {
         .style("position", "absolute")
         .style("top", "0")
+        .style("left", "0")
     }
 });
 

--- a/frontend/elements/src/_bundles/_sub-bundles/module/_groups/cards/edit.ts
+++ b/frontend/elements/src/_bundles/_sub-bundles/module/_groups/cards/edit.ts
@@ -7,7 +7,6 @@ import "@elements/module/_groups/cards/edit/main/card-pair/pair";
 import "@elements/module/_groups/cards/play/card/card";
 import "@elements/module/_groups/cards/play/card/text";
 import "@elements/module/_groups/cards/play/card/empty";
-import "@elements/module/_groups/cards/edit/sidebar/empty";
 import "@elements/module/_groups/cards/edit/sidebar/widgets/theme-selector/option";
 /* components */
 

--- a/frontend/elements/src/_bundles/_sub-bundles/module/edit.ts
+++ b/frontend/elements/src/_bundles/_sub-bundles/module/edit.ts
@@ -31,6 +31,7 @@ import "@elements/module/_common/edit/header";
 import "@elements/module/_groups/cards/_common/main-empty";
 import "@elements/module/_common/edit/preview-header";
 import "@elements/module/_common/edit/sidebar";
+import "@elements/module/_common/edit/sidebar-empty";
 import "@elements/module/_common/edit/sidebar-body";
 import "@elements/module/_common/edit/widgets/header-controller";
 import "@elements/module/_common/edit/widgets/choose-mode/choose-mode";

--- a/frontend/elements/src/module/_common/edit/sidebar-empty.ts
+++ b/frontend/elements/src/module/_common/edit/sidebar-empty.ts
@@ -1,5 +1,4 @@
 import { LitElement, html, css, customElement, property } from "lit-element";
-import { classMap } from "lit-html/directives/class-map";
 import { nothing } from "lit-html";
 
 @customElement("sidebar-empty")
@@ -8,6 +7,7 @@ export class _ extends LitElement {
         return [
             css`
                 :host {
+                    --image-offset: 0px;
                     display: flex;
                     flex-direction: column;
                     justify-content: center;
@@ -16,7 +16,7 @@ export class _ extends LitElement {
                 }
                 img-ui {
                     margin-bottom: 24px;
-                    transform: translateX(32px);
+                    transform: translateX(var(--image-offset));
                 }
                 .label {
                     font-size: 18px;
@@ -45,15 +45,31 @@ export class _ extends LitElement {
     }
 
     @property({ type: String })
-    label: string = "";
+    label?: string;
+
+    @property({ type: String })
+    imagePath?: string;
+
+    @property({ type: Number, reflect: true })
+    imageOffset: number = 0;
+
+    firstUpdated(_changed: any) {
+        this.style.setProperty('--image-offset', `${this.imageOffset}px`);
+    }
+
+    renderImage() {
+        return this.imagePath ? html`<img-ui path=${this.imagePath}></img-ui>` : nothing;
+    }
+
+    renderLabel() {
+        return this.label ? html`<div class="label">${this.label}</div>` : nothing;
+    }
 
     render() {
         return html`
             <section>
-                <img-ui
-                    path="module/_groups/cards/edit/sidebar/edit-words.svg"
-                ></img-ui>
-                <div class="label">${this.label}</div>
+                ${this.renderImage()}
+                ${this.renderLabel()}
             </section>
             <div class="clear"><slot name="clear"></slot></div>
         `;


### PR DESCRIPTION
Closes #2363

- Moves the sidebar-empty element into module/_common/edit
- Updates the element so that the image displayed can be changed
- Includes an offset property to adjust positioning of images for more natural centering (see card game activities)
- Adds the sidebar-empty element to the tapping-board activity

![image](https://user-images.githubusercontent.com/4161106/157432623-2969c2e1-ceb3-42f2-83e6-e3d03517c9bf.png)
