### PR TITLE
feat(fe/module/drag-drop): Use empty-sidebar element for "Drop Areas" step

### DIFF
--- a/frontend/apps/crates/entry/module/drag-drop/edit/src/base/sidebar/step_3/dom.rs
+++ b/frontend/apps/crates/entry/module/drag-drop/edit/src/base/sidebar/step_3/dom.rs
@@ -4,8 +4,9 @@ pub fn render_step_3() -> Dom {
     html!("module-sidebar-body", {
         .property("slot", "body")
         .child(
-            html!("div", {
-                .text(crate::strings::STR_SIDEBAR_TRACE)
+            html!("sidebar-empty", {
+                .property("label", crate::strings::STR_SIDEBAR_TRACE)
+                .property("imagePath", "module/_common/edit/sidebar/illustration-trace-area.svg")
             })
         )
     })


### PR DESCRIPTION
Part of #2363

- Uses the empty-sidebar element on the drag and drop activity's Drop Areas step

### Before

![Screenshot 2022-03-09 at 13 41 05](https://user-images.githubusercontent.com/4161106/157435989-3e291260-3171-4845-b999-42118480c514.png)

### After

![Screenshot 2022-03-09 at 13 45 12](https://user-images.githubusercontent.com/4161106/157436022-fb9b97c4-3c0a-475d-9531-b5bfaeced429.png)

