### PR TITLE
feat(fe/module/cards): Add confirm modal when clearing an unsaved list

### DIFF
--- a/frontend/apps/crates/components/src/lists/dual/state.rs
+++ b/frontend/apps/crates/components/src/lists/dual/state.rs
@@ -17,6 +17,7 @@ pub struct State {
     pub error_element_ref: RefCell<Option<HtmlElement>>,
     pub callbacks: Callbacks,
     pub opts: Options,
+    pub confirm_clear: Mutable<bool>,
 }
 
 pub struct Options {
@@ -57,6 +58,7 @@ impl State {
             error_element_ref: RefCell::new(None),
             callbacks,
             opts,
+            confirm_clear: Mutable::new(false),
         }
     }
 

--- a/frontend/apps/crates/components/src/lists/single/state.rs
+++ b/frontend/apps/crates/components/src/lists/single/state.rs
@@ -14,6 +14,7 @@ pub struct State {
     pub error_element_ref: RefCell<Option<HtmlElement>>,
     pub callbacks: Callbacks,
     pub opts: Options,
+    pub confirm_clear: Mutable<bool>,
 }
 
 pub struct Options {
@@ -48,6 +49,7 @@ impl State {
             error_element_ref: RefCell::new(None),
             callbacks,
             opts,
+            confirm_clear: Mutable::new(false),
         }
     }
 


### PR DESCRIPTION
Closes #1599 

- Adds confirm modal for clearing unsaved single/dual lists