### PR TITLE
chore(be/github_actions): replace pin; master to v0

### DIFF
--- a/.github/workflows/backend-api-release.yml
+++ b/.github/workflows/backend-api-release.yml
@@ -28,7 +28,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
       - name: install google cloud sdk
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           version: '295.0.0'
           service_account_key: ${{ secrets.GOOGLE_CLOUD_SERVICE_ACCOUNT_JSON_KEY }}

--- a/.github/workflows/backend-api-sandbox.yml
+++ b/.github/workflows/backend-api-sandbox.yml
@@ -28,7 +28,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
       - name: install google cloud sdk
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           version: '295.0.0'
           service_account_key: ${{ secrets.GOOGLE_CLOUD_SERVICE_ACCOUNT_JSON_KEY_SANDBOX }}

--- a/.github/workflows/backend-fastly-purge-release.yml
+++ b/.github/workflows/backend-fastly-purge-release.yml
@@ -26,7 +26,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
       - name: install google cloud sdk
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           version: '295.0.0'
           service_account_key: ${{ secrets.GOOGLE_CLOUD_SERVICE_ACCOUNT_JSON_KEY }}

--- a/.github/workflows/backend-fastly-purge-sandbox.yml
+++ b/.github/workflows/backend-fastly-purge-sandbox.yml
@@ -26,7 +26,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
       - name: install google cloud sdk
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           version: '295.0.0'
           service_account_key: ${{ secrets.GOOGLE_CLOUD_SERVICE_ACCOUNT_JSON_KEY_SANDBOX }}

--- a/.github/workflows/backend-media-release.yml
+++ b/.github/workflows/backend-media-release.yml
@@ -28,7 +28,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
       - name: install google cloud sdk
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           version: '295.0.0'
           service_account_key: ${{ secrets.GOOGLE_CLOUD_SERVICE_ACCOUNT_JSON_KEY }}

--- a/.github/workflows/backend-media-sandbox.yml
+++ b/.github/workflows/backend-media-sandbox.yml
@@ -28,7 +28,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
       - name: install google cloud sdk
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           version: '295.0.0'
           service_account_key: ${{ secrets.GOOGLE_CLOUD_SERVICE_ACCOUNT_JSON_KEY_SANDBOX }}

--- a/.github/workflows/backend-pages-release.yml
+++ b/.github/workflows/backend-pages-release.yml
@@ -23,7 +23,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
       - name: install google cloud sdk
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           version: '295.0.0'
           service_account_key: ${{ secrets.GOOGLE_CLOUD_SERVICE_ACCOUNT_JSON_KEY }}

--- a/.github/workflows/backend-pages-sandbox.yml
+++ b/.github/workflows/backend-pages-sandbox.yml
@@ -28,7 +28,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
       - name: install google cloud sdk
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           version: '295.0.0'
           service_account_key: ${{ secrets.GOOGLE_CLOUD_SERVICE_ACCOUNT_JSON_KEY_SANDBOX }}

--- a/.github/workflows/backend-screenshot-release.yml
+++ b/.github/workflows/backend-screenshot-release.yml
@@ -26,7 +26,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
       - name: install google cloud sdk
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           version: '295.0.0'
           service_account_key: ${{ secrets.GOOGLE_CLOUD_SERVICE_ACCOUNT_JSON_KEY }}

--- a/.github/workflows/backend-screenshot-sandbox.yml
+++ b/.github/workflows/backend-screenshot-sandbox.yml
@@ -26,7 +26,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
       - name: install google cloud sdk
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           version: '295.0.0'
           service_account_key: ${{ secrets.GOOGLE_CLOUD_SERVICE_ACCOUNT_JSON_KEY_SANDBOX }}

--- a/.github/workflows/frontend-entry-app-release.yml
+++ b/.github/workflows/frontend-entry-app-release.yml
@@ -74,7 +74,7 @@ jobs:
           LOCAL_CDN_FRONTEND_DIR: ${{ github.workspace }}/frontend
       
       - name: install google cloud sdk
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           version: '295.0.0'
           service_account_key: ${{ secrets.GOOGLE_CLOUD_SERVICE_ACCOUNT_JSON_KEY }}

