### PR TITLE
bug(fe/jig/edit): Hide sidebar open/close button when on add activity screen

### DIFF
--- a/frontend/elements/src/entry/jig/edit/sidebar/header.ts
+++ b/frontend/elements/src/entry/jig/edit/sidebar/header.ts
@@ -34,8 +34,7 @@ export class _ extends LitElement {
                     margin-right: -10px;
                 }
                 :host([isModulePage]) .close {
-                    opacity: 0;
-                    cursor: inherit;
+                    display: none;
                 }
                 :host([collapsed]) .close {
                     margin-right: 0px;


### PR DESCRIPTION
Closes #2525 

- Hides the open/close button completely when on the "Add activity" screen so that the sidebar cannot be closed.