### PR TITLE
feat(fe/user): dont preselect registration options, adjust spacing

### DIFF
--- a/frontend/apps/crates/entry/user/src/register/pages/step_3/actions.rs
+++ b/frontend/apps/crates/entry/user/src/register/pages/step_3/actions.rs
@@ -8,23 +8,8 @@ use shared::{
     },
 };
 use std::rc::Rc;
-use utils::{api_helpers::meta::MetaOptions, prelude::*, storage};
+use utils::{prelude::*, storage};
 use uuid::Uuid;
-
-impl State {
-    pub fn pre_select(&self, meta: &MetaOptions) {
-        let affiliations = &mut *self.affiliations.borrow_mut();
-        let age_ranges = &mut *self.age_ranges.borrow_mut();
-
-        for (id, _) in meta.affiliations.iter() {
-            affiliations.insert(id.clone());
-        }
-
-        for (id, _) in meta.age_ranges.iter() {
-            age_ranges.insert(id.clone());
-        }
-    }
-}
 
 pub fn submit(state: Rc<State>) {
     let age_ranges: Vec<AgeRangeId> = state

--- a/frontend/apps/crates/entry/user/src/register/pages/step_3/dom.rs
+++ b/frontend/apps/crates/entry/user/src/register/pages/step_3/dom.rs
@@ -21,10 +21,8 @@ impl Step3Page {
         let meta_options: Mutable<Option<MetaOptions>> = Mutable::new(None);
 
         html!("page-register-step3", {
-            .future(clone!(state, meta_options => async move {
+            .future(clone!(meta_options => async move {
                 let meta = MetaOptions::load().await.unwrap_ji();
-                state.pre_select(&meta);
-
                 meta_options.set(Some(meta));
             }))
             .children_signal_vec(Self::get_children(meta_options, state))

--- a/frontend/elements/src/entry/user/register/pages/step3.ts
+++ b/frontend/elements/src/entry/user/register/pages/step3.ts
@@ -31,7 +31,7 @@ export class _ extends LitElement {
                     display: grid;
                     grid-template-columns: 1fr 1fr;
                     grid-template-rows: 1fr 1fr;
-                    gap: 32px 31px;
+                    gap: 16px 16px;
                     grid-auto-flow: row;
                     grid-template-areas:
                         "tl tr"


### PR DESCRIPTION
closes #2557 

On registration Step 3:

- Don't preselect ages and affiliations
- Reduce grid gap to 16px

![image](https://user-images.githubusercontent.com/13839150/158416584-fe8a3f04-56f2-4bf0-82f5-3b7ed2894b46.png)