--- a/.github/workflows/frontend-entry-app-sandbox.yml
+++ b/.github/workflows/frontend-entry-app-sandbox.yml
@@ -74,7 +74,7 @@ jobs:
           LOCAL_CDN_FRONTEND_DIR: ${{ github.workspace }}/frontend
       
       - name: install google cloud sdk
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           version: '295.0.0'
           service_account_key: ${{ secrets.GOOGLE_CLOUD_SERVICE_ACCOUNT_JSON_KEY_SANDBOX }}

--- a/.github/workflows/frontend-entry-elements-release.yml
+++ b/.github/workflows/frontend-entry-elements-release.yml
@@ -96,7 +96,7 @@ jobs:
           FONTAWESOME_NPM_AUTH_TOKEN: ${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}
 
       - name: install google cloud sdk
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           version: '295.0.0'
           service_account_key: ${{ secrets.GOOGLE_CLOUD_SERVICE_ACCOUNT_JSON_KEY }}

--- a/.github/workflows/frontend-entry-elements-sandbox.yml
+++ b/.github/workflows/frontend-entry-elements-sandbox.yml
@@ -96,7 +96,7 @@ jobs:
           FONTAWESOME_NPM_AUTH_TOKEN: ${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}
 
       - name: install google cloud sdk
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           version: '295.0.0'
           service_account_key: ${{ secrets.GOOGLE_CLOUD_SERVICE_ACCOUNT_JSON_KEY_SANDBOX }}

--- a/.github/workflows/frontend-module-app-release.yml
+++ b/.github/workflows/frontend-module-app-release.yml
@@ -71,7 +71,7 @@ jobs:
           LOCAL_CDN_FRONTEND_DIR: ${{ github.workspace }}/frontend
       
       - name: install google cloud sdk
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           version: '295.0.0'
           service_account_key: ${{ secrets.GOOGLE_CLOUD_SERVICE_ACCOUNT_JSON_KEY }}

--- a/.github/workflows/frontend-module-app-sandbox.yml
+++ b/.github/workflows/frontend-module-app-sandbox.yml
@@ -71,7 +71,7 @@ jobs:
           LOCAL_CDN_FRONTEND_DIR: ${{ github.workspace }}/frontend
       
       - name: install google cloud sdk
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           version: '295.0.0'
           service_account_key: ${{ secrets.GOOGLE_CLOUD_SERVICE_ACCOUNT_JSON_KEY_SANDBOX }}

--- a/.github/workflows/frontend-module-elements-release.yml
+++ b/.github/workflows/frontend-module-elements-release.yml
@@ -97,7 +97,7 @@ jobs:
           FONTAWESOME_NPM_AUTH_TOKEN: ${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}
 
       - name: install google cloud sdk
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           version: '295.0.0'
           service_account_key: ${{ secrets.GOOGLE_CLOUD_SERVICE_ACCOUNT_JSON_KEY }}

--- a/.github/workflows/frontend-module-elements-sandbox.yml
+++ b/.github/workflows/frontend-module-elements-sandbox.yml
@@ -97,7 +97,7 @@ jobs:
           FONTAWESOME_NPM_AUTH_TOKEN: ${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}
 
       - name: install google cloud sdk
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           version: '295.0.0'
           service_account_key: ${{ secrets.GOOGLE_CLOUD_SERVICE_ACCOUNT_JSON_KEY_SANDBOX }}


### PR DESCRIPTION
Deployment to sandbox was failing due to GCP upcoming update in April.
- All YAML files in `.github/workflows` changed from `uses: 'google-github-actions/setup-gcloud@master'` to `uses: 'google-github-actions/setup-gcloud@v0'`
- Prompted by message: https://github.com/ji-devs/ji-cloud/runs/5636210323?check_suite_focus=true