### PR TITLE
fix(fe): Remove goals property from JigData

### DIFF
--- a/frontend/apps/crates/components/src/module/_common/edit/entry/state.rs
+++ b/frontend/apps/crates/components/src/module/_common/edit/entry/state.rs
@@ -175,7 +175,6 @@ where
                         modules: Vec::new(),
                         age_ranges: Vec::new(),
                         affiliations: Vec::new(),
-                        goals: Vec::new(),
                         language: String::from(Language::default().code()),
                         categories: Vec::new(),
                         additional_resources: Vec::new(),

--- a/frontend/apps/crates/components/src/module/_common/play/entry/state.rs
+++ b/frontend/apps/crates/components/src/module/_common/play/entry/state.rs
@@ -98,7 +98,6 @@ where
                         modules: Vec::new(),
                         age_ranges: Vec::new(),
                         affiliations: Vec::new(),
-                        goals: Vec::new(),
                         language: String::from(Language::default().code()),
                         categories: Vec::new(),
                         additional_resources: Vec::new(),

--- a/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/debug.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/debug.rs
@@ -62,7 +62,6 @@ pub fn get_jig() -> JigResponse {
             ],
             age_ranges: Vec::new(),
             affiliations: Vec::new(),
-            goals: Vec::new(),
             language: String::new(),
             categories: Vec::new(),
             additional_resources: Vec::new(),


### PR DESCRIPTION
- Updates frontend so that `goals` is removed from `JigData` (RE #2535)