### PR TITLE
feat(fe/jig/edit): Add publish action to module complete screen

### DIFF
--- a/frontend/apps/crates/components/src/module/_common/edit/post_preview/actions.rs
+++ b/frontend/apps/crates/components/src/module/_common/edit/post_preview/actions.rs
@@ -36,6 +36,21 @@ impl PostPreview {
         }
     }
 
+    pub fn publish(&self) {
+        let msg = IframeAction::new(ModuleToJigEditorMessage::Publish);
+
+        if let Err(_) = msg.try_post_message_to_editor() {
+            log::info!("Couldn't post message to top... redirect!");
+
+            let route: String = Route::Jig(JigRoute::Edit(
+                self.jig_id,
+                JigFocus::Modules, // only module focused jigs are should be here
+                JigEditRoute::Landing
+            )).into();
+            dominator::routing::go_to_url(&route);
+        }
+    }
+
     pub fn duplicate_module<RawData, Mode, Step>(&self, target_kind: ModuleKind, raw_data: RawData)
     where
         RawData: BodyExt<Mode, Step> + 'static,

--- a/frontend/apps/crates/components/src/module/_common/edit/post_preview/dom.rs
+++ b/frontend/apps/crates/components/src/module/_common/edit/post_preview/dom.rs
@@ -47,6 +47,15 @@ where
             */
             .child(
                 html!("post-preview-action", {
+                    .property("slot", "action-publish")
+                    .property("kind", "publish")
+                    .event(clone!(state => move |_evt:events::Click| {
+                        state.publish();
+                    }))
+                })
+            )
+            .child(
+                html!("post-preview-action", {
                     .property("slot", "action-continue")
                     .property("kind", "continue")
                     .event(clone!(state => move |_evt:events::Click| {

--- a/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/actions.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/actions.rs
@@ -175,6 +175,9 @@ pub fn on_iframe_message(state: Rc<State>, message: ModuleToJigEditorMessage) {
                 JigEditRoute::Landing
             )));
         }
+        ModuleToJigEditorMessage::Publish => {
+            navigate_to_publish(state);
+        }
     }
 }
 

--- a/frontend/apps/crates/utils/src/iframe.rs
+++ b/frontend/apps/crates/utils/src/iframe.rs
@@ -189,6 +189,7 @@ pub enum ModuleToJigEditorMessage {
     Next,
     /// Whenever a modules completion status changes, i.e. meets the minimum required content.
     Complete(ModuleId, bool),
+    Publish,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/frontend/elements/src/module/_common/edit/post-preview/post-preview-action.ts
+++ b/frontend/elements/src/module/_common/edit/post-preview/post-preview-action.ts
@@ -5,12 +5,13 @@ import {
     STR_MODULE_DISPLAY_NAME,
 } from "@elements/module/_common/types";
 
-export type Kind = ModuleKind | "print" | "continue";
+export type Kind = ModuleKind | "print" | "continue" | "publish";
 
 const STR_LABEL_LOOKUP: { [key in Kind]: string } = {
     ...STR_MODULE_DISPLAY_NAME,
     print: "Print the cards",
-    continue: "Continue",
+    continue: "Add new activity",
+    publish: "Publish JIG",
 };
 
 @customElement("post-preview-action")
@@ -53,12 +54,12 @@ export class _ extends LitElement {
     render() {
         const { kind } = this;
 
-        const isModule = kind !== "continue" && kind !== "print";
+        const isModule = kind !== "continue" && kind !== "print" && kind !== "publish";
 
         const path = isModule
             ? `module/_common/edit/post-preview/module/${kind}.svg`
             : `module/_common/edit/post-preview/${this.kind}${
-                  this.kind === "continue" ? ".png" : ".svg"
+                  this.kind === "continue" || this.kind === "publish" ? ".png" : ".svg"
               }`;
 
         return html`

--- a/frontend/elements/src/module/_common/edit/post-preview/post-preview.ts
+++ b/frontend/elements/src/module/_common/edit/post-preview/post-preview.ts
@@ -49,11 +49,15 @@ export class _ extends LitElement {
                 .bottom-section {
                     background-color: var(--light-orange-1);
                     display: grid;
-                    grid-template-columns: repeat(3, 116px) 1px repeat(2, 116px);
                     column-gap: 48px;
                     justify-content: center;
                     align-items: center;
                     padding: 46px 0;
+                }
+                .bottom-section .actions {
+                    display: grid;
+                    grid-template-columns: repeat(3, 116px) 1px repeat(2, 116px);
+                    column-gap: 48px;
                 }
                 .bottom-section-centered {
                     background-color: var(--light-orange-1);
@@ -149,16 +153,19 @@ function renderConvertable(module: ModuleKind) {
     return html`
         <div class="bottom-section">
             <h3 class="action-header">${STR_ACTION_HEADER}</h3>
-            <h4 class="action-use-in-header">
-                ${STR_USE_IN_PREFIX} ${STR_MODULE_DISPLAY_NAME[module]}
-                ${STR_USE_IN_SUFFIX}
-            </h4>
-            <slot class="module-1" name="module-1"></slot>
-            <slot class="module-2" name="module-2"></slot>
-            <slot class="module-3" name="module-3"></slot>
-            <div class="divider"></div>
-            <slot class="action-print" name="action-print"></slot>
-            <slot class="action-continue" name="action-continue"></slot>
+            <div class="actions">
+                <h4 class="action-use-in-header">
+                    ${STR_USE_IN_PREFIX} ${STR_MODULE_DISPLAY_NAME[module]}
+                    ${STR_USE_IN_SUFFIX}
+                </h4>
+                <slot class="module-1" name="module-1"></slot>
+                <slot class="module-2" name="module-2"></slot>
+                <slot class="module-3" name="module-3"></slot>
+                <div class="divider"></div>
+                <slot class="action-print" name="action-print"></slot>
+                <slot class="action-publish" name="action-publish"></slot>
+                <slot class="action-continue" name="action-continue"></slot>
+            </div>
         </div>
     `;
 }


### PR DESCRIPTION
Closes #2286

- Adds the "Publish" action to the complete screen;
- Updates "Continue" to "Add new activity"
- Fixes alignment of actions (see before and after below)

### Before

![before](https://user-images.githubusercontent.com/4161106/158304956-1cb34b26-a54b-485f-91ad-eb9ab48380eb.png)

### After

![after](https://user-images.githubusercontent.com/4161106/158304991-19c48dfd-718c-4069-9f80-7a775d918a66.png)
