### PR TITLE
fix(fe/elements/progress-bar): Fix infinite progress animation define it if necessary

### DIFF
--- a/frontend/apps/crates/components/src/audio/input/components/main_content.rs
+++ b/frontend/apps/crates/components/src/audio/input/components/main_content.rs
@@ -9,6 +9,8 @@ use wasm_bindgen_futures::spawn_local;
 use super::{super::actions::file_change, player};
 use crate::audio::input::state::{AudioInput, AudioInputAddMethod, AudioInputMode};
 
+const STR_UPLOADING_TEXT: &str = "Uploading... please wait.";
+
 pub fn render(state: Rc<AudioInput>, mode: AudioInputMode, add_method: AudioInputAddMethod) -> Dom {
     match mode {
         AudioInputMode::Playing(audio) => player::dom::render(state, audio),
@@ -73,6 +75,10 @@ fn render_uploading() -> Dom {
                 step = 0.5;
             };
             progress as i32
+        }))
+        .child(html!("div", {
+            .property("slot", "progress-label")
+            .text(STR_UPLOADING_TEXT)
         }))
     })
 }

--- a/frontend/elements/src/core/progress-bar/progress-bar.ts
+++ b/frontend/elements/src/core/progress-bar/progress-bar.ts
@@ -3,8 +3,6 @@ import { nothing } from "lit-html";
 
 export type ProgressColor = "blue" | "green";
 
-const STR_UPLOADING_TEXT = "Uploading... please wait.";
-
 @customElement("progress-bar")
 export class _ extends LitElement {
     static get styles() {
@@ -28,12 +26,14 @@ export class _ extends LitElement {
                     height: 100%;
                     border-radius: var(--border-radius);
                     background-color: var(--background-color);
-                    margin-bottom: 8px;
                     overflow: hidden;
                 }
                 .bar {
                     height: 100%;
                     background-color: var(--color);
+                }
+                ::slotted([slot="progress-label"]) {
+                    margin-top: 8px;
                 }
                 :host([progress=infinite]) .bar {
                     width: 25%;
@@ -73,7 +73,7 @@ export class _ extends LitElement {
             <div class="wrapper">
                 <div class="bar"></div>
             </div>
-            <div>${STR_UPLOADING_TEXT}</div>
+            <slot name="progress-label"></slot>
         `;
     }
 }

--- a/frontend/elements/src/core/progress-bar/progress-bar.ts
+++ b/frontend/elements/src/core/progress-bar/progress-bar.ts
@@ -28,12 +28,12 @@ export class _ extends LitElement {
                     height: 100%;
                     border-radius: var(--border-radius);
                     background-color: var(--background-color);
-                    
+                    margin-bottom: 8px;
+                    overflow: hidden;
                 }
                 .bar {
                     height: 100%;
                     background-color: var(--color);
-                    margin-bottom: 8px;
                 }
                 :host([progress=infinite]) .bar {
                     width: 25%;
@@ -72,8 +72,8 @@ export class _ extends LitElement {
             ` : nothing}
             <div class="wrapper">
                 <div class="bar"></div>
-                <div>${STR_UPLOADING_TEXT}</div>
             </div>
+            <div>${STR_UPLOADING_TEXT}</div>
         `;
     }
 }

--- a/frontend/storybook/src/components/core/progress-bar/progress-bar.ts
+++ b/frontend/storybook/src/components/core/progress-bar/progress-bar.ts
@@ -21,7 +21,9 @@ export const ProgressBar = (props?: Partial<Args>) => {
 
     return `
         <div style="height: 10px; margin: 25px; width: 350px;">
-            <progress-bar ${argsToAttrs(props)}></progress-bar>
+            <progress-bar ${argsToAttrs(props)}>
+                <div slot="progress-label">Processing...</div>
+            </progress-bar>
         </div>
     `;
 };

--- a/frontend/storybook/src/components/core/progress-bar/progress-bar.ts
+++ b/frontend/storybook/src/components/core/progress-bar/progress-bar.ts
@@ -20,7 +20,7 @@ export const ProgressBar = (props?: Partial<Args>) => {
     props = props ? { ...DEFAULT_ARGS, ...props } : DEFAULT_ARGS;
 
     return `
-        <div style="height: 10px">
+        <div style="height: 10px; margin: 25px; width: 350px;">
             <progress-bar ${argsToAttrs(props)}></progress-bar>
         </div>
     `;


### PR DESCRIPTION
Part of #2485

- Resolves infinite progress bar from overflowing out of the wrapper;
- Resolves missing rounded edges of progress indicator;
- Moves label into a slot so that callers can define the label if required, otherwise usages such as playing audio, would have the "Uploading... please wait." copy;
- Updates storybook to include the slotted label.

### Before

![image](https://user-images.githubusercontent.com/4161106/158333039-00ba24b8-a3fc-45e1-acc3-57ef2b4d698c.png)

![image](https://user-images.githubusercontent.com/4161106/158333058-0bcb2037-3b3b-41cd-89a1-54650d48f124.png)

#### Additional resources in publish screen

![image](https://user-images.githubusercontent.com/4161106/158334830-e2a7c661-4679-4dba-bfba-15d3eba71aec.png)

#### `progress="infinite"` in storybook

![Screenshot 2022-03-15 at 10 10 50](https://user-images.githubusercontent.com/4161106/158333835-8d7af92c-9408-408b-a366-a1752aec370c.png)


### After

![Screenshot 2022-03-15 at 10 08 38](https://user-images.githubusercontent.com/4161106/158333505-619f867d-b3dc-4a78-bbb9-453cd14bee70.png)

![Screenshot 2022-03-15 at 10 08 17](https://user-images.githubusercontent.com/4161106/158333531-503288b4-d512-4173-8e18-a7c03863ec96.png)

![image](https://user-images.githubusercontent.com/4161106/158333902-3db5dd72-8e9a-4f18-a83c-f29a44ddb98e.png)
