### PR TITLE
fix(fe/jig/edit): Remove upper limit on word/image lists during validation

### DIFF
--- a/shared/rust/src/domain/jig/module/body/_groups/cards.rs
+++ b/shared/rust/src/domain/jig/module/body/_groups/cards.rs
@@ -46,9 +46,7 @@ impl BaseContent {
     /// Convenience method to determine whether pairs have been configured correctly
     pub fn is_valid(&self) -> bool {
         let pair_len = self.pairs.len();
-        pair_len >= config::MIN_LIST_WORDS
-            && pair_len <= config::MAX_LIST_WORDS
-            && self.mode.pairs_valid(&self.pairs)
+        pair_len >= config::MIN_LIST_WORDS && self.mode.pairs_valid(&self.pairs)
     }
 }
 


### PR DESCRIPTION
- Removes upper limit on the length of lists when creating/editing card game activies.