### PR TITLE
optimize(be/category): Remove unused image and jig counts

### DIFF
--- a/backend/api/query/category/get_ancestor_tree.sql
+++ b/backend/api/query/category/get_ancestor_tree.sql
@@ -1,27 +1,23 @@
 with recursive links as
-                   (
-                       select id,
-                              parent_id
-                       from category co
-                       where id = any ($1::uuid[])
-                       union all
-                       select co.id,
-                              co.parent_id
-                       from category co
-                                inner join links ct on (ct.parent_id = co.id)
-                   )
+(
+    select id,
+    parent_id
+    from category co
+    where id = any ($1::uuid[])
+    union all
+    select co.id,
+    co.parent_id
+    from category co
+    inner join links ct on (ct.parent_id = co.id)
+)
 
-select distinct id,
-       category.parent_id,
-       name,
-       category.index,
-       created_at,
-       updated_at,
-       (select count(*) from image_category where category_id = id)::int8 as "image_count!",
-       (select count(distinct jig.id)::int8
-        from jig
-                 join jig_data_category on (jig.live_id = jig_data_id or jig.draft_id = jig_data_id)
-        where category_id = id)                                           as "jig_count!",
-        user_scopes
+select
+    distinct id,
+    category.parent_id,
+    name,
+    category.index,
+    created_at,
+    updated_at,
+    user_scopes
 from category
-         inner join links using (id);
+inner join links using (id);

--- a/backend/api/query/category/get_subtree.sql
+++ b/backend/api/query/category/get_subtree.sql
@@ -15,11 +15,6 @@ select distinct id as "id!",
        name,
        created_at,
        updated_at,
-       (select count(*) from image_category where category_id = id)::int8 as "image_count!",
-       (select count(distinct jig.id)::int8
-        from jig
-                 join jig_data_category on (jig.live_id = jig_data_id or jig.draft_id = jig_data_id)
-        where category_id = id)                                           as "jig_count!",
        user_scopes
 
 from path

--- a/backend/api/sqlx-data.json
+++ b/backend/api/sqlx-data.json
@@ -1,68 +1,68 @@
 {
   "db": "PostgreSQL",
   "01a135ff430fa6ab0ac75454f6d1c25d2198d9f885e1abfdb4ca22c888df32a5": {
-    "query": "\nupdate jig_data\nset description = $2,\n    translated_description = '{}',\n    updated_at = now()\nwhere id = $1 and $2 is distinct from description",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Text"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\nupdate jig_data\nset description = $2,\n    translated_description = '{}',\n    updated_at = now()\nwhere id = $1 and $2 is distinct from description"
   },
   "02c99d434bef7ea8602e6e462c5e93d9a0e11f47771b10b90d9482e79c18cfb0": {
-    "query": "delete from web_media_library_url where media_url = $1",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Text"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "delete from web_media_library_url where media_url = $1"
   },
   "034484d9f50cb98103b4a710a59bd6367b5934bd4aff7668d71ca85df3fb198e": {
-    "query": "\nupdate jig_data_module\nset\n    index = case when index = $2 then $3 else index - 1 end,\n    updated_at = now()\nwhere jig_data_id = $1 and index between $2 and $3\n",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Int2",
           "Int2"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\nupdate jig_data_module\nset\n    index = case when index = $2 then $3 else index - 1 end,\n    updated_at = now()\nwhere jig_data_id = $1 and index between $2 and $3\n"
   },
   "041c763ec559907841f70e45f627d3864a9e9fef4929d6b96327064617a2f5ec": {
-    "query": "select exists(select 1 from user_profile where user_id = $1) as \"exists!\"",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "exists!",
+          "ordinal": 0,
           "type_info": "Bool"
         }
+      ],
+      "nullable": [
+        null
       ],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": [
-        null
-      ]
-    }
+      }
+    },
+    "query": "select exists(select 1 from user_profile where user_id = $1) as \"exists!\""
   },
   "04237ddf4199bff3727b4e83a0def6c41ffc32a9efe01fb50d780b8de3f29f53": {
-    "query": "\ninsert into jig_player_session (jig_id, index, direction, display_score, track_assessments, drag_assist, expires_at)\nvalues ($1, $2, $3, $4, $5, $6, $7)\n\n",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
@@ -73,148 +73,140 @@
           "Bool",
           "Timestamptz"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\ninsert into jig_player_session (jig_id, index, direction, display_score, track_assessments, drag_assist, expires_at)\nvalues ($1, $2, $3, $4, $5, $6, $7)\n\n"
   },
   "04fb89e42da5ea9503934560463dca443ce0dbb9ba2fc38977da4aeb355f8d77": {
-    "query": "\nupdate jig_play_count\nset play_count = play_count + 1\nwhere jig_id = $1;\n            ",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\nupdate jig_play_count\nset play_count = play_count + 1\nwhere jig_id = $1;\n            "
   },
   "07a08e527260ed80e9a98a2f24bf76fb43524033f639b527bfa99b26839a76d1": {
-    "query": "\ninsert into jig_data_module (stable_id, \"index\", jig_data_id, kind, is_complete, contents)\nselect stable_id, \"index\", $2 as \"jig_id\", kind, is_complete, contents\nfrom jig_data_module\nwhere jig_data_id = $1\n        ",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\ninsert into jig_data_module (stable_id, \"index\", jig_data_id, kind, is_complete, contents)\nselect stable_id, \"index\", $2 as \"jig_id\", kind, is_complete, contents\nfrom jig_data_module\nwhere jig_data_id = $1\n        "
   },
   "07c23d4be4038602fadd286c040a438b0366a8308e634d0ef4f5325c7b07b225": {
-    "query": "\n            update image_tag set index = $2 where index = $1\n            ",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Int2",
           "Int2"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\n            update image_tag set index = $2 where index = $1\n            "
   },
   "085304fd00f042843830c03dab547f7547aad3b4f611d26beb5ec22b583686d8": {
-    "query": "\nselect color\nfrom user_color\nwhere user_id = $1\norder by index\n",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "color",
+          "ordinal": 0,
           "type_info": "Int4"
         }
+      ],
+      "nullable": [
+        false
       ],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": [
-        false
-      ]
-    }
+      }
+    },
+    "query": "\nselect color\nfrom user_color\nwhere user_id = $1\norder by index\n"
   },
   "0978a2ae9cbe0c16d58c15229324bad8325b60d9128b982a6476980be6965677": {
-    "query": "\nupdate category\nset updated_at = now(),\n    index = least((select count(*)::int2 from category c where c.parent_id is not distinct from parent_id), $1)\nwhere id = $2\n",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Int2",
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\nupdate category\nset updated_at = now(),\n    index = least((select count(*)::int2 from category c where c.parent_id is not distinct from parent_id), $1)\nwhere id = $2\n"
   },
   "0a1f9e5fee4b10a173b8723976cecfb920f90a4828d723abb14f6e0215cf880b": {
-    "query": "select exists(select 1 from locale_entry where id = $1 for update) as \"exists!\"",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "exists!",
+          "ordinal": 0,
           "type_info": "Bool"
         }
+      ],
+      "nullable": [
+        null
       ],
       "parameters": {
         "Left": [
           "Int4"
         ]
-      },
-      "nullable": [
-        null
-      ]
-    }
+      }
+    },
+    "query": "select exists(select 1 from locale_entry where id = $1 for update) as \"exists!\""
   },
   "0a861ac7c9fe36dcb1c2e85773df87e2d8356024214ad62e5a269a6ad8c088b3": {
-    "query": "\nselect id          as \"id: ModuleId\",\n       stable_id   as \"stable_id: StableModuleId\",\n       contents    as \"body\",\n       created_at  as \"created_at\",\n       updated_at  as \"updated_at\",\n       kind        as \"kind: ModuleKind\",\n       is_complete as \"is_complete\"\nfrom jig_data_module\nwhere jig_data_module.id is not distinct from $2\n   or (jig_data_id = (select live_id from jig where jig.id = $1) and stable_id is not distinct from $3)\n",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id: ModuleId",
+          "ordinal": 0,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 1,
           "name": "stable_id: StableModuleId",
+          "ordinal": 1,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 2,
           "name": "body",
+          "ordinal": 2,
           "type_info": "Jsonb"
         },
         {
-          "ordinal": 3,
           "name": "created_at",
+          "ordinal": 3,
           "type_info": "Timestamptz"
         },
         {
-          "ordinal": 4,
           "name": "updated_at",
+          "ordinal": 4,
           "type_info": "Timestamptz"
         },
         {
-          "ordinal": 5,
           "name": "kind: ModuleKind",
+          "ordinal": 5,
           "type_info": "Int2"
         },
         {
-          "ordinal": 6,
           "name": "is_complete",
+          "ordinal": 6,
           "type_info": "Bool"
         }
       ],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Uuid",
-          "Uuid"
-        ]
-      },
       "nullable": [
         false,
         false,
@@ -223,94 +215,95 @@
         false,
         false,
         false
-      ]
-    }
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Uuid",
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\nselect id          as \"id: ModuleId\",\n       stable_id   as \"stable_id: StableModuleId\",\n       contents    as \"body\",\n       created_at  as \"created_at\",\n       updated_at  as \"updated_at\",\n       kind        as \"kind: ModuleKind\",\n       is_complete as \"is_complete\"\nfrom jig_data_module\nwhere jig_data_module.id is not distinct from $2\n   or (jig_data_id = (select live_id from jig where jig.id = $1) and stable_id is not distinct from $3)\n"
   },
   "0d33ddd6d34bf4755b8ff298de37d678fc3d79222c8d193dc06d1e8fe25b2354": {
-    "query": "insert into user_email (user_id, email) values ($1, $2::text)",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Text"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "insert into user_email (user_id, email) values ($1, $2::text)"
   },
   "0db02aca55bd8f7c7ecdf168ac6d80c6a556ebf2efc5cdafe0afee57a49aeff1": {
-    "query": "\nselect id,  kind as \"kind: AnimationKind\"\nfrom animation_metadata\ninner join global_animation_upload on animation_metadata.id = global_animation_upload.animation_id\nwhere (id = $1 and uploaded_at is not null and processed_at >= uploaded_at is not true)\nfor no key update of global_animation_upload\nfor share of animation_metadata\nskip locked\n",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id",
+          "ordinal": 0,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 1,
           "name": "kind: AnimationKind",
+          "ordinal": 1,
           "type_info": "Int2"
         }
       ],
-      "parameters": {
-        "Left": [
-          "Uuid"
-        ]
-      },
       "nullable": [
         false,
         false
-      ]
-    }
-  },
-  "0e9cec4ea69218f08784c12a17bcd8b15c22486f0e76051fea80fd21b12af760": {
-    "query": "\nselect id                                   as \"id!: ReportId\",\n       jig_id                               as \"jig_id!: JigId\",    \n       report_type                          as \"report_type!: JigReportType\",                  \n       created_at,\n       reporter_id                          as \"reporter_id?: Uuid\",\n       (\n            select given_name || ' '::text || family_name\n            from user_profile\n            where user_profile.user_id = reporter_id\n        )                                       as \"name?\",\n        (\n            select email::text\n            from user_email\n            where user_email.user_id = reporter_id\n        )                                       as \"email?\"\nfrom jig_report\nwhere id = $1 and jig_id = $2\n",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id!: ReportId",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 1,
-          "name": "jig_id!: JigId",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 2,
-          "name": "report_type!: JigReportType",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 3,
-          "name": "created_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 4,
-          "name": "reporter_id?: Uuid",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 5,
-          "name": "name?",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 6,
-          "name": "email?",
-          "type_info": "Text"
-        }
       ],
       "parameters": {
         "Left": [
-          "Uuid",
           "Uuid"
         ]
-      },
+      }
+    },
+    "query": "\nselect id,  kind as \"kind: AnimationKind\"\nfrom animation_metadata\ninner join global_animation_upload on animation_metadata.id = global_animation_upload.animation_id\nwhere (id = $1 and uploaded_at is not null and processed_at >= uploaded_at is not true)\nfor no key update of global_animation_upload\nfor share of animation_metadata\nskip locked\n"
+  },
+  "0e9cec4ea69218f08784c12a17bcd8b15c22486f0e76051fea80fd21b12af760": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id!: ReportId",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "jig_id!: JigId",
+          "ordinal": 1,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "report_type!: JigReportType",
+          "ordinal": 2,
+          "type_info": "Int2"
+        },
+        {
+          "name": "created_at",
+          "ordinal": 3,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "reporter_id?: Uuid",
+          "ordinal": 4,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "name?",
+          "ordinal": 5,
+          "type_info": "Text"
+        },
+        {
+          "name": "email?",
+          "ordinal": 6,
+          "type_info": "Text"
+        }
+      ],
       "nullable": [
         false,
         false,
@@ -319,79 +312,80 @@
         true,
         null,
         null
-      ]
-    }
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\nselect id                                   as \"id!: ReportId\",\n       jig_id                               as \"jig_id!: JigId\",    \n       report_type                          as \"report_type!: JigReportType\",                  \n       created_at,\n       reporter_id                          as \"reporter_id?: Uuid\",\n       (\n            select given_name || ' '::text || family_name\n            from user_profile\n            where user_profile.user_id = reporter_id\n        )                                       as \"name?\",\n        (\n            select email::text\n            from user_email\n            where user_email.user_id = reporter_id\n        )                                       as \"email?\"\nfrom jig_report\nwhere id = $1 and jig_id = $2\n"
   },
   "0eaa3162be77943a44df9ba08acf627d0f82b1b11b5486710ccfc445691b8a5f": {
-    "query": "\nselect\n    id as \"id: u32\",\n    bundle_id,\n    section,\n    item_kind_id,\n    english,\n    hebrew,\n    status as \"status: EntryStatus\",\n    zeplin_reference,\n    comments,\n    in_app, \n    in_element, \n    in_mock\nfrom locale_entry\nwhere id = $1\n",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id: u32",
+          "ordinal": 0,
           "type_info": "Int4"
         },
         {
-          "ordinal": 1,
           "name": "bundle_id",
+          "ordinal": 1,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 2,
           "name": "section",
+          "ordinal": 2,
           "type_info": "Text"
         },
         {
-          "ordinal": 3,
           "name": "item_kind_id",
+          "ordinal": 3,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 4,
           "name": "english",
+          "ordinal": 4,
           "type_info": "Text"
         },
         {
-          "ordinal": 5,
           "name": "hebrew",
+          "ordinal": 5,
           "type_info": "Text"
         },
         {
-          "ordinal": 6,
           "name": "status: EntryStatus",
+          "ordinal": 6,
           "type_info": "Int2"
         },
         {
-          "ordinal": 7,
           "name": "zeplin_reference",
+          "ordinal": 7,
           "type_info": "Text"
         },
         {
-          "ordinal": 8,
           "name": "comments",
+          "ordinal": 8,
           "type_info": "Text"
         },
         {
-          "ordinal": 9,
           "name": "in_app",
+          "ordinal": 9,
           "type_info": "Bool"
         },
         {
-          "ordinal": 10,
           "name": "in_element",
+          "ordinal": 10,
           "type_info": "Bool"
         },
         {
-          "ordinal": 11,
           "name": "in_mock",
+          "ordinal": 11,
           "type_info": "Bool"
         }
       ],
-      "parameters": {
-        "Left": [
-          "Int4"
-        ]
-      },
       "nullable": [
         false,
         false,
@@ -405,197 +399,196 @@
         false,
         false,
         false
-      ]
-    }
+      ],
+      "parameters": {
+        "Left": [
+          "Int4"
+        ]
+      }
+    },
+    "query": "\nselect\n    id as \"id: u32\",\n    bundle_id,\n    section,\n    item_kind_id,\n    english,\n    hebrew,\n    status as \"status: EntryStatus\",\n    zeplin_reference,\n    comments,\n    in_app, \n    in_element, \n    in_mock\nfrom locale_entry\nwhere id = $1\n"
   },
   "0f15170b401de47fa6e6ec802a12a8c00412902a4d3bf942897c8bb8e41f44fa": {
-    "query": "insert into image_upload (image_id) values($1)",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "insert into image_upload (image_id) values($1)"
   },
   "102535bed5d4048f3f9f8e1698b38371e26577f7d70fc4eb8367588485a170ae": {
-    "query": "\nwith cte as (\n    select id      as \"jig_id\",\n           creator_id,\n           author_id,\n           liked_count,\n           play_count,\n           case\n               when $2 = 0 then jig.draft_id\n               when $2 = 1 then jig.live_id\n               end as \"draft_or_live_id\",\n           published_at,\n           rating,\n           blocked,\n           curated,\n           jig_focus\n    from jig\n    left join jig_play_count on jig_play_count.jig_id = jig.id\n    left join jig_admin_data \"admin\" on admin.jig_id = jig.id\n    where id = $1\n)\nselect cte.jig_id                                          as \"jig_id: JigId\",\n       display_name,\n       creator_id,\n       author_id,\n       (select given_name || ' '::text || family_name\n        from user_profile\n        where user_profile.user_id = author_id)            as \"author_name\",\n       published_at,\n       updated_at,\n       privacy_level                                       as \"privacy_level!: PrivacyLevel\",\n       jig_focus                                           as \"jig_focus!: JigFocus\",\n       language,\n       description,\n       translated_description                              as \"translated_description!: Json<HashMap<String, String>>\",\n       direction                                           as \"direction: TextDirection\",\n       display_score,\n       track_assessments,\n       drag_assist,\n       theme                                               as \"theme: ThemeId\",\n       audio_background                                    as \"audio_background: AudioBackground\",\n       liked_count,\n       play_count,\n       locked,\n       other_keywords,\n       translated_keywords,\n       rating                                               as \"rating?: JigRating\",\n       blocked                                              as \"blocked\",\n       curated,\n       array(select row (unnest(audio_feedback_positive))) as \"audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>\",\n       array(select row (unnest(audio_feedback_negative))) as \"audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>\",\n       array(\n               select row (jig_data_module.id, kind, is_complete)\n               from jig_data_module\n               where jig_data_id = cte.draft_or_live_id\n               order by \"index\"\n           )                                               as \"modules!: Vec<(ModuleId, ModuleKind, bool)>\",\n       array(select row (category_id)\n             from jig_data_category\n             where jig_data_id = cte.draft_or_live_id)     as \"categories!: Vec<(CategoryId,)>\",\n       array(select row (affiliation_id)\n             from jig_data_affiliation\n             where jig_data_id = cte.draft_or_live_id)     as \"affiliations!: Vec<(AffiliationId,)>\",\n       array(select row (age_range_id)\n             from jig_data_age_range\n             where jig_data_id = cte.draft_or_live_id)     as \"age_ranges!: Vec<(AgeRangeId,)>\",\n       array(\n             select row (jdar.id, jdar.display_name, resource_type_id, resource_content)\n             from jig_data_additional_resource \"jdar\"\n             where jdar.jig_data_id = cte.draft_or_live_id\n       )                                                    as \"additional_resource!: Vec<(AddId, String, TypeId, Value)>\"\nfrom jig_data\n         inner join cte on cte.draft_or_live_id = jig_data.id\n",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "jig_id: JigId",
+          "ordinal": 0,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 1,
           "name": "display_name",
+          "ordinal": 1,
           "type_info": "Text"
         },
         {
-          "ordinal": 2,
           "name": "creator_id",
+          "ordinal": 2,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 3,
           "name": "author_id",
+          "ordinal": 3,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 4,
           "name": "author_name",
+          "ordinal": 4,
           "type_info": "Text"
         },
         {
-          "ordinal": 5,
           "name": "published_at",
+          "ordinal": 5,
           "type_info": "Timestamptz"
         },
         {
-          "ordinal": 6,
           "name": "updated_at",
+          "ordinal": 6,
           "type_info": "Timestamptz"
         },
         {
-          "ordinal": 7,
           "name": "privacy_level!: PrivacyLevel",
+          "ordinal": 7,
           "type_info": "Int2"
         },
         {
-          "ordinal": 8,
           "name": "jig_focus!: JigFocus",
+          "ordinal": 8,
           "type_info": "Int2"
         },
         {
-          "ordinal": 9,
           "name": "language",
+          "ordinal": 9,
           "type_info": "Text"
         },
         {
-          "ordinal": 10,
           "name": "description",
+          "ordinal": 10,
           "type_info": "Text"
         },
         {
-          "ordinal": 11,
           "name": "translated_description!: Json<HashMap<String, String>>",
+          "ordinal": 11,
           "type_info": "Jsonb"
         },
         {
-          "ordinal": 12,
           "name": "direction: TextDirection",
+          "ordinal": 12,
           "type_info": "Int2"
         },
         {
-          "ordinal": 13,
           "name": "display_score",
+          "ordinal": 13,
           "type_info": "Bool"
         },
         {
-          "ordinal": 14,
           "name": "track_assessments",
+          "ordinal": 14,
           "type_info": "Bool"
         },
         {
-          "ordinal": 15,
           "name": "drag_assist",
+          "ordinal": 15,
           "type_info": "Bool"
         },
         {
-          "ordinal": 16,
           "name": "theme: ThemeId",
+          "ordinal": 16,
           "type_info": "Int2"
         },
         {
-          "ordinal": 17,
           "name": "audio_background: AudioBackground",
+          "ordinal": 17,
           "type_info": "Int2"
         },
         {
-          "ordinal": 18,
           "name": "liked_count",
+          "ordinal": 18,
           "type_info": "Int8"
         },
         {
-          "ordinal": 19,
           "name": "play_count",
+          "ordinal": 19,
           "type_info": "Int8"
         },
         {
-          "ordinal": 20,
           "name": "locked",
+          "ordinal": 20,
           "type_info": "Bool"
         },
         {
-          "ordinal": 21,
           "name": "other_keywords",
+          "ordinal": 21,
           "type_info": "Text"
         },
         {
-          "ordinal": 22,
           "name": "translated_keywords",
+          "ordinal": 22,
           "type_info": "Text"
         },
         {
-          "ordinal": 23,
           "name": "rating?: JigRating",
+          "ordinal": 23,
           "type_info": "Int2"
         },
         {
-          "ordinal": 24,
           "name": "blocked",
+          "ordinal": 24,
           "type_info": "Bool"
         },
         {
-          "ordinal": 25,
           "name": "curated",
+          "ordinal": 25,
           "type_info": "Bool"
         },
         {
-          "ordinal": 26,
           "name": "audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>",
+          "ordinal": 26,
           "type_info": "RecordArray"
         },
         {
-          "ordinal": 27,
           "name": "audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>",
+          "ordinal": 27,
           "type_info": "RecordArray"
         },
         {
-          "ordinal": 28,
           "name": "modules!: Vec<(ModuleId, ModuleKind, bool)>",
+          "ordinal": 28,
           "type_info": "RecordArray"
         },
         {
-          "ordinal": 29,
           "name": "categories!: Vec<(CategoryId,)>",
+          "ordinal": 29,
           "type_info": "RecordArray"
         },
         {
-          "ordinal": 30,
           "name": "affiliations!: Vec<(AffiliationId,)>",
+          "ordinal": 30,
           "type_info": "RecordArray"
         },
         {
-          "ordinal": 31,
           "name": "age_ranges!: Vec<(AgeRangeId,)>",
+          "ordinal": 31,
           "type_info": "RecordArray"
         },
         {
-          "ordinal": 32,
           "name": "additional_resource!: Vec<(AddId, String, TypeId, Value)>",
+          "ordinal": 32,
           "type_info": "RecordArray"
         }
       ],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Int4"
-        ]
-      },
       "nullable": [
         false,
         false,
@@ -630,58 +623,67 @@
         null,
         null,
         null
-      ]
-    }
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Int4"
+        ]
+      }
+    },
+    "query": "\nwith cte as (\n    select id      as \"jig_id\",\n           creator_id,\n           author_id,\n           liked_count,\n           play_count,\n           case\n               when $2 = 0 then jig.draft_id\n               when $2 = 1 then jig.live_id\n               end as \"draft_or_live_id\",\n           published_at,\n           rating,\n           blocked,\n           curated,\n           jig_focus\n    from jig\n    left join jig_play_count on jig_play_count.jig_id = jig.id\n    left join jig_admin_data \"admin\" on admin.jig_id = jig.id\n    where id = $1\n)\nselect cte.jig_id                                          as \"jig_id: JigId\",\n       display_name,\n       creator_id,\n       author_id,\n       (select given_name || ' '::text || family_name\n        from user_profile\n        where user_profile.user_id = author_id)            as \"author_name\",\n       published_at,\n       updated_at,\n       privacy_level                                       as \"privacy_level!: PrivacyLevel\",\n       jig_focus                                           as \"jig_focus!: JigFocus\",\n       language,\n       description,\n       translated_description                              as \"translated_description!: Json<HashMap<String, String>>\",\n       direction                                           as \"direction: TextDirection\",\n       display_score,\n       track_assessments,\n       drag_assist,\n       theme                                               as \"theme: ThemeId\",\n       audio_background                                    as \"audio_background: AudioBackground\",\n       liked_count,\n       play_count,\n       locked,\n       other_keywords,\n       translated_keywords,\n       rating                                               as \"rating?: JigRating\",\n       blocked                                              as \"blocked\",\n       curated,\n       array(select row (unnest(audio_feedback_positive))) as \"audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>\",\n       array(select row (unnest(audio_feedback_negative))) as \"audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>\",\n       array(\n               select row (jig_data_module.id, kind, is_complete)\n               from jig_data_module\n               where jig_data_id = cte.draft_or_live_id\n               order by \"index\"\n           )                                               as \"modules!: Vec<(ModuleId, ModuleKind, bool)>\",\n       array(select row (category_id)\n             from jig_data_category\n             where jig_data_id = cte.draft_or_live_id)     as \"categories!: Vec<(CategoryId,)>\",\n       array(select row (affiliation_id)\n             from jig_data_affiliation\n             where jig_data_id = cte.draft_or_live_id)     as \"affiliations!: Vec<(AffiliationId,)>\",\n       array(select row (age_range_id)\n             from jig_data_age_range\n             where jig_data_id = cte.draft_or_live_id)     as \"age_ranges!: Vec<(AgeRangeId,)>\",\n       array(\n             select row (jdar.id, jdar.display_name, resource_type_id, resource_content)\n             from jig_data_additional_resource \"jdar\"\n             where jdar.jig_data_id = cte.draft_or_live_id\n       )                                                    as \"additional_resource!: Vec<(AddId, String, TypeId, Value)>\"\nfrom jig_data\n         inner join cte on cte.draft_or_live_id = jig_data.id\n"
   },
   "1150af6395059759109a8e8200058064186a44dc8db4e6098dd1fa449e6a8e7f": {
-    "query": "\nupdate user_profile\nset location = $2\nwhere user_id = $1 and location is distinct from $2",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Jsonb"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\nupdate user_profile\nset location = $2\nwhere user_id = $1 and location is distinct from $2"
   },
   "11623dd925dc935401e7c2ef73941a1a46d253df579b98af410e69d1e578850d": {
-    "query": "\nupdate jig_curation_data\nset display_name = $2\nwhere jig_id = $1 and $2 is distinct from display_name\n            ",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Bool"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\nupdate jig_curation_data\nset display_name = $2\nwhere jig_id = $1 and $2 is distinct from display_name\n            "
   },
   "11be0aa19af23c8c3ee5c0b166fa7f4127ffe6dc9d2f62b01a11e7385e5b5202": {
-    "query": "\ninsert into jig_data_additional_resource(jig_data_id, resource_type_id, display_name, resource_content)\nselect $2, resource_type_id, display_name, resource_content\nfrom jig_data_additional_resource\nwhere jig_data_id = $1\n        ",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\ninsert into jig_data_additional_resource(jig_data_id, resource_type_id, display_name, resource_content)\nselect $2, resource_type_id, display_name, resource_content\nfrom jig_data_additional_resource\nwhere jig_data_id = $1\n        "
   },
   "124802b593631b117b5b2e1d2eb43712d579be04d5b218f7c19f382f3fe5dcca": {
-    "query": "\ninsert into locale_entry (bundle_id, section, item_kind_id, english, hebrew, status, zeplin_reference, comments, in_app, in_element, in_mock)\nvalues ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)\nreturning id\n",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id",
+          "ordinal": 0,
           "type_info": "Int4"
         }
       ],
+      "nullable": [
+        false
+      ],
       "parameters": {
         "Left": [
           "Uuid",
@@ -696,53 +698,53 @@
           "Bool",
           "Bool"
         ]
-      },
-      "nullable": [
-        false
-      ]
-    }
+      }
+    },
+    "query": "\ninsert into locale_entry (bundle_id, section, item_kind_id, english, hebrew, status, zeplin_reference, comments, in_app, in_element, in_mock)\nvalues ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)\nreturning id\n"
   },
   "12733111814b439e48d7e9f8ce720e88382a2e0a92dc6ec1dc077c09ad4a47a9": {
-    "query": "select exists (select 1 from \"user\" where id = $1) as \"exists!\"",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "exists!",
+          "ordinal": 0,
           "type_info": "Bool"
         }
+      ],
+      "nullable": [
+        null
       ],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": [
-        null
-      ]
-    }
+      }
+    },
+    "query": "select exists (select 1 from \"user\" where id = $1) as \"exists!\""
   },
   "131b0ba5b42db6c02145b25d2f21f6e7f37af65f4dca9eadd6287f0405c5482a": {
-    "query": "\nupdate jig_data\nset last_synced_at = now()\nwhere jig_data.id = any (select live_id from jig where jig.id = any ($1))\n",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "UuidArray"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\nupdate jig_data\nset last_synced_at = now()\nwhere jig_data.id = any (select live_id from jig where jig.id = any ($1))\n"
   },
   "137a46c39e9037a81b12017740d3aba9c8a9971f2ee4d71cb83f3f82d50057a3": {
-    "query": "\nselect exists (\n    select 1 from user_scope where user_id = $1 and scope = any($2)\n) or (\n    exists (select 1 from user_scope where user_id = $1 and scope = $3) and\n    not exists (select 1 from jig where jig.id = $4 and jig.author_id <> $1)\n) as \"authed!\"\n",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "authed!",
+          "ordinal": 0,
           "type_info": "Bool"
         }
+      ],
+      "nullable": [
+        null
       ],
       "parameters": {
         "Left": [
@@ -751,477 +753,471 @@
           "Int2",
           "Uuid"
         ]
-      },
-      "nullable": [
-        null
-      ]
-    }
+      }
+    },
+    "query": "\nselect exists (\n    select 1 from user_scope where user_id = $1 and scope = any($2)\n) or (\n    exists (select 1 from user_scope where user_id = $1 and scope = $3) and\n    not exists (select 1 from jig where jig.id = $4 and jig.author_id <> $1)\n) as \"authed!\"\n"
   },
   "140ff97c5bd0b551e1c2b0026a53c713117faf011a3f7f9e6f7e420cc481204a": {
-    "query": "\n        update jig_curation_data\n        set additional_resources = $2\n        where jig_id = $1 and $2 is distinct from additional_resources\n                    ",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Bool"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\n        update jig_curation_data\n        set additional_resources = $2\n        where jig_id = $1 and $2 is distinct from additional_resources\n                    "
   },
   "145cde06bc00df1855bd4307423b6f6f7f36a4560ed6e354a127f166d0d21011": {
-    "query": "update user_audio_upload set uploaded_at = now(), processing_result = null where audio_id = $1",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "update user_audio_upload set uploaded_at = now(), processing_result = null where audio_id = $1"
   },
   "14f012bfa5f6e21f23b17bc3d4a56b40dcffe39be966cd8b6af3aba87631968a": {
-    "query": "select exists(select 1 from user_pdf_upload where pdf_id = $1 for no key update) as \"exists!\"",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "exists!",
+          "ordinal": 0,
           "type_info": "Bool"
         }
       ],
+      "nullable": [
+        null
+      ],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": [
-        null
-      ]
-    }
+      }
+    },
+    "query": "select exists(select 1 from user_pdf_upload where pdf_id = $1 for no key update) as \"exists!\""
   },
   "160b640822791b21c7d5d057e0d388bfdf669e70b2a2eeb99056919681a607ee": {
-    "query": "\nselect id as \"id: ResourceTypeId\", display_name, created_at, updated_at from \"resource_type\"\norder by index\n",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id: ResourceTypeId",
+          "ordinal": 0,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 1,
           "name": "display_name",
+          "ordinal": 1,
           "type_info": "Text"
         },
         {
-          "ordinal": 2,
           "name": "created_at",
+          "ordinal": 2,
           "type_info": "Timestamptz"
         },
         {
-          "ordinal": 3,
           "name": "updated_at",
+          "ordinal": 3,
           "type_info": "Timestamptz"
         }
       ],
-      "parameters": {
-        "Left": []
-      },
       "nullable": [
         false,
         false,
         false,
         true
-      ]
-    }
-  },
-  "16b8e7596de9c8c57e8a50d4b6788e6d7874603ce815762fae2380223a4ddfc0": {
-    "query": "select id as \"id: AudioId\" from user_audio_library order by created_at desc",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id: AudioId",
-          "type_info": "Uuid"
-        }
       ],
       "parameters": {
         "Left": []
-      },
-      "nullable": [
-        false
-      ]
-    }
+      }
+    },
+    "query": "\nselect id as \"id: ResourceTypeId\", display_name, created_at, updated_at from \"resource_type\"\norder by index\n"
   },
-  "1781983a4042cb8447163d98ee232c71d24ef75c29ea58219fc7604d95780767": {
-    "query": "select id, display_name as name from locale_bundle order by created_at",
+  "16b8e7596de9c8c57e8a50d4b6788e6d7874603ce815762fae2380223a4ddfc0": {
     "describe": {
       "columns": [
         {
+          "name": "id: AudioId",
           "ordinal": 0,
+          "type_info": "Uuid"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "select id as \"id: AudioId\" from user_audio_library order by created_at desc"
+  },
+  "1781983a4042cb8447163d98ee232c71d24ef75c29ea58219fc7604d95780767": {
+    "describe": {
+      "columns": [
+        {
           "name": "id",
+          "ordinal": 0,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 1,
           "name": "name",
+          "ordinal": 1,
           "type_info": "Text"
         }
       ],
-      "parameters": {
-        "Left": []
-      },
       "nullable": [
         false,
         false
-      ]
-    }
+      ],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "select id, display_name as name from locale_bundle order by created_at"
   },
   "17c068f0940d505201e9323c0d5d93d2565806c21b75c86f167f18f17caf652f": {
-    "query": "\nupdate jig_curation_data\nset categories = $2\nwhere jig_id = $1 and $2 is distinct from categories\n            ",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Bool"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\nupdate jig_curation_data\nset categories = $2\nwhere jig_id = $1 and $2 is distinct from categories\n            "
   },
   "1920891993d8927a88d3fc291f1b99e47d8826748b92810b34f1f637f07726ad": {
-    "query": "select index as \"index: i16\" from image_tag where index = $1 for update",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "index: i16",
+          "ordinal": 0,
           "type_info": "Int2"
         }
+      ],
+      "nullable": [
+        false
       ],
       "parameters": {
         "Left": [
           "Int2"
         ]
-      },
-      "nullable": [
-        false
-      ]
-    }
+      }
+    },
+    "query": "select index as \"index: i16\" from image_tag where index = $1 for update"
   },
   "19e0b4ddf95507058d054928c0275e5091e02c75fd1b74867e54d0188ba2c56a": {
-    "query": "\n            select id as \"id: AgeRangeId\", display_name, short_display_name, created_at, updated_at from age_range\n            order by index\n        ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id: AgeRangeId",
+          "ordinal": 0,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 1,
           "name": "display_name",
+          "ordinal": 1,
           "type_info": "Text"
         },
         {
-          "ordinal": 2,
           "name": "short_display_name",
+          "ordinal": 2,
           "type_info": "Text"
         },
         {
-          "ordinal": 3,
           "name": "created_at",
+          "ordinal": 3,
           "type_info": "Timestamptz"
         },
         {
-          "ordinal": 4,
           "name": "updated_at",
+          "ordinal": 4,
           "type_info": "Timestamptz"
         }
       ],
-      "parameters": {
-        "Left": []
-      },
       "nullable": [
         false,
         false,
         true,
         false,
         true
-      ]
-    }
+      ],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "\n            select id as \"id: AgeRangeId\", display_name, short_display_name, created_at, updated_at from age_range\n            order by index\n        "
   },
   "19e13d35722d768bfabd2104aaabd88c7c6b7436ac230485dfe370a6b4609aee": {
-    "query": "insert into user_auth_google (user_id, google_id) values ($1, $2)",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Text"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "insert into user_auth_google (user_id, google_id) values ($1, $2)"
   },
   "1a8b1e8b534e0c03972838146a54d715f11f647be57465718d61defdd7af242d": {
-    "query": "update image_tag set display_name = $2 where index = $1",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Int2",
           "Text"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "update image_tag set display_name = $2 where index = $1"
   },
   "1c34eda829dd92980a83bf0ff3b38800febb950fd3b6e5f3e3694938b7bc19e3": {
-    "query": "\nselect display_name                               as \"display_name!\",    \n       report_type                                as \"report_type!: JigReportType\",                  \n       (\n            select given_name || ' '::text || family_name\n            from user_profile\n            where user_profile.user_id = reporter_id\n        )                                       as \"name?\",\n        (\n            select email::text\n            from user_email\n            where user_email.user_id = reporter_id\n        )                                       as \"email?\",\n        (\n            select given_name || ' '::text || family_name\n            from user_profile\n            where user_profile.user_id = creator_id\n        )                                       as \"creator_name!\"\nfrom jig_report\n    left join jig on jig.id = jig_report.jig_id\n    left join jig_data on jig_data.id = jig.live_id\nwhere jig_report.id = $1 and jig_report.jig_id = $2\n",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "display_name!",
+          "ordinal": 0,
           "type_info": "Text"
         },
         {
-          "ordinal": 1,
           "name": "report_type!: JigReportType",
+          "ordinal": 1,
           "type_info": "Int2"
         },
         {
-          "ordinal": 2,
           "name": "name?",
+          "ordinal": 2,
           "type_info": "Text"
         },
         {
-          "ordinal": 3,
           "name": "email?",
+          "ordinal": 3,
           "type_info": "Text"
         },
         {
-          "ordinal": 4,
           "name": "creator_name!",
+          "ordinal": 4,
           "type_info": "Text"
         }
       ],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Uuid"
-        ]
-      },
       "nullable": [
         false,
         false,
         null,
         null,
         null
-      ]
-    }
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\nselect display_name                               as \"display_name!\",    \n       report_type                                as \"report_type!: JigReportType\",                  \n       (\n            select given_name || ' '::text || family_name\n            from user_profile\n            where user_profile.user_id = reporter_id\n        )                                       as \"name?\",\n        (\n            select email::text\n            from user_email\n            where user_email.user_id = reporter_id\n        )                                       as \"email?\",\n        (\n            select given_name || ' '::text || family_name\n            from user_profile\n            where user_profile.user_id = creator_id\n        )                                       as \"creator_name!\"\nfrom jig_report\n    left join jig on jig.id = jig_report.jig_id\n    left join jig_data on jig_data.id = jig.live_id\nwhere jig_report.id = $1 and jig_report.jig_id = $2\n"
   },
   "1c72ff4451fa5342ae8ae20bb4169b62efa25b9b44c80ce26bf9a9619336dd60": {
-    "query": "delete from user_pdf_library where id = $1",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "delete from user_pdf_library where id = $1"
   },
   "1c7400d27c33a6b7204302b5cf2ced8fb445de00304be5b424133f3b7afbf1cb": {
-    "query": "insert into user_auth_basic (user_id, email, password) values ($1, $2::text, $3)",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Text",
           "Text"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "insert into user_auth_basic (user_id, email, password) values ($1, $2::text, $3)"
   },
   "1d1f0368934f600bc36f0955ac595e554d8d1aeb0632ddd325177529c983e0d9": {
-    "query": "\nupdate jig_data\nset updated_at = now()\nfrom jig\nwhere jig.live_id = $1\n            ",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\nupdate jig_data\nset updated_at = now()\nfrom jig\nwhere jig.live_id = $1\n            "
   },
   "1d746c9230859f4c45b71571b3a4c3884929165504fb9f95b622e8ec907487de": {
-    "query": "select language from user_profile where user_id = $1",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "language",
+          "ordinal": 0,
           "type_info": "Text"
         }
+      ],
+      "nullable": [
+        false
       ],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": [
-        false
-      ]
-    }
+      }
+    },
+    "query": "select language from user_profile where user_id = $1"
   },
   "1e42e953fa2d327cc392c6c2d4452b88773ab521e72d754f8b08ae44b005ef8f": {
-    "query": "\ndelete\nfrom jig_player_session_instance\nwhere id = $1\nreturning ip_address, user_agent, (\n    select jig_id\n    from jig_player_session_instance\n             join jig_player_session on session_index = index\n) as \"jig_id!: JigId\"\n        ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "ip_address",
+          "ordinal": 0,
           "type_info": "Text"
         },
         {
-          "ordinal": 1,
           "name": "user_agent",
+          "ordinal": 1,
           "type_info": "Text"
         },
         {
-          "ordinal": 2,
           "name": "jig_id!: JigId",
+          "ordinal": 2,
           "type_info": "Uuid"
         }
       ],
-      "parameters": {
-        "Left": [
-          "Uuid"
-        ]
-      },
       "nullable": [
         true,
         true,
         null
-      ]
-    }
-  },
-  "1f632d95656642bf59d0e5223e62370d4bb13f7bdc65cb3aa9171e6b39114c6d": {
-    "query": "select uploaded_at from image_upload where image_id = $1 for update",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "uploaded_at",
-          "type_info": "Timestamptz"
-        }
       ],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": [
-        true
-      ]
-    }
+      }
+    },
+    "query": "\ndelete\nfrom jig_player_session_instance\nwhere id = $1\nreturning ip_address, user_agent, (\n    select jig_id\n    from jig_player_session_instance\n             join jig_player_session on session_index = index\n) as \"jig_id!: JigId\"\n        "
   },
-  "1f8df54bb87c543c4a975eb72c8c981ecd033664f68e66a2caff692ac30c14c3": {
-    "query": "\nupdate category\nset parent_id = $1,\n    updated_at = now(),\n    index = (select count(*)::int2 from category where parent_id is not distinct from $1)\nwhere id = $2\nreturning index\n",
+  "1f632d95656642bf59d0e5223e62370d4bb13f7bdc65cb3aa9171e6b39114c6d": {
     "describe": {
       "columns": [
         {
+          "name": "uploaded_at",
           "ordinal": 0,
+          "type_info": "Timestamptz"
+        }
+      ],
+      "nullable": [
+        true
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "select uploaded_at from image_upload where image_id = $1 for update"
+  },
+  "1f8df54bb87c543c4a975eb72c8c981ecd033664f68e66a2caff692ac30c14c3": {
+    "describe": {
+      "columns": [
+        {
           "name": "index",
+          "ordinal": 0,
           "type_info": "Int2"
         }
+      ],
+      "nullable": [
+        false
       ],
       "parameters": {
         "Left": [
           "Uuid",
           "Uuid"
         ]
-      },
-      "nullable": [
-        false
-      ]
-    }
+      }
+    },
+    "query": "\nupdate category\nset parent_id = $1,\n    updated_at = now(),\n    index = (select count(*)::int2 from category where parent_id is not distinct from $1)\nwhere id = $2\nreturning index\n"
   },
   "228687aa01cb6d5780d804f5ddf78a5e070fc552dbb3b3f8e5224b8a6a9e9b18": {
-    "query": "\nselect id as \"id: ImageId\", kind as \"kind: ImageKind\"\nfrom user_image_library\n         join user_image_upload\n              on user_image_library.id = user_image_upload.image_id\nwhere processing_result is true\n  and user_id = $1\n  and (kind is not distinct from $2 or $2 is null)\norder by created_at desc\n",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id: ImageId",
+          "ordinal": 0,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 1,
           "name": "kind: ImageKind",
+          "ordinal": 1,
           "type_info": "Int2"
         }
+      ],
+      "nullable": [
+        false,
+        false
       ],
       "parameters": {
         "Left": [
           "Uuid",
           "Int2"
         ]
-      },
-      "nullable": [
-        false,
-        false
-      ]
-    }
+      }
+    },
+    "query": "\nselect id as \"id: ImageId\", kind as \"kind: ImageKind\"\nfrom user_image_library\n         join user_image_upload\n              on user_image_library.id = user_image_upload.image_id\nwhere processing_result is true\n  and user_id = $1\n  and (kind is not distinct from $2 or $2 is null)\norder by created_at desc\n"
   },
   "29a0f9148a4fa42c0e68388554eca61b27aae6fd7ce9dda131ad6571523833ad": {
-    "query": "select\n  id as \"id!\",\n  case\n    kind -- PngCanvasImage\n    when 0 then 3 -- PngStickerImage\n    when 1 then 0\n  end :: int2 \"kind!: MediaKind\",\n  created_at as \"created_at!\",\n  updated_at,\n  uploaded_at,\n  0 :: int2 as \"library!: MediaLibrary\" -- global\nfrom\n  image_metadata\n  left join image_upload on image_id = id\nunion all\nselect\n  id as \"id!\",\n  case\n    kind -- GifAnimation\n    when 0 then 1 -- SpritesheetAnimation\n    when 1 then 2\n  end :: int2 \"kind!: MediaKind\",\n  created_at as \"created_at!\",\n  updated_at,\n  uploaded_at,\n  0 :: int2 as \"library!: MediaLibrary\" -- global\nfrom\n  animation_metadata\n  left join global_animation_upload on animation_id = id\nunion all\nselect\n  id as \"id!\",\n  -- PngStickerImage\n  0 :: int2 as \"kind!: MediaKind\",\n  created_at as \"created_at!\",\n  updated_at,\n  uploaded_at,\n  1 :: int2 as \"library!: MediaLibrary\" -- user\nfrom\n  user_image_library\n  left join user_image_upload on image_id = id\nunion all\nselect\n  id as \"id!\",\n  -- Mp3Audio\n  4 :: int2 as \"kind!: MediaKind\",\n  created_at as \"created_at!\",\n  updated_at,\n  uploaded_at,\n  1 :: int2 as \"library!: MediaLibrary\" -- user\nfrom\n  user_audio_library\n  left join user_audio_upload on audio_id = id\nunion all\nselect\n  id as \"id!\",\n  kind as \"kind!: MediaKind\",\n  created_at as \"created_at!\",\n  updated_at,\n  uploaded_at,\n  2 :: int2 as \"library!: MediaLibrary\" -- web\nfrom web_media_upload wmu\ninner join web_media_library wml on wml.kind = kind\nwhere wmu.media_id = media_id ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id!",
+          "ordinal": 0,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 1,
           "name": "kind!: MediaKind",
+          "ordinal": 1,
           "type_info": "Int2"
         },
         {
-          "ordinal": 2,
           "name": "created_at!",
+          "ordinal": 2,
           "type_info": "Timestamptz"
         },
         {
-          "ordinal": 3,
           "name": "updated_at",
+          "ordinal": 3,
           "type_info": "Timestamptz"
         },
         {
-          "ordinal": 4,
           "name": "uploaded_at",
+          "ordinal": 4,
           "type_info": "Timestamptz"
         },
         {
-          "ordinal": 5,
           "name": "library!: MediaLibrary",
+          "ordinal": 5,
           "type_info": "Int2"
         }
       ],
-      "parameters": {
-        "Left": []
-      },
       "nullable": [
         null,
         null,
@@ -1229,169 +1225,175 @@
         null,
         null,
         null
-      ]
-    }
+      ],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "select\n  id as \"id!\",\n  case\n    kind -- PngCanvasImage\n    when 0 then 3 -- PngStickerImage\n    when 1 then 0\n  end :: int2 \"kind!: MediaKind\",\n  created_at as \"created_at!\",\n  updated_at,\n  uploaded_at,\n  0 :: int2 as \"library!: MediaLibrary\" -- global\nfrom\n  image_metadata\n  left join image_upload on image_id = id\nunion all\nselect\n  id as \"id!\",\n  case\n    kind -- GifAnimation\n    when 0 then 1 -- SpritesheetAnimation\n    when 1 then 2\n  end :: int2 \"kind!: MediaKind\",\n  created_at as \"created_at!\",\n  updated_at,\n  uploaded_at,\n  0 :: int2 as \"library!: MediaLibrary\" -- global\nfrom\n  animation_metadata\n  left join global_animation_upload on animation_id = id\nunion all\nselect\n  id as \"id!\",\n  -- PngStickerImage\n  0 :: int2 as \"kind!: MediaKind\",\n  created_at as \"created_at!\",\n  updated_at,\n  uploaded_at,\n  1 :: int2 as \"library!: MediaLibrary\" -- user\nfrom\n  user_image_library\n  left join user_image_upload on image_id = id\nunion all\nselect\n  id as \"id!\",\n  -- Mp3Audio\n  4 :: int2 as \"kind!: MediaKind\",\n  created_at as \"created_at!\",\n  updated_at,\n  uploaded_at,\n  1 :: int2 as \"library!: MediaLibrary\" -- user\nfrom\n  user_audio_library\n  left join user_audio_upload on audio_id = id\nunion all\nselect\n  id as \"id!\",\n  kind as \"kind!: MediaKind\",\n  created_at as \"created_at!\",\n  updated_at,\n  uploaded_at,\n  2 :: int2 as \"library!: MediaLibrary\" -- web\nfrom web_media_upload wmu\ninner join web_media_library wml on wml.kind = kind\nwhere wmu.media_id = media_id "
   },
   "2c9269da9de0d178512713b7fc2789ad3472cc1dcea22eecd5fb941415d37bc4": {
-    "query": "\ninsert into user_pdf_library(user_id)\nvalues($1)\nreturning id as \"id: PdfId\"\n        ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id: PdfId",
+          "ordinal": 0,
           "type_info": "Uuid"
         }
+      ],
+      "nullable": [
+        false
       ],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": [
-        false
-      ]
-    }
+      }
+    },
+    "query": "\ninsert into user_pdf_library(user_id)\nvalues($1)\nreturning id as \"id: PdfId\"\n        "
   },
   "30e211c77af70b7a52d9ffde24d7a442e3565e2135840cb8d2646bb7fa048509": {
-    "query": "\nselect id,\n       kind as \"kind: MediaKind\",\n       created_at,\n       updated_at,\n       array(select media_url from web_media_library_url where media_id = $1) as \"urls!\"\nfrom web_media_library\nwhere id = $1",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id",
+          "ordinal": 0,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 1,
           "name": "kind: MediaKind",
+          "ordinal": 1,
           "type_info": "Int2"
         },
         {
-          "ordinal": 2,
           "name": "created_at",
+          "ordinal": 2,
           "type_info": "Timestamptz"
         },
         {
-          "ordinal": 3,
           "name": "updated_at",
+          "ordinal": 3,
           "type_info": "Timestamptz"
         },
         {
-          "ordinal": 4,
           "name": "urls!",
+          "ordinal": 4,
           "type_info": "TextArray"
         }
       ],
-      "parameters": {
-        "Left": [
-          "Uuid"
-        ]
-      },
       "nullable": [
         false,
         false,
         false,
         true,
         null
-      ]
-    }
-  },
-  "3246ffd2a6be78dd21c837147f5eaa58fefa4cc0474b3c9a0e94d8f8d158b41c": {
-    "query": "\nselect\n    user_id,\n    password,\n    exists(select 1 from user_profile where user_id = user_auth_basic.user_id) as \"has_profile!\",\n    exists(select 1 from user_email where user_id = user_auth_basic.user_id) as \"has_verified_email!\"\nfrom user_auth_basic where email = $1::text\n",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "user_id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 1,
-          "name": "password",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 2,
-          "name": "has_profile!",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 3,
-          "name": "has_verified_email!",
-          "type_info": "Bool"
-        }
       ],
       "parameters": {
         "Left": [
-          "Text"
+          "Uuid"
         ]
-      },
+      }
+    },
+    "query": "\nselect id,\n       kind as \"kind: MediaKind\",\n       created_at,\n       updated_at,\n       array(select media_url from web_media_library_url where media_id = $1) as \"urls!\"\nfrom web_media_library\nwhere id = $1"
+  },
+  "3246ffd2a6be78dd21c837147f5eaa58fefa4cc0474b3c9a0e94d8f8d158b41c": {
+    "describe": {
+      "columns": [
+        {
+          "name": "user_id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "password",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "has_profile!",
+          "ordinal": 2,
+          "type_info": "Bool"
+        },
+        {
+          "name": "has_verified_email!",
+          "ordinal": 3,
+          "type_info": "Bool"
+        }
+      ],
       "nullable": [
         false,
         false,
         null,
         null
-      ]
-    }
+      ],
+      "parameters": {
+        "Left": [
+          "Text"
+        ]
+      }
+    },
+    "query": "\nselect\n    user_id,\n    password,\n    exists(select 1 from user_profile where user_id = user_auth_basic.user_id) as \"has_profile!\",\n    exists(select 1 from user_email where user_id = user_auth_basic.user_id) as \"has_verified_email!\"\nfrom user_auth_basic where email = $1::text\n"
   },
   "32bbb9dc2446795abc480d132b14960dc9b5d636d4b95d75400cffae27762155": {
-    "query": "\n            select id as \"id: AffiliationId\", display_name, created_at, updated_at from affiliation\n            order by index\n        ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id: AffiliationId",
+          "ordinal": 0,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 1,
           "name": "display_name",
+          "ordinal": 1,
           "type_info": "Text"
         },
         {
-          "ordinal": 2,
           "name": "created_at",
+          "ordinal": 2,
           "type_info": "Timestamptz"
         },
         {
-          "ordinal": 3,
           "name": "updated_at",
+          "ordinal": 3,
           "type_info": "Timestamptz"
         }
       ],
-      "parameters": {
-        "Left": []
-      },
       "nullable": [
         false,
         false,
         false,
         true
-      ]
-    }
+      ],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "\n            select id as \"id: AffiliationId\", display_name, created_at, updated_at from affiliation\n            order by index\n        "
   },
   "33b3def525f80ae097847489feda1bcb7cc23f2b24ae237dbb93e17802d5fb74": {
-    "query": "update category set name = $1, updated_at = now() where id = $2",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Text",
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "update category set name = $1, updated_at = now() where id = $2"
   },
   "393f95d2043398ff3307695a8616e0d5075cb7e500ecd3efdb49ddd30b7991ed": {
-    "query": "\nselect count(distinct jig.id) as \"count!: i64\"\nfrom jig\nleft join jig_admin_data \"admin\" on admin.jig_id = jig.id\nleft join jig_data on (draft_id = jig_data.id or (live_id = jig_data.id and last_synced_at is not null))\nleft join jig_data_additional_resource \"resource\" on jig_data.id = resource.jig_data_id\nwhere (author_id = $1 or $1 is null)\n    and (jig_data.draft_or_live = $3 or $3 is null)\n    and (jig_focus = $2 or $2 is null)\n    and (jig_data.privacy_level = any($4) or $4 = array[]::smallint[])\n    and (blocked = $5 or $5 is null)\n    and (resource.resource_type_id = any($6) or $6 = array[]::uuid[])\n",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "count!: i64",
+          "ordinal": 0,
           "type_info": "Int8"
         }
+      ],
+      "nullable": [
+        null
       ],
       "parameters": {
         "Left": [
@@ -1402,16 +1404,14 @@
           "Bool",
           "UuidArray"
         ]
-      },
-      "nullable": [
-        null
-      ]
-    }
+      }
+    },
+    "query": "\nselect count(distinct jig.id) as \"count!: i64\"\nfrom jig\nleft join jig_admin_data \"admin\" on admin.jig_id = jig.id\nleft join jig_data on (draft_id = jig_data.id or (live_id = jig_data.id and last_synced_at is not null))\nleft join jig_data_additional_resource \"resource\" on jig_data.id = resource.jig_data_id\nwhere (author_id = $1 or $1 is null)\n    and (jig_data.draft_or_live = $3 or $3 is null)\n    and (jig_focus = $2 or $2 is null)\n    and (jig_data.privacy_level = any($4) or $4 = array[]::smallint[])\n    and (blocked = $5 or $5 is null)\n    and (resource.resource_type_id = any($6) or $6 = array[]::uuid[])\n"
   },
   "399f537a8091d51635c2cd32bf16449c26317d1f56c576064968a2bfd57953e0": {
-    "query": "\nupdate locale_entry\nset\n    bundle_id = coalesce(bundle_id, $2),\n    item_kind_id = coalesce($3, item_kind_id),\n    english = coalesce($4, english),\n    hebrew = coalesce($5, hebrew),\n    status = coalesce($6, status),\n    in_app = coalesce($7, in_app),\n    in_element = coalesce($8, in_element),\n    in_mock = coalesce($9, in_mock),\n    section = case when $10 then $11 else section end,\n    zeplin_reference = case when $12 then $13 else zeplin_reference end,\n    comments = case when $14 then $15 else comments end\nwhere id = $1",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Int4",
@@ -1430,78 +1430,82 @@
           "Bool",
           "Text"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\nupdate locale_entry\nset\n    bundle_id = coalesce(bundle_id, $2),\n    item_kind_id = coalesce($3, item_kind_id),\n    english = coalesce($4, english),\n    hebrew = coalesce($5, hebrew),\n    status = coalesce($6, status),\n    in_app = coalesce($7, in_app),\n    in_element = coalesce($8, in_element),\n    in_mock = coalesce($9, in_mock),\n    section = case when $10 then $11 else section end,\n    zeplin_reference = case when $12 then $13 else zeplin_reference end,\n    comments = case when $14 then $15 else comments end\nwhere id = $1"
   },
   "39a8d9f6b645305b1a6282c110154c481dcdd211fabf7944655438c13b55511c": {
-    "query": "update category set name = $1 where id = $2",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Text",
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "update category set name = $1 where id = $2"
   },
   "3ad66986079ea2df21f1a6af0c50510d362a19addcf3bc0f62b8f3948ea14cf8": {
-    "query": "\nwith cte as (\n    select distinct style_id as id\n    from animation_style\n)\nselect id as \"id: AnimationStyleId\", display_name, created_at, updated_at\nfrom cte inner join style using (id)\norder by index\n        ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id: AnimationStyleId",
+          "ordinal": 0,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 1,
           "name": "display_name",
+          "ordinal": 1,
           "type_info": "Text"
         },
         {
-          "ordinal": 2,
           "name": "created_at",
+          "ordinal": 2,
           "type_info": "Timestamptz"
         },
         {
-          "ordinal": 3,
           "name": "updated_at",
+          "ordinal": 3,
           "type_info": "Timestamptz"
         }
       ],
-      "parameters": {
-        "Left": []
-      },
       "nullable": [
         false,
         false,
         false,
         true
-      ]
-    }
+      ],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "\nwith cte as (\n    select distinct style_id as id\n    from animation_style\n)\nselect id as \"id: AnimationStyleId\", display_name, created_at, updated_at\nfrom cte inner join style using (id)\norder by index\n        "
   },
   "3bc3d5919da8639f36fa262d3f7294004774ae8c98b735b8c569301c6d9fba60": {
-    "query": "\ninsert into user_recent_image (user_id, image_id, media_library)\nvalues ($1, $2, $3)\nON CONFLICT (user_id, image_id) DO UPDATE\n  SET user_id = $1,\n    image_id = $2,\n    media_library = $3,\n    last_used = now()\nreturning image_id as \"id: ImageId\", media_library as \"library: MediaLibrary\", last_used as \"last_used: DateTime<Utc>\";\n        ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id: ImageId",
+          "ordinal": 0,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 1,
           "name": "library: MediaLibrary",
+          "ordinal": 1,
           "type_info": "Int2"
         },
         {
-          "ordinal": 2,
           "name": "last_used: DateTime<Utc>",
+          "ordinal": 2,
           "type_info": "Timestamptz"
         }
+      ],
+      "nullable": [
+        false,
+        false,
+        false
       ],
       "parameters": {
         "Left": [
@@ -1509,62 +1513,60 @@
           "Uuid",
           "Int2"
         ]
-      },
-      "nullable": [
-        false,
-        false,
-        false
-      ]
-    }
+      }
+    },
+    "query": "\ninsert into user_recent_image (user_id, image_id, media_library)\nvalues ($1, $2, $3)\nON CONFLICT (user_id, image_id) DO UPDATE\n  SET user_id = $1,\n    image_id = $2,\n    media_library = $3,\n    last_used = now()\nreturning image_id as \"id: ImageId\", media_library as \"library: MediaLibrary\", last_used as \"last_used: DateTime<Utc>\";\n        "
   },
   "3cfa772cac043b6accabfde5a1fd872956182b08d67b5a9ab2e35a6bb95405b3": {
-    "query": "delete from session where user_id = $1 and (scope_mask | $2) <> 0",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Int2"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "delete from session where user_id = $1 and (scope_mask | $2) <> 0"
   },
   "3e940a4ae4a432d2cc0ce4a8de4f98eacd1a9b8b356ecfaeeb5c9cd686ad008e": {
-    "query": "\n        update user_email\n        set email = $3::text\n        where user_id = $1 and email = $2::text\n        ",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Text",
           "Text"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\n        update user_email\n        set email = $3::text\n        where user_id = $1 and email = $2::text\n        "
   },
   "3f7ad7f5eb03139f9584aa6928a1b805b4f8908a1df023a12a7cf8cba3d56d26": {
-    "query": "delete from session where token = $1",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Text"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "delete from session where token = $1"
   },
   "41d611eeb98a3c32644ff2440ecdb979eefaa5e86a155d4c2e57aabb42415fea": {
-    "query": "\ndelete\nfrom jig_data_module\nwhere jig_data_module.id is not distinct from $2\n   or (jig_data_id = $1 and stable_id is not distinct from $3)\nreturning index\n",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "index",
+          "ordinal": 0,
           "type_info": "Int2"
         }
+      ],
+      "nullable": [
+        false
       ],
       "parameters": {
         "Left": [
@@ -1572,29 +1574,27 @@
           "Uuid",
           "Uuid"
         ]
-      },
-      "nullable": [
-        false
-      ]
-    }
+      }
+    },
+    "query": "\ndelete\nfrom jig_data_module\nwhere jig_data_module.id is not distinct from $2\n   or (jig_data_id = $1 and stable_id is not distinct from $3)\nreturning index\n"
   },
   "43fe8702f219dcd783e0f253f7dfe3c1786829a7dc2d043a8e79eb3deaf061e9": {
-    "query": "\nupdate user_font\nset index = index - 1\nwhere index > $2 and user_id = $1\n        ",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Int2"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\nupdate user_font\nset index = index - 1\nwhere index > $2 and user_id = $1\n        "
   },
   "44559bdf72e9071b9dd849039e4ae6ccf90281a3e751b1bd2ff5ecf18132e53e": {
-    "query": "insert into session (token, user_id, impersonator_id, expires_at, scope_mask) values ($1, $2, $3, $4, $5)",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Text",
@@ -1603,24 +1603,27 @@
           "Timestamptz",
           "Int2"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "insert into session (token, user_id, impersonator_id, expires_at, scope_mask) values ($1, $2, $3, $4, $5)"
   },
   "4485adb8cd789a26f1d0930478a2870c60300ec8612b076a059358c2baaa69a6": {
-    "query": "\ninsert into jig_data_module (jig_data_id, kind, contents, index)\nvalues ($1, $2, $3, (select count(*) from jig_data_module where jig_data_id = $1))\nreturning id, \"index\"\n",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id",
+          "ordinal": 0,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 1,
           "name": "index",
+          "ordinal": 1,
           "type_info": "Int2"
         }
+      ],
+      "nullable": [
+        false,
+        false
       ],
       "parameters": {
         "Left": [
@@ -1628,73 +1631,14 @@
           "Int2",
           "Jsonb"
         ]
-      },
-      "nullable": [
-        false,
-        false
-      ]
-    }
-  },
-  "4525dd6ca4c71dcfe23f0d502f4cd496b8e77752a41a53c5aaa0008334a22fd3": {
-    "query": "\nselect id                                                                 as \"id!: CategoryId\",\n       name                                                               as \"name!\",\n       created_at                                                         as \"created_at!\",\n       updated_at,\n       (select count(*)::int8 from image_category where category_id = id) as \"image_count!\",\n       (select count(*)::int8 from jig_data_category where category_id = id)   as \"jig_count!\",\n       user_scopes                                                        as \"user_scopes!\"\nfrom category\n         inner join unnest($1::uuid[]) with ordinality t(id, ord) USING (id)\norder by t.ord\n",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id!: CategoryId",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 1,
-          "name": "name!",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 2,
-          "name": "created_at!",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 3,
-          "name": "updated_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 4,
-          "name": "image_count!",
-          "type_info": "Int8"
-        },
-        {
-          "ordinal": 5,
-          "name": "jig_count!",
-          "type_info": "Int8"
-        },
-        {
-          "ordinal": 6,
-          "name": "user_scopes!",
-          "type_info": "Int2Array"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "UuidArray"
-        ]
-      },
-      "nullable": [
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true
-      ]
-    }
+      }
+    },
+    "query": "\ninsert into jig_data_module (jig_data_id, kind, contents, index)\nvalues ($1, $2, $3, (select count(*) from jig_data_module where jig_data_id = $1))\nreturning id, \"index\"\n"
   },
   "477cc11eb6ff88e4c8c0779c11ab3480de42748968c29564bc0e70db1f18a9bc": {
-    "query": "\nupdate jig_data_module\nset contents    = coalesce($3, contents),\n    kind        = coalesce($4, kind),\n    is_complete = coalesce($5, is_complete)\nwhere jig_data_id = $1\n  and index = $2\n",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
@@ -1703,100 +1647,93 @@
           "Int2",
           "Bool"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\nupdate jig_data_module\nset contents    = coalesce($3, contents),\n    kind        = coalesce($4, kind),\n    is_complete = coalesce($5, is_complete)\nwhere jig_data_id = $1\n  and index = $2\n"
   },
   "4783cc4d1b317c1b58f392738ab9399d63ec4926354e35348c91fa13564f016d": {
-    "query": "update user_audio_upload set processed_at = now(), processing_result = true where audio_id = $1",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "update user_audio_upload set processed_at = now(), processing_result = true where audio_id = $1"
   },
   "47ba2a8d778709b04f8f3670835606cefd05288068ca52c5e5e0f1be5c93c268": {
-    "query": "\nselect id                               as \"id!: ImageId\",\n       description                                                                                    \nfrom image_metadata\n     join image_upload on id = image_id\nwhere description <> '' and translated_description = '{}'\nand processed_at is not null\norder by coalesce(updated_at, created_at) desc\nlimit 50 for no key update skip locked;\n ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id!: ImageId",
+          "ordinal": 0,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 1,
           "name": "description",
+          "ordinal": 1,
           "type_info": "Text"
         }
       ],
-      "parameters": {
-        "Left": []
-      },
       "nullable": [
         false,
         false
-      ]
-    }
+      ],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "\nselect id                               as \"id!: ImageId\",\n       description                                                                                    \nfrom image_metadata\n     join image_upload on id = image_id\nwhere description <> '' and translated_description = '{}'\nand processed_at is not null\norder by coalesce(updated_at, created_at) desc\nlimit 50 for no key update skip locked;\n "
   },
   "47f87006d700bed96cbf873d8addacbd9c160cf71e5cd0a4543b1fd7754d563d": {
-    "query": "\ndelete from user_recent_image\nwhere user_id = $1 and image_id = $2\n            ",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\ndelete from user_recent_image\nwhere user_id = $1 and image_id = $2\n            "
   },
   "497d102ecb4180c0d121a24d6005b7bf078dd8c59dc68949b82c62bbb41951c0": {
-    "query": "\nselect id                                   as \"id!: CommentId\",\n       jig_id                               as \"jig_id!: JigId\",                      \n       comment,\n       created_at,\n       author_id                            as \"author_id!: Uuid\",\n       (\n            select given_name || ' '::text || family_name\n            from user_profile\n            where user_profile.user_id = author_id\n        )                                       as \"author_name!\"\nfrom jig_curation_comment\nwhere id = $1 and jig_id = $2\n",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id!: CommentId",
+          "ordinal": 0,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 1,
           "name": "jig_id!: JigId",
+          "ordinal": 1,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 2,
           "name": "comment",
+          "ordinal": 2,
           "type_info": "Text"
         },
         {
-          "ordinal": 3,
           "name": "created_at",
+          "ordinal": 3,
           "type_info": "Timestamptz"
         },
         {
-          "ordinal": 4,
           "name": "author_id!: Uuid",
+          "ordinal": 4,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 5,
           "name": "author_name!",
+          "ordinal": 5,
           "type_info": "Text"
         }
       ],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Uuid"
-        ]
-      },
       "nullable": [
         false,
         false,
@@ -1804,278 +1741,279 @@
         false,
         false,
         null
-      ]
-    }
-  },
-  "49e49fd07ac30a6dde52fa0090ae8a616a808e045e474fedac23568b6d876fdb": {
-    "query": "\ninsert into jig_data_category(jig_data_id, category_id)\nselect $2, category_id\nfrom jig_data_category\nwhere jig_data_id = $1\n        ",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Uuid"
-        ]
-      },
-      "nullable": []
-    }
-  },
-  "4a5db1ebad6d217717b56533f1c6147d1decddb324981a107dc95e2bfd8f1872": {
-    "query": "\nselect display_name         as \"display_name!\",\n       resource_type_id     as \"resource_type_id!: ResourceTypeId\",\n       resource_content    as \"resource_content!\"\nfrom jig_data_additional_resource \"jdar\"\nwhere jig_data_id = $1\n  and jdar.id = $2\n        ",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "display_name!",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 1,
-          "name": "resource_type_id!: ResourceTypeId",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 2,
-          "name": "resource_content!",
-          "type_info": "Jsonb"
-        }
       ],
       "parameters": {
         "Left": [
           "Uuid",
           "Uuid"
         ]
-      },
+      }
+    },
+    "query": "\nselect id                                   as \"id!: CommentId\",\n       jig_id                               as \"jig_id!: JigId\",                      \n       comment,\n       created_at,\n       author_id                            as \"author_id!: Uuid\",\n       (\n            select given_name || ' '::text || family_name\n            from user_profile\n            where user_profile.user_id = author_id\n        )                                       as \"author_name!\"\nfrom jig_curation_comment\nwhere id = $1 and jig_id = $2\n"
+  },
+  "49e49fd07ac30a6dde52fa0090ae8a616a808e045e474fedac23568b6d876fdb": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\ninsert into jig_data_category(jig_data_id, category_id)\nselect $2, category_id\nfrom jig_data_category\nwhere jig_data_id = $1\n        "
+  },
+  "4a5db1ebad6d217717b56533f1c6147d1decddb324981a107dc95e2bfd8f1872": {
+    "describe": {
+      "columns": [
+        {
+          "name": "display_name!",
+          "ordinal": 0,
+          "type_info": "Text"
+        },
+        {
+          "name": "resource_type_id!: ResourceTypeId",
+          "ordinal": 1,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "resource_content!",
+          "ordinal": 2,
+          "type_info": "Jsonb"
+        }
+      ],
       "nullable": [
         false,
         false,
         false
-      ]
-    }
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\nselect display_name         as \"display_name!\",\n       resource_type_id     as \"resource_type_id!: ResourceTypeId\",\n       resource_content    as \"resource_content!\"\nfrom jig_data_additional_resource \"jdar\"\nwhere jig_data_id = $1\n  and jdar.id = $2\n        "
   },
   "4b59765bf5f97002c95e723a2d831e75df863ce1f73be3c0cc7714aee57b54a7": {
-    "query": "\nselect exists(\n        select 1\n        from user_font\n        where user_id = $1\n            and index = $2\n        for update\n) as \"exists!\"\n        ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "exists!",
+          "ordinal": 0,
           "type_info": "Bool"
         }
+      ],
+      "nullable": [
+        null
       ],
       "parameters": {
         "Left": [
           "Uuid",
           "Int2"
         ]
-      },
-      "nullable": [
-        null
-      ]
-    }
+      }
+    },
+    "query": "\nselect exists(\n        select 1\n        from user_font\n        where user_id = $1\n            and index = $2\n        for update\n) as \"exists!\"\n        "
   },
   "4ce0b3cd3acb70b250136f3b5d951fb79e8cfec345f875c95582f5b276cbca72": {
-    "query": "update user_audio_upload set processed_at = now(), processing_result = false where audio_id = $1",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "update user_audio_upload set processed_at = now(), processing_result = false where audio_id = $1"
   },
   "4d327320e1810b7c419009172dc1137243a3d1d67ec65c614afb0101e374c4fc": {
-    "query": "select id as \"id: PdfId\" from user_pdf_library where id = $1",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id: PdfId",
+          "ordinal": 0,
           "type_info": "Uuid"
         }
+      ],
+      "nullable": [
+        false
       ],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": [
-        false
-      ]
-    }
+      }
+    },
+    "query": "select id as \"id: PdfId\" from user_pdf_library where id = $1"
   },
   "4fb49fe4ad3204755e0a09d701e36d421c6a6696509bd37c238b1a835e022d7b": {
-    "query": "\ninsert into jig_like(jig_id, user_id)\nvalues ($1, $2)\n            ",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\ninsert into jig_like(jig_id, user_id)\nvalues ($1, $2)\n            "
   },
   "50ff48a8d492e560f61066b5217a70876d23552f79fcb6d43dbbcd5331da14ef": {
-    "query": "delete from animation_metadata where id = $1 returning kind as \"kind: AnimationKind\"",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "kind: AnimationKind",
+          "ordinal": 0,
           "type_info": "Int2"
         }
       ],
-      "parameters": {
-        "Left": [
-          "Uuid"
-        ]
-      },
       "nullable": [
         false
-      ]
-    }
-  },
-  "51a40f41372d3ac245973b6c148c56e71684c771e64465cf5c188241d4416d4a": {
-    "query": "\nupdate category\nset index = index - 1, updated_at = now()\nwhere index > $1 and index <= $2 is not false and parent_id is not distinct from $3\n",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Int2",
-          "Int2",
-          "Uuid"
-        ]
-      },
-      "nullable": []
-    }
-  },
-  "5330258c1771d3e64b884d567ed1290ab484fb36f84360c05a1ac06fb8e11032": {
-    "query": "\ninsert into jig_data_affiliation(jig_data_id, affiliation_id)\nselect $2, affiliation_id\nfrom jig_data_affiliation\nwhere jig_data_id = $1\n        ",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Uuid"
-        ]
-      },
-      "nullable": []
-    }
-  },
-  "55f6173b885847956231438a0f6bb21651b7d21074dbd6ae5cffb9d55cbd68bd": {
-    "query": "\nselect user_id as \"id\",\n    username,\n    user_email.email::text as \"email!\",\n    given_name,\n    family_name,\n    profile_image_id       as \"profile_image?: ImageId\",\n    language,\n    locale,\n    opt_into_edu_resources,\n    over_18,\n    timezone,\n    user_profile.created_at,\n    user_profile.updated_at,\n    organization,\n    persona                as \"persona!: Vec<String>\",\n    location,\n    array(select scope from user_scope where user_scope.user_id = \"user\".id) as \"scopes!: Vec<i16>\",\n    array(select subject_id from user_subject where user_subject.user_id = \"user\".id) as \"subjects!: Vec<Uuid>\",\n    array(select affiliation_id from user_affiliation where user_affiliation.user_id = \"user\".id) as \"affiliations!: Vec<Uuid>\",\n    array(select age_range_id from user_age_range where user_age_range.user_id = \"user\".id) as \"age_ranges!: Vec<Uuid>\"\nfrom \"user\"\n    inner join user_profile on \"user\".id = user_profile.user_id\n    inner join user_email using(user_id)\nwhere id = $1",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 1,
-          "name": "username",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 2,
-          "name": "email!",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 3,
-          "name": "given_name",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 4,
-          "name": "family_name",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 5,
-          "name": "profile_image?: ImageId",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 6,
-          "name": "language",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 7,
-          "name": "locale",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 8,
-          "name": "opt_into_edu_resources",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 9,
-          "name": "over_18",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 10,
-          "name": "timezone",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 11,
-          "name": "created_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 12,
-          "name": "updated_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 13,
-          "name": "organization",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 14,
-          "name": "persona!: Vec<String>",
-          "type_info": "TextArray"
-        },
-        {
-          "ordinal": 15,
-          "name": "location",
-          "type_info": "Jsonb"
-        },
-        {
-          "ordinal": 16,
-          "name": "scopes!: Vec<i16>",
-          "type_info": "Int2Array"
-        },
-        {
-          "ordinal": 17,
-          "name": "subjects!: Vec<Uuid>",
-          "type_info": "UuidArray"
-        },
-        {
-          "ordinal": 18,
-          "name": "affiliations!: Vec<Uuid>",
-          "type_info": "UuidArray"
-        },
-        {
-          "ordinal": 19,
-          "name": "age_ranges!: Vec<Uuid>",
-          "type_info": "UuidArray"
-        }
       ],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
+      }
+    },
+    "query": "delete from animation_metadata where id = $1 returning kind as \"kind: AnimationKind\""
+  },
+  "51a40f41372d3ac245973b6c148c56e71684c771e64465cf5c188241d4416d4a": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Int2",
+          "Int2",
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\nupdate category\nset index = index - 1, updated_at = now()\nwhere index > $1 and index <= $2 is not false and parent_id is not distinct from $3\n"
+  },
+  "5330258c1771d3e64b884d567ed1290ab484fb36f84360c05a1ac06fb8e11032": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\ninsert into jig_data_affiliation(jig_data_id, affiliation_id)\nselect $2, affiliation_id\nfrom jig_data_affiliation\nwhere jig_data_id = $1\n        "
+  },
+  "55f6173b885847956231438a0f6bb21651b7d21074dbd6ae5cffb9d55cbd68bd": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "username",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "email!",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "given_name",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "family_name",
+          "ordinal": 4,
+          "type_info": "Text"
+        },
+        {
+          "name": "profile_image?: ImageId",
+          "ordinal": 5,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "language",
+          "ordinal": 6,
+          "type_info": "Text"
+        },
+        {
+          "name": "locale",
+          "ordinal": 7,
+          "type_info": "Text"
+        },
+        {
+          "name": "opt_into_edu_resources",
+          "ordinal": 8,
+          "type_info": "Bool"
+        },
+        {
+          "name": "over_18",
+          "ordinal": 9,
+          "type_info": "Bool"
+        },
+        {
+          "name": "timezone",
+          "ordinal": 10,
+          "type_info": "Text"
+        },
+        {
+          "name": "created_at",
+          "ordinal": 11,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "updated_at",
+          "ordinal": 12,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "organization",
+          "ordinal": 13,
+          "type_info": "Text"
+        },
+        {
+          "name": "persona!: Vec<String>",
+          "ordinal": 14,
+          "type_info": "TextArray"
+        },
+        {
+          "name": "location",
+          "ordinal": 15,
+          "type_info": "Jsonb"
+        },
+        {
+          "name": "scopes!: Vec<i16>",
+          "ordinal": 16,
+          "type_info": "Int2Array"
+        },
+        {
+          "name": "subjects!: Vec<Uuid>",
+          "ordinal": 17,
+          "type_info": "UuidArray"
+        },
+        {
+          "name": "affiliations!: Vec<Uuid>",
+          "ordinal": 18,
+          "type_info": "UuidArray"
+        },
+        {
+          "name": "age_ranges!: Vec<Uuid>",
+          "ordinal": 19,
+          "type_info": "UuidArray"
+        }
+      ],
       "nullable": [
         false,
         false,
@@ -2097,427 +2035,301 @@
         null,
         null,
         null
-      ]
-    }
-  },
-  "56567f2d09b683dfb6209093ff0ded597cda78b614466626b84956d955eb69c6": {
-    "query": "\n        update jig_play_count\n        set play_count = play_count + 1\n        where jig_id = $1\n        ",
-    "describe": {
-      "columns": [],
+      ],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\nselect user_id as \"id\",\n    username,\n    user_email.email::text as \"email!\",\n    given_name,\n    family_name,\n    profile_image_id       as \"profile_image?: ImageId\",\n    language,\n    locale,\n    opt_into_edu_resources,\n    over_18,\n    timezone,\n    user_profile.created_at,\n    user_profile.updated_at,\n    organization,\n    persona                as \"persona!: Vec<String>\",\n    location,\n    array(select scope from user_scope where user_scope.user_id = \"user\".id) as \"scopes!: Vec<i16>\",\n    array(select subject_id from user_subject where user_subject.user_id = \"user\".id) as \"subjects!: Vec<Uuid>\",\n    array(select affiliation_id from user_affiliation where user_affiliation.user_id = \"user\".id) as \"affiliations!: Vec<Uuid>\",\n    array(select age_range_id from user_age_range where user_age_range.user_id = \"user\".id) as \"age_ranges!: Vec<Uuid>\"\nfrom \"user\"\n    inner join user_profile on \"user\".id = user_profile.user_id\n    inner join user_email using(user_id)\nwhere id = $1"
   },
-  "565914a8fc1c1af596e272f153892585c460566614844181566d2a531e0a613a": {
-    "query": "\nupdate jig_data\nset audio_feedback_positive = $2,\n    audio_feedback_negative = $3,\n    updated_at = now()\nwhere id = $1 and ($2 <> audio_feedback_positive or $3 <> audio_feedback_negative)\n            ",
+  "56567f2d09b683dfb6209093ff0ded597cda78b614466626b84956d955eb69c6": {
     "describe": {
       "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\n        update jig_play_count\n        set play_count = play_count + 1\n        where jig_id = $1\n        "
+  },
+  "565914a8fc1c1af596e272f153892585c460566614844181566d2a531e0a613a": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Int2Array",
           "Int2Array"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\nupdate jig_data\nset audio_feedback_positive = $2,\n    audio_feedback_negative = $3,\n    updated_at = now()\nwhere id = $1 and ($2 <> audio_feedback_positive or $3 <> audio_feedback_negative)\n            "
   },
   "57b72bbdece8deb3ac84c44b94157afbd3d50d16c893613f54145b9ca7e255d0": {
-    "query": "insert into user_audio_upload (audio_id) values($1)",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "insert into user_audio_upload (audio_id) values($1)"
   },
   "5842389dd9a03ba291f04a518e3eccc249eb3664c1ecd12b294de7a81d132a59": {
-    "query": "delete from user_audio_library where id = $1",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "delete from user_audio_library where id = $1"
   },
   "584c1a6c3683272dc4cb0785bdb9ee07ca772df2c04a8ce0cbe406a3d1487016": {
-    "query": "update user_pdf_upload set processed_at = now(), processing_result = false where pdf_id = $1",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "update user_pdf_upload set processed_at = now(), processing_result = false where pdf_id = $1"
   },
   "58ed84397822e7790a3c721f37579e8cbe5aa2e6836c533323229873e88e247d": {
-    "query": "delete from image_metadata where id = $1",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "delete from image_metadata where id = $1"
   },
   "59c49f0ffacb928c16d48a8a91fc04e16057b123de225183c88bfd1348042e1b": {
-    "query": "\nupdate user_image_upload\nset uploaded_at       = now(),\n    processed_at      = now(),\n    processing_result = true\nwhere image_id = $1\n",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\nupdate user_image_upload\nset uploaded_at       = now(),\n    processed_at      = now(),\n    processing_result = true\nwhere image_id = $1\n"
   },
   "5cd7636d958f3bcd952a1f43385608a494bf08b39cfa6ffed6250bf8545713d6": {
-    "query": "\n            select uploaded_at\n            from web_media_upload wmu\n            inner join web_media_library wml on wml.kind = $1\n            where wmu.media_id = $2 for update",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "uploaded_at",
+          "ordinal": 0,
           "type_info": "Timestamptz"
         }
+      ],
+      "nullable": [
+        true
       ],
       "parameters": {
         "Left": [
           "Int2",
           "Uuid"
         ]
-      },
-      "nullable": [
-        true
-      ]
-    }
+      }
+    },
+    "query": "\n            select uploaded_at\n            from web_media_upload wmu\n            inner join web_media_library wml on wml.kind = $1\n            where wmu.media_id = $2 for update"
   },
   "5d39b246259043965846dc0fd205dc25a7a1263d74d2a6451b15c70052ec4844": {
-    "query": "delete from image_upload where image_id = $1",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
-  },
-  "5d508a44a8a4b9151654f4fc46ada307f9b3e288972f7f76578ccab07ec117c7": {
-    "query": "with recursive links as\n                   (\n                       select id,\n                              parent_id\n                       from category co\n                       where id = any ($1::uuid[])\n                       union all\n                       select co.id,\n                              co.parent_id\n                       from category co\n                                inner join links ct on (ct.parent_id = co.id)\n                   )\n\nselect distinct id,\n       category.parent_id,\n       name,\n       category.index,\n       created_at,\n       updated_at,\n       (select count(*) from image_category where category_id = id)::int8 as \"image_count!\",\n       (select count(distinct jig.id)::int8\n        from jig\n                 join jig_data_category on (jig.live_id = jig_data_id or jig.draft_id = jig_data_id)\n        where category_id = id)                                           as \"jig_count!\",\n        user_scopes\nfrom category\n         inner join links using (id);\n",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 1,
-          "name": "parent_id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 2,
-          "name": "name",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 3,
-          "name": "index",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 4,
-          "name": "created_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 5,
-          "name": "updated_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 6,
-          "name": "image_count!",
-          "type_info": "Int8"
-        },
-        {
-          "ordinal": 7,
-          "name": "jig_count!",
-          "type_info": "Int8"
-        },
-        {
-          "ordinal": 8,
-          "name": "user_scopes",
-          "type_info": "Int2Array"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "UuidArray"
-        ]
-      },
-      "nullable": [
-        false,
-        true,
-        false,
-        false,
-        false,
-        true,
-        null,
-        null,
-        false
-      ]
-    }
+      }
+    },
+    "query": "delete from image_upload where image_id = $1"
   },
   "5d7020b3759281d303b515cf05ae1445d421aabf48d2212565a20faf794e6fc2": {
-    "query": "update category set user_scopes= $1, updated_at = now() where id = $2",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Int2Array",
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "update category set user_scopes= $1, updated_at = now() where id = $2"
   },
   "5daa06279831770307bdc0bbf7ecfad3ba4338634f2b76f518b0d3a93bdbc993": {
-    "query": "\nupdate image_metadata\nset description = $2,\n    translated_description = '{}',\n    updated_at = now()\nwhere id = $1 and $2 is distinct from description",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Text"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\nupdate image_metadata\nset description = $2,\n    translated_description = '{}',\n    updated_at = now()\nwhere id = $1 and $2 is distinct from description"
   },
   "5db8993ee5d00df44d48007636297504ce52b6f236c785cc04e4e39df9f4a3ce": {
-    "query": "\n    update jig_curation_data\n    set age_ranges = $2\n    where jig_id = $1 and $2 is distinct from age_ranges\n                ",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Bool"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\n    update jig_curation_data\n    set age_ranges = $2\n    where jig_id = $1 and $2 is distinct from age_ranges\n                "
   },
   "5e4bfa7c86f036663500b75df28a943c55cbc671a2dd296514568680f1b3733f": {
-    "query": "\nselect id,\n       kind as \"kind: MediaKind\",\n       created_at,\n       updated_at,\n       array(select media_url from web_media_library_url where media_id = id) as \"urls!\"\nfrom web_media_library\nwhere id = (select media_id from web_media_library_url where media_url = $1)\n",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id",
+          "ordinal": 0,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 1,
           "name": "kind: MediaKind",
+          "ordinal": 1,
           "type_info": "Int2"
         },
         {
-          "ordinal": 2,
           "name": "created_at",
+          "ordinal": 2,
           "type_info": "Timestamptz"
         },
         {
-          "ordinal": 3,
           "name": "updated_at",
+          "ordinal": 3,
           "type_info": "Timestamptz"
         },
         {
-          "ordinal": 4,
           "name": "urls!",
+          "ordinal": 4,
           "type_info": "TextArray"
         }
       ],
-      "parameters": {
-        "Left": [
-          "Text"
-        ]
-      },
       "nullable": [
         false,
         false,
         false,
         true,
         null
-      ]
-    }
+      ],
+      "parameters": {
+        "Left": [
+          "Text"
+        ]
+      }
+    },
+    "query": "\nselect id,\n       kind as \"kind: MediaKind\",\n       created_at,\n       updated_at,\n       array(select media_url from web_media_library_url where media_id = id) as \"urls!\"\nfrom web_media_library\nwhere id = (select media_id from web_media_library_url where media_url = $1)\n"
   },
   "5f3fd649e82c3d0a8deb3a4c0bd9c6afddb137b24f8b45ed4e673acb8f00b651": {
-    "query": "\nselect draft_id, live_id from jig where id = $1\n",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "draft_id",
+          "ordinal": 0,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 1,
           "name": "live_id",
+          "ordinal": 1,
           "type_info": "Uuid"
         }
+      ],
+      "nullable": [
+        false,
+        false
       ],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": [
-        false,
-        false
-      ]
-    }
+      }
+    },
+    "query": "\nselect draft_id, live_id from jig where id = $1\n"
   },
   "5ff5fa2a87043688acf1a71be7f3a293bd4cad618ed473b7ef536a116dabf50c": {
-    "query": "\n    update jig_curation_data\n    set description = $2\n    where jig_id = $1 and $2 is distinct from description\n                ",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Bool"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\n    update jig_curation_data\n    set description = $2\n    where jig_id = $1 and $2 is distinct from description\n                "
   },
   "6022c1b3fa61fd8de70432380a299ffad5bb5cbf9cd6ccea335c0a8973d258e7": {
-    "query": "\nupdate user_profile\nset profile_image_id = $2\nwhere user_id = $1 and profile_image_id is distinct from $2\n        ",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
-  },
-  "61200a1c7428f0933508dc4fa8a44b5ff5e10e4b281e119f8f7b527887c326dd": {
-    "query": "\nselect id,\n       parent_id,\n       name,\n       index,\n       created_at,\n       updated_at,\n       (select count(*) from image_category where category_id = id)::int8 as \"image_count!\",\n       (select count(*) from jig_data_category where category_id = id)::int8 as \"jig_count!\",\n       user_scopes\nfrom category\norder by index\n",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 1,
-          "name": "parent_id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 2,
-          "name": "name",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 3,
-          "name": "index",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 4,
-          "name": "created_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 5,
-          "name": "updated_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 6,
-          "name": "image_count!",
-          "type_info": "Int8"
-        },
-        {
-          "ordinal": 7,
-          "name": "jig_count!",
-          "type_info": "Int8"
-        },
-        {
-          "ordinal": 8,
-          "name": "user_scopes",
-          "type_info": "Int2Array"
-        }
-      ],
-      "parameters": {
-        "Left": []
-      },
-      "nullable": [
-        false,
-        true,
-        false,
-        false,
-        false,
-        true,
-        null,
-        null,
-        false
-      ]
-    }
+      }
+    },
+    "query": "\nupdate user_profile\nset profile_image_id = $2\nwhere user_id = $1 and profile_image_id is distinct from $2\n        "
   },
   "620638cd11c57d625c799e1d5ada2d57161cb59e06559bc3bd7ee3e3e3a8d5ee": {
-    "query": "\nselect exists(select 1 from user_image_library where user_id = $1 and id = $2) as \"exists!\"\n    ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "exists!",
+          "ordinal": 0,
           "type_info": "Bool"
         }
       ],
+      "nullable": [
+        null
+      ],
       "parameters": {
         "Left": [
           "Uuid",
           "Uuid"
         ]
-      },
-      "nullable": [
-        null
-      ]
-    }
+      }
+    },
+    "query": "\nselect exists(select 1 from user_image_library where user_id = $1 and id = $2) as \"exists!\"\n    "
   },
   "62d96e4b30f7828cbc7255b3be93f16aa1a868bd5a9780ae80079dbbfe858694": {
-    "query": "\ninsert into jig_data_additional_resource (jig_data_id, resource_type_id, resource_content, display_name)\nvalues ((select draft_id from jig where id = $1), $2, $3, $4)\nreturning id as \"id!: AdditionalResourceId\"\n        ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id!: AdditionalResourceId",
+          "ordinal": 0,
           "type_info": "Uuid"
         }
+      ],
+      "nullable": [
+        false
       ],
       "parameters": {
         "Left": [
@@ -2526,215 +2338,215 @@
           "Jsonb",
           "Text"
         ]
-      },
-      "nullable": [
-        false
-      ]
-    }
+      }
+    },
+    "query": "\ninsert into jig_data_additional_resource (jig_data_id, resource_type_id, resource_content, display_name)\nvalues ((select draft_id from jig where id = $1), $2, $3, $4)\nreturning id as \"id!: AdditionalResourceId\"\n        "
   },
   "63282a245bbfff4db34ea00a9f53cf8f6cbbd26ff4106d3b53f3edf3e48197d0": {
-    "query": "\nselect image_id as \"id: ImageId\", media_library as \"library: MediaLibrary\", last_used as \"last_used: DateTime<Utc>\"\nfrom user_recent_image\nwhere user_id = $1\norder by last_used desc\nlimit $2\n            ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id: ImageId",
+          "ordinal": 0,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 1,
           "name": "library: MediaLibrary",
+          "ordinal": 1,
           "type_info": "Int2"
         },
         {
-          "ordinal": 2,
           "name": "last_used: DateTime<Utc>",
+          "ordinal": 2,
           "type_info": "Timestamptz"
         }
+      ],
+      "nullable": [
+        false,
+        false,
+        false
       ],
       "parameters": {
         "Left": [
           "Uuid",
           "Int8"
         ]
-      },
-      "nullable": [
-        false,
-        false,
-        false
-      ]
-    }
+      }
+    },
+    "query": "\nselect image_id as \"id: ImageId\", media_library as \"library: MediaLibrary\", last_used as \"last_used: DateTime<Utc>\"\nfrom user_recent_image\nwhere user_id = $1\norder by last_used desc\nlimit $2\n            "
   },
   "63a9ba01a124f3d9755abb0c3649bc0224d1ac27f4fe3fb52399cde83d266fd0": {
-    "query": "\n            select subject_id as \"id: SubjectId\", display_name, created_at, updated_at from subject\n            order by index\n        ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id: SubjectId",
+          "ordinal": 0,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 1,
           "name": "display_name",
+          "ordinal": 1,
           "type_info": "Text"
         },
         {
-          "ordinal": 2,
           "name": "created_at",
+          "ordinal": 2,
           "type_info": "Timestamptz"
         },
         {
-          "ordinal": 3,
           "name": "updated_at",
+          "ordinal": 3,
           "type_info": "Timestamptz"
         }
       ],
-      "parameters": {
-        "Left": []
-      },
       "nullable": [
         false,
         false,
         false,
         true
-      ]
-    }
+      ],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "\n            select subject_id as \"id: SubjectId\", display_name, created_at, updated_at from subject\n            order by index\n        "
   },
   "64cfdb8662f781313ee5765279e6d4b9a03cc12c3873a00386e94a1eda9e472b": {
-    "query": "\nwith delete as (\n        delete from user_font\n    where user_id = $1 and index = $2\n)\nselect 1 as discard\nfrom user_font\nwhere user_id = $1 and index > $2\nfor update\n        ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "discard",
+          "ordinal": 0,
           "type_info": "Int4"
         }
+      ],
+      "nullable": [
+        null
       ],
       "parameters": {
         "Left": [
           "Uuid",
           "Int2"
         ]
-      },
-      "nullable": [
-        null
-      ]
-    }
+      }
+    },
+    "query": "\nwith delete as (\n        delete from user_font\n    where user_id = $1 and index = $2\n)\nselect 1 as discard\nfrom user_font\nwhere user_id = $1 and index > $2\nfor update\n        "
   },
   "65128054686ca484939559c5f09dd4ff6fae8fd4afe478a479718fd2d89d1cc2": {
-    "query": "\nselect jig_data.id,\n       description                                                                                    \nfrom jig_data\nwhere description <> '' and translated_description = '{}'\nand draft_or_live is not NULL\norder by coalesce(updated_at, created_at) desc\nlimit 50 for no key update skip locked;\n ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id",
+          "ordinal": 0,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 1,
           "name": "description",
+          "ordinal": 1,
           "type_info": "Text"
         }
       ],
-      "parameters": {
-        "Left": []
-      },
       "nullable": [
         false,
         false
-      ]
-    }
+      ],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "\nselect jig_data.id,\n       description                                                                                    \nfrom jig_data\nwhere description <> '' and translated_description = '{}'\nand draft_or_live is not NULL\norder by coalesce(updated_at, created_at) desc\nlimit 50 for no key update skip locked;\n "
   },
   "65bbbe5cb9eba5f0bf454b10f8b07ccf8eb3f519970d09868b486cbaa7d560a1": {
-    "query": "delete from category where id = $1 returning index, parent_id",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "index",
+          "ordinal": 0,
           "type_info": "Int2"
         },
         {
-          "ordinal": 1,
           "name": "parent_id",
+          "ordinal": 1,
           "type_info": "Uuid"
         }
+      ],
+      "nullable": [
+        false,
+        true
       ],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": [
-        false,
-        true
-      ]
-    }
+      }
+    },
+    "query": "delete from category where id = $1 returning index, parent_id"
   },
   "674424a88094e0ceb29cc4c2c4548cc97162b931eff9316fcdb78ede5cf7d7da": {
-    "query": "\nupdate jig_admin_data\nset blocked = coalesce($2, blocked)\nwhere jig_id = $1 and $2 is distinct from blocked\n            ",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Bool"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\nupdate jig_admin_data\nset blocked = coalesce($2, blocked)\nwhere jig_id = $1 and $2 is distinct from blocked\n            "
   },
   "684289dd550908cfb5adac9278ac9beb606e7d0ac91d8aa8a95d81100f357c3c": {
-    "query": "\n    insert into jig_report(jig_id, report_type)\n    values ($1, $2)\n    returning id as \"id!: ReportId\"\n            ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id!: ReportId",
+          "ordinal": 0,
           "type_info": "Uuid"
         }
+      ],
+      "nullable": [
+        false
       ],
       "parameters": {
         "Left": [
           "Uuid",
           "Int2"
         ]
-      },
-      "nullable": [
-        false
-      ]
-    }
+      }
+    },
+    "query": "\n    insert into jig_report(jig_id, report_type)\n    values ($1, $2)\n    returning id as \"id!: ReportId\"\n            "
   },
   "68a6cedcf31dbac17f23ec2cf4cdead5973b0bf72e32708d64e680ecc2997f6b": {
-    "query": "\nselect play_count from jig_play_count\nwhere jig_id = $1;\n            ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "play_count",
+          "ordinal": 0,
           "type_info": "Int8"
         }
+      ],
+      "nullable": [
+        false
       ],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": [
-        false
-      ]
-    }
+      }
+    },
+    "query": "\nselect play_count from jig_play_count\nwhere jig_id = $1;\n            "
   },
   "695f61600966e7be0be50f3536900ac2a78517c4ef39c5386cd8f7936119ffa3": {
-    "query": "\ninsert into jig_data\n   (display_name, language, description, direction, display_score, track_assessments, drag_assist, draft_or_live)\nvalues ($1, $2, $3, $4, $5, $6, $7, $8)\nreturning id\n",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id",
+          "ordinal": 0,
           "type_info": "Uuid"
         }
+      ],
+      "nullable": [
+        false
       ],
       "parameters": {
         "Left": [
@@ -2747,87 +2559,129 @@
           "Bool",
           "Int2"
         ]
-      },
-      "nullable": [
-        false
-      ]
-    }
+      }
+    },
+    "query": "\ninsert into jig_data\n   (display_name, language, description, direction, display_score, track_assessments, drag_assist, draft_or_live)\nvalues ($1, $2, $3, $4, $5, $6, $7, $8)\nreturning id\n"
   },
   "69b512127b70875985bb54e50242397b7e362535b1a338276778abde7b695787": {
-    "query": "update user_color set color = $3 where user_id = $1 and index = $2",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Int2",
           "Int4"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "update user_color set color = $3 where user_id = $1 and index = $2"
   },
   "6a2fcbea5b62e0a5c0eb65c28769c1b3e70e3376f664d5ad84c864aaef8f0548": {
-    "query": "update global_animation_upload set uploaded_at = now(), processing_result = null where animation_id = $1",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "update global_animation_upload set uploaded_at = now(), processing_result = null where animation_id = $1"
   },
-  "6db1735f61450670c2ca115000a413f3b2eb9d4874eeec7e749f6243b2db5f7d": {
-    "query": "select user_id from user_email where email = $1::text",
+  "6ad4df2298dcd688eb035ff09918b592e3be2dac06b5ffb13012fb166daa814b": {
     "describe": {
       "columns": [
         {
+          "name": "id: CategoryId",
           "ordinal": 0,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "name",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "created_at",
+          "ordinal": 2,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "updated_at",
+          "ordinal": 3,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "user_scopes",
+          "ordinal": 4,
+          "type_info": "Int2Array"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        true,
+        false
+      ],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "\nselect id                                                                 as \"id: CategoryId\",\n       name,\n       created_at,\n       updated_at,\n       user_scopes\nfrom category\nwhere parent_id is null\norder by index\n "
+  },
+  "6db1735f61450670c2ca115000a413f3b2eb9d4874eeec7e749f6243b2db5f7d": {
+    "describe": {
+      "columns": [
+        {
           "name": "user_id",
+          "ordinal": 0,
           "type_info": "Uuid"
         }
+      ],
+      "nullable": [
+        false
       ],
       "parameters": {
         "Left": [
           "Text"
         ]
-      },
-      "nullable": [
-        false
-      ]
-    }
+      }
+    },
+    "query": "select user_id from user_email where email = $1::text"
   },
   "6dcc3e22fd2bb64cec50f447237de2968384af1de326d4b26b8816611f2cc2e5": {
-    "query": "select algolia_index_version != $1 as \"outdated!\" from settings",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "outdated!",
+          "ordinal": 0,
           "type_info": "Bool"
         }
+      ],
+      "nullable": [
+        null
       ],
       "parameters": {
         "Left": [
           "Int2"
         ]
-      },
-      "nullable": [
-        null
-      ]
-    }
+      }
+    },
+    "query": "select algolia_index_version != $1 as \"outdated!\" from settings"
   },
   "6f88dced30ef38b92e48c5b78cda75cfc877dff08195c25609ad0f19ddff49cc": {
-    "query": "\ninsert into image_metadata (name, description, is_premium, publish_at, kind) values ($1, $2, $3, $4, $5)\nreturning id as \"id: ImageId\"\n        ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id: ImageId",
+          "ordinal": 0,
           "type_info": "Uuid"
         }
+      ],
+      "nullable": [
+        false
       ],
       "parameters": {
         "Left": [
@@ -2837,109 +2691,109 @@
           "Timestamptz",
           "Int2"
         ]
-      },
-      "nullable": [
-        false
-      ]
-    }
+      }
+    },
+    "query": "\ninsert into image_metadata (name, description, is_premium, publish_at, kind) values ($1, $2, $3, $4, $5)\nreturning id as \"id: ImageId\"\n        "
   },
   "701de512b57a7bb90c579f09319277ac921dff5152c1fb8a2bc1d8bc0548504a": {
-    "query": "\nselect exists(\n        select 1\n        from user_color\n        where user_id = $1\n            and index = $2\n        for update\n) as \"exists!\"",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "exists!",
+          "ordinal": 0,
           "type_info": "Bool"
         }
+      ],
+      "nullable": [
+        null
       ],
       "parameters": {
         "Left": [
           "Uuid",
           "Int2"
         ]
-      },
-      "nullable": [
-        null
-      ]
-    }
+      }
+    },
+    "query": "\nselect exists(\n        select 1\n        from user_color\n        where user_id = $1\n            and index = $2\n        for update\n) as \"exists!\""
   },
   "72b024e92b7f83b7e9fbb725e9955b62d22c676d62a8bbe2ce46be9cb163a991": {
-    "query": "update image_upload set uploaded_at = now(), processing_result = null where image_id = $1",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "update image_upload set uploaded_at = now(), processing_result = null where image_id = $1"
   },
   "72e3aca05740c8e1615e5e90644ce5edcf661280ab2b72b5f6af4932618ce5ab": {
-    "query": "\ninsert into user_audio_library default values\nreturning id as \"id: AudioId\"\n",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id: AudioId",
+          "ordinal": 0,
           "type_info": "Uuid"
         }
       ],
-      "parameters": {
-        "Left": []
-      },
       "nullable": [
         false
-      ]
-    }
+      ],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "\ninsert into user_audio_library default values\nreturning id as \"id: AudioId\"\n"
   },
   "7325c7ed63eb3cf5405a37c590c086cb0f1c457f27f6b53eacd26bb6dac849ec": {
-    "query": "insert into user_image_upload (image_id) values ($1)",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "insert into user_image_upload (image_id) values ($1)"
   },
   "739d2d716267f671e775806df135ccdcbbbc12e0fc4398a07de6235f71bddd6b": {
-    "query": "update web_media_upload set processed_at = now(), processing_result = true where media_id = $1",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "update web_media_upload set processed_at = now(), processing_result = true where media_id = $1"
   },
   "73e6d12163642604e2ab682da08c141d29e8e19665979d7de7ec5e59b507ffc2": {
-    "query": "\ninsert into jig_data_age_range(jig_data_id, age_range_id)\nselect $2, age_range_id\nfrom jig_data_age_range\nwhere jig_data_id = $1\n        ",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\ninsert into jig_data_age_range(jig_data_id, age_range_id)\nselect $2, age_range_id\nfrom jig_data_age_range\nwhere jig_data_id = $1\n        "
   },
   "73f764f872bffc9e08fe85ba34a7b52d7c9e645095e3b1e4cec6a0b1d5b27d2d": {
-    "query": "\ninsert into animation_metadata (name, description, is_premium, publish_at, kind, is_looping) values ($1, $2, $3, $4, $5, $6)\nreturning id as \"id: AnimationId\"\n        ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id: AnimationId",
+          "ordinal": 0,
           "type_info": "Uuid"
         }
+      ],
+      "nullable": [
+        false
       ],
       "parameters": {
         "Left": [
@@ -2950,77 +2804,77 @@
           "Int2",
           "Bool"
         ]
-      },
-      "nullable": [
-        false
-      ]
-    }
+      }
+    },
+    "query": "\ninsert into animation_metadata (name, description, is_premium, publish_at, kind, is_looping) values ($1, $2, $3, $4, $5, $6)\nreturning id as \"id: AnimationId\"\n        "
   },
   "74b512fde797ad5d92d4a9fca1ce7d546e799815ed95169ad0591de8db129393": {
-    "query": "\nselect user_id\nfrom user_auth_basic\nwhere\n    email = $1::text and\n    not exists(select 1 from user_email where email = $1)\n",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "user_id",
+          "ordinal": 0,
           "type_info": "Uuid"
         }
+      ],
+      "nullable": [
+        false
       ],
       "parameters": {
         "Left": [
           "Text"
         ]
-      },
-      "nullable": [
-        false
-      ]
-    }
+      }
+    },
+    "query": "\nselect user_id\nfrom user_auth_basic\nwhere\n    email = $1::text and\n    not exists(select 1 from user_email where email = $1)\n"
   },
   "758bee136eaae799c8beef0e069597d0f67cfc590d5ecc6a4353d24b3474e39b": {
-    "query": "\n        select index as \"index: ImageTagIndex\", display_name, created_at, updated_at from \"image_tag\"\n        order by index\n    ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "index: ImageTagIndex",
+          "ordinal": 0,
           "type_info": "Int2"
         },
         {
-          "ordinal": 1,
           "name": "display_name",
+          "ordinal": 1,
           "type_info": "Text"
         },
         {
-          "ordinal": 2,
           "name": "created_at",
+          "ordinal": 2,
           "type_info": "Timestamptz"
         },
         {
-          "ordinal": 3,
           "name": "updated_at",
+          "ordinal": 3,
           "type_info": "Timestamptz"
         }
       ],
-      "parameters": {
-        "Left": []
-      },
       "nullable": [
         false,
         false,
         false,
         true
-      ]
-    }
+      ],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "\n        select index as \"index: ImageTagIndex\", display_name, created_at, updated_at from \"image_tag\"\n        order by index\n    "
   },
   "75e02a67b94a983658f9fd56de48e3eb99738391c236ba6cbba1e1d6b42ad4fb": {
-    "query": "\nselect count(distinct jig_data.id) as \"count!: i64\"\nfrom jig_data\nleft join jig on (draft_id = jig_data.id or (live_id = jig_data.id and last_synced_at is not null))\nleft join jig_admin_data \"admin\" on admin.jig_id = jig.id\nleft join jig_data_additional_resource \"resource\" on jig_data.id = resource.jig_data_id\nwhere (author_id = $1 or $1 is null)\n    and (jig_data.draft_or_live = $3 or $3 is null)\n    and (jig_focus = $2 or $2 is null)\n    and (jig_data.privacy_level = any($4) or $4 = array[]::smallint[])\n    and (blocked = $5 or $5 is null)\n    and (resource.resource_type_id = any($6) or $6 = array[]::uuid[])\n",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "count!: i64",
+          "ordinal": 0,
           "type_info": "Int8"
         }
+      ],
+      "nullable": [
+        null
       ],
       "parameters": {
         "Left": [
@@ -3031,211 +2885,209 @@
           "Bool",
           "UuidArray"
         ]
-      },
-      "nullable": [
-        null
-      ]
-    }
+      }
+    },
+    "query": "\nselect count(distinct jig_data.id) as \"count!: i64\"\nfrom jig_data\nleft join jig on (draft_id = jig_data.id or (live_id = jig_data.id and last_synced_at is not null))\nleft join jig_admin_data \"admin\" on admin.jig_id = jig.id\nleft join jig_data_additional_resource \"resource\" on jig_data.id = resource.jig_data_id\nwhere (author_id = $1 or $1 is null)\n    and (jig_data.draft_or_live = $3 or $3 is null)\n    and (jig_focus = $2 or $2 is null)\n    and (jig_data.privacy_level = any($4) or $4 = array[]::smallint[])\n    and (blocked = $5 or $5 is null)\n    and (resource.resource_type_id = any($6) or $6 = array[]::uuid[])\n"
   },
   "760185608bd03a9a30aba9100ecc18e170aed0b1008c5f51ad0c7c6f564b090e": {
-    "query": "select user_id from user_auth_google where google_id = $1",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "user_id",
+          "ordinal": 0,
           "type_info": "Uuid"
         }
+      ],
+      "nullable": [
+        false
       ],
       "parameters": {
         "Left": [
           "Text"
         ]
-      },
-      "nullable": [
-        false
-      ]
-    }
+      }
+    },
+    "query": "select user_id from user_auth_google where google_id = $1"
   },
   "76f5138776b2544741d5bd7a20298dd4309fa398f23fac98b74873899a0f88b3": {
-    "query": "\ninsert into image_tag (index, display_name)\nvalues ($1, $2)\nreturning index as \"index: ImageTagIndex\", display_name\n            ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "index: ImageTagIndex",
+          "ordinal": 0,
           "type_info": "Int2"
         },
         {
-          "ordinal": 1,
           "name": "display_name",
+          "ordinal": 1,
           "type_info": "Text"
         }
+      ],
+      "nullable": [
+        false,
+        false
       ],
       "parameters": {
         "Left": [
           "Int2",
           "Text"
         ]
-      },
-      "nullable": [
-        false,
-        false
-      ]
-    }
+      }
+    },
+    "query": "\ninsert into image_tag (index, display_name)\nvalues ($1, $2)\nreturning index as \"index: ImageTagIndex\", display_name\n            "
   },
   "79bce8bafae973dfdb2932091ebeeed4f007ecf2849cc8c859d45a1fea68a251": {
-    "query": "\ndelete from jig_like\nwhere jig_id = $1 and user_id = $2\n    ",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\ndelete from jig_like\nwhere jig_id = $1 and user_id = $2\n    "
   },
   "7a3746ec8866c890e58cd4e3cd5a876235b1b9b116d9f5fbb7aab1187000c86f": {
-    "query": "insert into web_media_upload (media_id, uploaded_at) values ($1, now())",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "insert into web_media_upload (media_id, uploaded_at) values ($1, now())"
   },
   "7c52442554186edb177fcd9dca9083748cd77443e1a0923be7de29cf0c811fdd": {
-    "query": "\nupdate image_metadata\nset name        = coalesce($2, name),\n    is_premium  = coalesce($3, is_premium),\n    updated_at  = now()\nwhere id = $1\n  and (($2::text is not null and $2 is distinct from name) or\n       ($3::boolean is not null and $3 is distinct from is_premium))",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Text",
           "Bool"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\nupdate image_metadata\nset name        = coalesce($2, name),\n    is_premium  = coalesce($3, is_premium),\n    updated_at  = now()\nwhere id = $1\n  and (($2::text is not null and $2 is distinct from name) or\n       ($3::boolean is not null and $3 is distinct from is_premium))"
   },
   "7de388b21267e45c30f82ed5f18a433423d535b7e22a752bcd95c82fc050190e": {
-    "query": "select count(*) - 1 as \"max_index!\" from jig_data_module where jig_data_id = $1",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "max_index!",
+          "ordinal": 0,
           "type_info": "Int8"
         }
+      ],
+      "nullable": [
+        null
       ],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": [
-        null
-      ]
-    }
+      }
+    },
+    "query": "select count(*) - 1 as \"max_index!\" from jig_data_module where jig_data_id = $1"
   },
   "7f4908d542be3a32a0d877287e49a87f69834904c30affc1dce2454cd0c8d4de": {
-    "query": "\nupdate jig_data\nset privacy_level = coalesce($2, privacy_level)\nwhere id = $1\n  and $2 is distinct from privacy_level\n    ",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Int2"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\nupdate jig_data\nset privacy_level = coalesce($2, privacy_level)\nwhere id = $1\n  and $2 is distinct from privacy_level\n    "
   },
   "7fc1aef6a00aa47799aa01f4313417b431ea5230c52a4ceddcde7139305310b1": {
-    "query": "\n        select jig_id as \"jig_id: JigId\", \n               direction as \"direction: TextDirection\", \n               display_score, \n               track_assessments, \n               drag_assist\n        from jig_player_session\n        where index=$1\n        ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "jig_id: JigId",
+          "ordinal": 0,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 1,
           "name": "direction: TextDirection",
+          "ordinal": 1,
           "type_info": "Int2"
         },
         {
-          "ordinal": 2,
           "name": "display_score",
+          "ordinal": 2,
           "type_info": "Bool"
         },
         {
-          "ordinal": 3,
           "name": "track_assessments",
+          "ordinal": 3,
           "type_info": "Bool"
         },
         {
-          "ordinal": 4,
           "name": "drag_assist",
+          "ordinal": 4,
           "type_info": "Bool"
         }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false
       ],
       "parameters": {
         "Left": [
           "Int2"
         ]
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false
-      ]
-    }
+      }
+    },
+    "query": "\n        select jig_id as \"jig_id: JigId\", \n               direction as \"direction: TextDirection\", \n               display_score, \n               track_assessments, \n               drag_assist\n        from jig_player_session\n        where index=$1\n        "
   },
   "80e114ec0b610550438d73280239678e249985eb19134c9917b39b34ead292c6": {
-    "query": "select id as \"id: ImageId\" from user_image_library where id = $1",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id: ImageId",
+          "ordinal": 0,
           "type_info": "Uuid"
         }
+      ],
+      "nullable": [
+        false
       ],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": [
-        false
-      ]
-    }
+      }
+    },
+    "query": "select id as \"id: ImageId\" from user_image_library where id = $1"
   },
   "81d346d41686f94b2bbb1477d0e7e407d67e12bb2c2cccfb474c536ddd8f0eeb": {
-    "query": "update user_image_upload set processed_at = now(), processing_result = false where image_id = $1",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "update user_image_upload set processed_at = now(), processing_result = false where image_id = $1"
   },
   "82de08cbfe2a726089a5d9277cca6c2e3e4796c5ff2ff9303959957706e47a1d": {
-    "query": "\ninsert into user_profile\n    (user_id, username, over_18, given_name, family_name, profile_image_id, language, locale, timezone, opt_into_edu_resources, organization, persona, location)\nvalues\n    ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)\non conflict (user_id) do update\nset\n    over_18 = $3,\n    given_name = $4,\n    family_name = $5,\n    profile_image_id = $6,\n    language = $7,\n    locale = $8,\n    timezone = $9,\n    opt_into_edu_resources = $10,\n    organization = $11,\n    persona = $12,\n    location = $13\n",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
@@ -3252,226 +3104,284 @@
           "TextArray",
           "Jsonb"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\ninsert into user_profile\n    (user_id, username, over_18, given_name, family_name, profile_image_id, language, locale, timezone, opt_into_edu_resources, organization, persona, location)\nvalues\n    ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)\non conflict (user_id) do update\nset\n    over_18 = $3,\n    given_name = $4,\n    family_name = $5,\n    profile_image_id = $6,\n    language = $7,\n    locale = $8,\n    timezone = $9,\n    opt_into_edu_resources = $10,\n    organization = $11,\n    persona = $12,\n    location = $13\n"
   },
   "82fb52aa41cccc3af1b68d0266aa291db61b2b33adf95590022f86ac1a56f7fa": {
-    "query": "update user_pdf_upload set uploaded_at = now(), processing_result = null where pdf_id = $1",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "update user_pdf_upload set uploaded_at = now(), processing_result = null where pdf_id = $1"
   },
   "8313a67bf42c71861a5f4935f1cd53fda46e3da275e46cdaa266a785595b8cd1": {
-    "query": "select id as \"id: AudioId\" from user_audio_library where id = $1",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id: AudioId",
+          "ordinal": 0,
           "type_info": "Uuid"
         }
+      ],
+      "nullable": [
+        false
       ],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": [
-        false
-      ]
-    }
+      }
+    },
+    "query": "select id as \"id: AudioId\" from user_audio_library where id = $1"
   },
   "83a19967d79935450a0c984ec7c3cde0626f3347618e8dd1d84e883f73ae2898": {
-    "query": "update image_metadata set last_synced_at = now() where id = any($1)",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "UuidArray"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "update image_metadata set last_synced_at = now() where id = any($1)"
   },
-  "84f05210fc0d761dda68090751705c6448814262eab6eae4c3c1fc04290cf357": {
-    "query": "insert into web_media_library (\"hash\", kind) values($1, $2) returning id",
+  "84519449aef6978269fca20ecf493b800916711dc260fff2b2fdc537842fc947": {
     "describe": {
       "columns": [
         {
+          "name": "id!",
           "ordinal": 0,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "index!",
+          "ordinal": 1,
+          "type_info": "Int2"
+        },
+        {
+          "name": "parent_id",
+          "ordinal": 2,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "name",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "created_at",
+          "ordinal": 4,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "updated_at",
+          "ordinal": 5,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "user_scopes",
+          "ordinal": 6,
+          "type_info": "Int2Array"
+        }
+      ],
+      "nullable": [
+        null,
+        null,
+        null,
+        false,
+        false,
+        true,
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "UuidArray"
+        ]
+      }
+    },
+    "query": "with recursive path(id, index, parent_id) as (\n    select id, ord, null::uuid\n    from category\n             inner join unnest(\n            $1::uuid[]) with ordinality t(id, ord)\n                        using (id)\n    union all\n    select c.id, c.index, p.id\n    from path p\n             inner join category c on (c.parent_id = p.id)\n)\nselect distinct id as \"id!\",\n       path.index::int2 as \"index!\",\n       path.parent_id,\n       name,\n       created_at,\n       updated_at,\n       user_scopes\n\nfrom path\n         inner join category using (id);\n"
+  },
+  "84f05210fc0d761dda68090751705c6448814262eab6eae4c3c1fc04290cf357": {
+    "describe": {
+      "columns": [
+        {
           "name": "id",
+          "ordinal": 0,
           "type_info": "Uuid"
         }
+      ],
+      "nullable": [
+        false
       ],
       "parameters": {
         "Left": [
           "Bytea",
           "Int2"
         ]
-      },
-      "nullable": [
-        false
-      ]
-    }
+      }
+    },
+    "query": "insert into web_media_library (\"hash\", kind) values($1, $2) returning id"
   },
   "8731b3b67aae4e9ceaab3893d91215f857dbe9642a301409ebc50fc1860342b6": {
-    "query": "\nselect\n    id as \"id: u32\",\n    bundle_id,\n    section,\n    item_kind_id,\n    english,\n    hebrew,\n    status as \"status: EntryStatus\",\n    zeplin_reference,\n    comments,\n    in_app, \n    in_element, \n    in_mock\nfrom locale_entry\nwhere $2 or bundle_id = any($1)\norder by id\n",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id: u32",
+          "ordinal": 0,
           "type_info": "Int4"
         },
         {
-          "ordinal": 1,
           "name": "bundle_id",
+          "ordinal": 1,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 2,
           "name": "section",
+          "ordinal": 2,
           "type_info": "Text"
         },
         {
-          "ordinal": 3,
           "name": "item_kind_id",
+          "ordinal": 3,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 4,
           "name": "english",
+          "ordinal": 4,
           "type_info": "Text"
         },
         {
-          "ordinal": 5,
           "name": "hebrew",
+          "ordinal": 5,
           "type_info": "Text"
         },
         {
-          "ordinal": 6,
           "name": "status: EntryStatus",
+          "ordinal": 6,
           "type_info": "Int2"
         },
         {
-          "ordinal": 7,
           "name": "zeplin_reference",
+          "ordinal": 7,
           "type_info": "Text"
         },
         {
-          "ordinal": 8,
           "name": "comments",
+          "ordinal": 8,
           "type_info": "Text"
         },
         {
-          "ordinal": 9,
           "name": "in_app",
+          "ordinal": 9,
           "type_info": "Bool"
         },
         {
-          "ordinal": 10,
           "name": "in_element",
+          "ordinal": 10,
           "type_info": "Bool"
         },
         {
-          "ordinal": 11,
           "name": "in_mock",
+          "ordinal": 11,
           "type_info": "Bool"
         }
+      ],
+      "nullable": [
+        false,
+        false,
+        true,
+        true,
+        true,
+        true,
+        false,
+        true,
+        true,
+        false,
+        false,
+        false
       ],
       "parameters": {
         "Left": [
           "UuidArray",
           "Bool"
         ]
-      },
-      "nullable": [
-        false,
-        false,
-        true,
-        true,
-        true,
-        true,
-        false,
-        true,
-        true,
-        false,
-        false,
-        false
-      ]
-    }
+      }
+    },
+    "query": "\nselect\n    id as \"id: u32\",\n    bundle_id,\n    section,\n    item_kind_id,\n    english,\n    hebrew,\n    status as \"status: EntryStatus\",\n    zeplin_reference,\n    comments,\n    in_app, \n    in_element, \n    in_mock\nfrom locale_entry\nwhere $2 or bundle_id = any($1)\norder by id\n"
   },
   "87c78754f010d2cd7d18cc1024071cfd6d00983eb0d01153d7b4ad368ba20f71": {
-    "query": "\nselect exists(select 1 from user_scope where user_id = $1 and scope = any($2)) as \"authed!\"\n",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "authed!",
+          "ordinal": 0,
           "type_info": "Bool"
         }
+      ],
+      "nullable": [
+        null
       ],
       "parameters": {
         "Left": [
           "Uuid",
           "Int2Array"
         ]
-      },
-      "nullable": [
-        null
-      ]
-    }
+      }
+    },
+    "query": "\nselect exists(select 1 from user_scope where user_id = $1 and scope = any($2)) as \"authed!\"\n"
   },
   "87fc2b6aae796b62d4bca602b3d6d99d961677cc1fa42b96b112015927be1d6e": {
-    "query": "\ninsert into user_image_library (user_id, kind)\nvalues ($1, $2)\nreturning id as \"id: ImageId\"\n",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id: ImageId",
+          "ordinal": 0,
           "type_info": "Uuid"
         }
+      ],
+      "nullable": [
+        false
       ],
       "parameters": {
         "Left": [
           "Uuid",
           "Int2"
         ]
-      },
-      "nullable": [
-        false
-      ]
-    }
+      }
+    },
+    "query": "\ninsert into user_image_library (user_id, kind)\nvalues ($1, $2)\nreturning id as \"id: ImageId\"\n"
   },
   "886cfa63188f2755838af80e5a1585835cd903063796b378903a0163c255f160": {
-    "query": "update jig set live_id = $1, published_at = now() where id = $2",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "update jig set live_id = $1, published_at = now() where id = $2"
   },
   "890c3176a91e4028feb349523c366a1ff87072efa205b953476e58a5358b3850": {
-    "query": "\n        insert into jig_player_session_instance (session_index, ip_address, user_agent)\n        values ($1, $2, $3)\n        returning id as \"id: Uuid\"\n        ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id: Uuid",
+          "ordinal": 0,
           "type_info": "Uuid"
         }
+      ],
+      "nullable": [
+        false
       ],
       "parameters": {
         "Left": [
@@ -3479,126 +3389,126 @@
           "Text",
           "Text"
         ]
-      },
-      "nullable": [
-        false
-      ]
-    }
+      }
+    },
+    "query": "\n        insert into jig_player_session_instance (session_index, ip_address, user_agent)\n        values ($1, $2, $3)\n        returning id as \"id: Uuid\"\n        "
   },
   "8954f7a250fa53e9bb3ee9e22c807b6013f08b2cf794be6faeac9b2d01cc25e3": {
-    "query": "\ndelete\nfrom jig_data_additional_resource\nwhere jig_data_id = $1\n   or jig_data_id = $2\n    and id = $3\n        ",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Uuid",
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\ndelete\nfrom jig_data_additional_resource\nwhere jig_data_id = $1\n   or jig_data_id = $2\n    and id = $3\n        "
   },
   "89a0dbe7265e411f69b9ea0dc06cb43f7c4290b23e7053af2b1583ae97cdd4ff": {
-    "query": "\nselect id,\n       hash,\n       kind as \"kind: MediaKind\"\nfrom web_media_library\nwhere hash = $1\nfor update\n",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id",
+          "ordinal": 0,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 1,
           "name": "hash",
+          "ordinal": 1,
           "type_info": "Bytea"
         },
         {
-          "ordinal": 2,
           "name": "kind: MediaKind",
+          "ordinal": 2,
           "type_info": "Int2"
         }
+      ],
+      "nullable": [
+        false,
+        false,
+        false
       ],
       "parameters": {
         "Left": [
           "Bytea"
         ]
-      },
-      "nullable": [
-        false,
-        false,
-        false
-      ]
-    }
+      }
+    },
+    "query": "\nselect id,\n       hash,\n       kind as \"kind: MediaKind\"\nfrom web_media_library\nwhere hash = $1\nfor update\n"
   },
   "8b5a14ecfd4982d3bc52a06e56d522b2ab65afecc898e2de015adcaa2b039a93": {
-    "query": "select exists(select 1 from user_auth_basic where email = lower($1)) as \"exists!\"",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "exists!",
+          "ordinal": 0,
           "type_info": "Bool"
         }
+      ],
+      "nullable": [
+        null
       ],
       "parameters": {
         "Left": [
           "Text"
         ]
-      },
-      "nullable": [
-        null
-      ]
-    }
+      }
+    },
+    "query": "select exists(select 1 from user_auth_basic where email = lower($1)) as \"exists!\""
   },
   "8d68bfd788c54445f0c9769db7b644b918ff5909ad934d27a9924b43a75a2c7d": {
-    "query": "\nupdate jig_data_additional_resource\nset display_name = coalesce($2, display_name)\nwhere id = $1 and $2 is distinct from display_name\n            ",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Text"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\nupdate jig_data_additional_resource\nset display_name = coalesce($2, display_name)\nwhere id = $1 and $2 is distinct from display_name\n            "
   },
   "8d817d6384c10aa3eddcbe4b990c830b69970f782ad4ecdd5af9380994dfef0c": {
-    "query": "\nselect media_id,\n       kind as \"kind: MediaKind\"\nfrom web_media_library_url\ninner join web_media_library on id = media_id\nwhere media_url = $1",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "media_id",
+          "ordinal": 0,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 1,
           "name": "kind: MediaKind",
+          "ordinal": 1,
           "type_info": "Int2"
         }
+      ],
+      "nullable": [
+        false,
+        false
       ],
       "parameters": {
         "Left": [
           "Text"
         ]
-      },
-      "nullable": [
-        false,
-        false
-      ]
-    }
+      }
+    },
+    "query": "\nselect media_id,\n       kind as \"kind: MediaKind\"\nfrom web_media_library_url\ninner join web_media_library on id = media_id\nwhere media_url = $1"
   },
   "8dd0d15f8499b6b424752b11db318e0eaa9da44e1067c6ce84f0d02355ebe816": {
-    "query": "insert into jig (creator_id, author_id, live_id, draft_id, jig_focus) values ($1, $1, $2, $3, $4) returning id",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id",
+          "ordinal": 0,
           "type_info": "Uuid"
         }
+      ],
+      "nullable": [
+        false
       ],
       "parameters": {
         "Left": [
@@ -3607,105 +3517,99 @@
           "Uuid",
           "Int2"
         ]
-      },
-      "nullable": [
-        false
-      ]
-    }
+      }
+    },
+    "query": "insert into jig (creator_id, author_id, live_id, draft_id, jig_focus) values ($1, $1, $2, $3, $4) returning id"
   },
   "8e275e9f53e8192c7299a6bed97b2313030df3f9caa7f7824b48da4a86d0fed2": {
-    "query": "\nselect id,\n       name,\n       kind                                                                                     as \"kind!: ImageKind\",\n       description,\n       translated_description                                                                   as \"translated_description!: Json<HashMap<String, String>>\",\n       array((select affiliation_id from image_affiliation where image_id = image_metadata.id)) as \"affiliations!\",\n       array((select affiliation.display_name\n              from affiliation\n                       inner join image_affiliation on affiliation.id = image_affiliation.affiliation_id\n              where image_affiliation.image_id = image_metadata.id))                            as \"affiliation_names!\",\n       array((select style_id from image_style where image_id = image_metadata.id))             as \"styles!\",\n       array((select style.display_name\n              from style\n                       inner join image_style on style.id = image_style.style_id\n              where image_style.image_id = image_metadata.id))                                  as \"style_names!\",\n       array((select age_range_id from image_age_range where image_id = image_metadata.id))     as \"age_ranges!\",\n       array((select age_range.display_name\n              from age_range\n                       inner join image_age_range on age_range.id = image_age_range.age_range_id\n              where image_age_range.image_id = image_metadata.id))                              as \"age_range_names!\",\n       array((select category_id from image_category where image_id = image_metadata.id))       as \"categories!\",\n       array((select name\n              from category\n                       inner join image_category on category.id = image_category.category_id\n              where image_category.image_id = image_metadata.id))                               as \"category_names!\",\n       array((select index\n              from image_tag\n                       inner join image_tag_join on image_tag.index = image_tag_join.tag_index\n              where image_tag_join.image_id = image_metadata.id))                               as \"tags!\",\n       array((select display_name\n              from image_tag\n                       inner join image_tag_join on image_tag.index = image_tag_join.tag_index\n              where image_tag_join.image_id = image_metadata.id))                               as \"tag_names!\",\n       (publish_at < now() is true)                                                             as \"is_published!\",\n       is_premium\nfrom image_metadata\n         join image_upload on id = image_id\nwhere (last_synced_at is null or\n       (updated_at is not null and last_synced_at < updated_at) or\n       (publish_at < now() is true and last_synced_at < publish_at))\n  and processed_at is not null\nlimit 100 for no key update skip locked;\n     ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id",
+          "ordinal": 0,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 1,
           "name": "name",
+          "ordinal": 1,
           "type_info": "Text"
         },
         {
-          "ordinal": 2,
           "name": "kind!: ImageKind",
+          "ordinal": 2,
           "type_info": "Int2"
         },
         {
-          "ordinal": 3,
           "name": "description",
+          "ordinal": 3,
           "type_info": "Text"
         },
         {
-          "ordinal": 4,
           "name": "translated_description!: Json<HashMap<String, String>>",
+          "ordinal": 4,
           "type_info": "Jsonb"
         },
         {
-          "ordinal": 5,
           "name": "affiliations!",
+          "ordinal": 5,
           "type_info": "UuidArray"
         },
         {
-          "ordinal": 6,
           "name": "affiliation_names!",
+          "ordinal": 6,
           "type_info": "TextArray"
         },
         {
-          "ordinal": 7,
           "name": "styles!",
+          "ordinal": 7,
           "type_info": "UuidArray"
         },
         {
-          "ordinal": 8,
           "name": "style_names!",
+          "ordinal": 8,
           "type_info": "TextArray"
         },
         {
-          "ordinal": 9,
           "name": "age_ranges!",
+          "ordinal": 9,
           "type_info": "UuidArray"
         },
         {
-          "ordinal": 10,
           "name": "age_range_names!",
+          "ordinal": 10,
           "type_info": "TextArray"
         },
         {
-          "ordinal": 11,
           "name": "categories!",
+          "ordinal": 11,
           "type_info": "UuidArray"
         },
         {
-          "ordinal": 12,
           "name": "category_names!",
+          "ordinal": 12,
           "type_info": "TextArray"
         },
         {
-          "ordinal": 13,
           "name": "tags!",
+          "ordinal": 13,
           "type_info": "Int2Array"
         },
         {
-          "ordinal": 14,
           "name": "tag_names!",
+          "ordinal": 14,
           "type_info": "TextArray"
         },
         {
-          "ordinal": 15,
           "name": "is_published!",
+          "ordinal": 15,
           "type_info": "Bool"
         },
         {
-          "ordinal": 16,
           "name": "is_premium",
+          "ordinal": 16,
           "type_info": "Bool"
         }
       ],
-      "parameters": {
-        "Left": []
-      },
       "nullable": [
         false,
         false,
@@ -3724,169 +3628,169 @@
         null,
         null,
         false
-      ]
-    }
+      ],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "\nselect id,\n       name,\n       kind                                                                                     as \"kind!: ImageKind\",\n       description,\n       translated_description                                                                   as \"translated_description!: Json<HashMap<String, String>>\",\n       array((select affiliation_id from image_affiliation where image_id = image_metadata.id)) as \"affiliations!\",\n       array((select affiliation.display_name\n              from affiliation\n                       inner join image_affiliation on affiliation.id = image_affiliation.affiliation_id\n              where image_affiliation.image_id = image_metadata.id))                            as \"affiliation_names!\",\n       array((select style_id from image_style where image_id = image_metadata.id))             as \"styles!\",\n       array((select style.display_name\n              from style\n                       inner join image_style on style.id = image_style.style_id\n              where image_style.image_id = image_metadata.id))                                  as \"style_names!\",\n       array((select age_range_id from image_age_range where image_id = image_metadata.id))     as \"age_ranges!\",\n       array((select age_range.display_name\n              from age_range\n                       inner join image_age_range on age_range.id = image_age_range.age_range_id\n              where image_age_range.image_id = image_metadata.id))                              as \"age_range_names!\",\n       array((select category_id from image_category where image_id = image_metadata.id))       as \"categories!\",\n       array((select name\n              from category\n                       inner join image_category on category.id = image_category.category_id\n              where image_category.image_id = image_metadata.id))                               as \"category_names!\",\n       array((select index\n              from image_tag\n                       inner join image_tag_join on image_tag.index = image_tag_join.tag_index\n              where image_tag_join.image_id = image_metadata.id))                               as \"tags!\",\n       array((select display_name\n              from image_tag\n                       inner join image_tag_join on image_tag.index = image_tag_join.tag_index\n              where image_tag_join.image_id = image_metadata.id))                               as \"tag_names!\",\n       (publish_at < now() is true)                                                             as \"is_published!\",\n       is_premium\nfrom image_metadata\n         join image_upload on id = image_id\nwhere (last_synced_at is null or\n       (updated_at is not null and last_synced_at < updated_at) or\n       (publish_at < now() is true and last_synced_at < publish_at))\n  and processed_at is not null\nlimit 100 for no key update skip locked;\n     "
   },
   "8e91b63b58e15b8c898573ffd729ea87968e8d2efa24ee4d855ac357c193087b": {
-    "query": "insert into web_media_library_url (media_id, media_url) values ($1, $2) on conflict (media_id, media_url) do nothing",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Text"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "insert into web_media_library_url (media_id, media_url) values ($1, $2) on conflict (media_id, media_url) do nothing"
   },
   "8f1e210ff17b689cd69ae47b2eb88e74893142db5328e8919768818648693bbd": {
-    "query": "\n        update user_auth_basic\n        set email = $3::text\n        where user_id = $1 and email = $2::text\n        ",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Text",
           "Text"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\n        update user_auth_basic\n        set email = $3::text\n        where user_id = $1 and email = $2::text\n        "
   },
   "8f303f3e590326fbb1930c1eedf4795b25fe1d648ea0a6e308028ba23165cd26": {
-    "query": "\nselect jig.id,\n       display_name                                                                                                 as \"name\",\n       language                                                                                                     as \"language!\",\n       description                                                                                                  as \"description!\",\n       translated_description                                                                                       as \"translated_description!: Json<HashMap<String, String>>\",\n       array((select affiliation_id\n              from jig_data_affiliation\n              where jig_data_id = jig_data.id))                                                                     as \"affiliations!\",\n       array((select affiliation.display_name\n              from affiliation\n                       inner join jig_data_affiliation on affiliation.id = jig_data_affiliation.affiliation_id\n              where jig_data_affiliation.jig_data_id = jig_data.id))                                                as \"affiliation_names!\",\n        array((select resource_type_id\n                from jig_data_additional_resource\n                where jig_data_id = jig_data.id))                                                                     as \"resource_types!\",\n        array((select resource_type.display_name\n              from resource_type\n                        inner join jig_data_additional_resource on resource_type.id = jig_data_additional_resource.resource_type_id\n             where jig_data_additional_resource.jig_data_id = jig_data.id))                                         as \"resource_type_names!\",\n       array((select age_range_id\n              from jig_data_age_range\n              where jig_data_id = jig_data.id))                                                                     as \"age_ranges!\",\n       array((select age_range.display_name\n              from age_range\n                       inner join jig_data_age_range on age_range.id = jig_data_age_range.age_range_id\n              where jig_data_age_range.jig_data_id = jig_data.id))                                                  as \"age_range_names!\",\n       array((select category_id\n              from jig_data_category\n              where jig_data_id = jig_data.id))                                                                     as \"categories!\",\n       array((select name\n              from category\n                       inner join jig_data_category on category.id = jig_data_category.category_id\n              where jig_data_category.jig_data_id = jig_data.id))                                                   as \"category_names!\",\n       privacy_level                                                                                                as \"privacy_level!: PrivacyLevel\",\n       jig_focus                                                                                                    as \"jig_focus!: JigFocus\",\n       author_id                                                                                                    as \"author_id\",\n       locked                                                                                                       as \"locked!\",\n       other_keywords                                                                                               as \"other_keywords!\",\n       translated_keywords                                                                                          as \"translated_keywords!\",\n       (select given_name || ' '::text || family_name\n        from user_profile\n        where user_profile.user_id = jig.author_id)                                                                 as \"author_name\",\n        rating                                                                                                      as \"rating\",\n        liked_count                                                                                                 as \"likes!\",\n        (\n            select play_count\n            from jig_play_count \"jpc\"\n            where jpc.jig_id = jig.id\n        )                                                                                                           as \"plays!\",\n        published_at                                                                                                as \"published_at\",\n        blocked                                                                                                     as \"blocked!\"\nfrom jig\n         inner join jig_data on live_id = jig_data.id\n         inner join jig_admin_data \"jad\" on jad.jig_id = jig.id\nwhere (last_synced_at is null\n   or (updated_at is not null and last_synced_at < updated_at))\n   and draft_or_live is not NULL\nlimit 100 for no key update skip locked;\n     ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id",
+          "ordinal": 0,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 1,
           "name": "name",
+          "ordinal": 1,
           "type_info": "Text"
         },
         {
-          "ordinal": 2,
           "name": "language!",
+          "ordinal": 2,
           "type_info": "Text"
         },
         {
-          "ordinal": 3,
           "name": "description!",
+          "ordinal": 3,
           "type_info": "Text"
         },
         {
-          "ordinal": 4,
           "name": "translated_description!: Json<HashMap<String, String>>",
+          "ordinal": 4,
           "type_info": "Jsonb"
         },
         {
-          "ordinal": 5,
           "name": "affiliations!",
+          "ordinal": 5,
           "type_info": "UuidArray"
         },
         {
-          "ordinal": 6,
           "name": "affiliation_names!",
+          "ordinal": 6,
           "type_info": "TextArray"
         },
         {
-          "ordinal": 7,
           "name": "resource_types!",
+          "ordinal": 7,
           "type_info": "UuidArray"
         },
         {
-          "ordinal": 8,
           "name": "resource_type_names!",
+          "ordinal": 8,
           "type_info": "TextArray"
         },
         {
-          "ordinal": 9,
           "name": "age_ranges!",
+          "ordinal": 9,
           "type_info": "UuidArray"
         },
         {
-          "ordinal": 10,
           "name": "age_range_names!",
+          "ordinal": 10,
           "type_info": "TextArray"
         },
         {
-          "ordinal": 11,
           "name": "categories!",
+          "ordinal": 11,
           "type_info": "UuidArray"
         },
         {
-          "ordinal": 12,
           "name": "category_names!",
+          "ordinal": 12,
           "type_info": "TextArray"
         },
         {
-          "ordinal": 13,
           "name": "privacy_level!: PrivacyLevel",
+          "ordinal": 13,
           "type_info": "Int2"
         },
         {
-          "ordinal": 14,
           "name": "jig_focus!: JigFocus",
+          "ordinal": 14,
           "type_info": "Int2"
         },
         {
-          "ordinal": 15,
           "name": "author_id",
+          "ordinal": 15,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 16,
           "name": "locked!",
+          "ordinal": 16,
           "type_info": "Bool"
         },
         {
-          "ordinal": 17,
           "name": "other_keywords!",
+          "ordinal": 17,
           "type_info": "Text"
         },
         {
-          "ordinal": 18,
           "name": "translated_keywords!",
+          "ordinal": 18,
           "type_info": "Text"
         },
         {
-          "ordinal": 19,
           "name": "author_name",
+          "ordinal": 19,
           "type_info": "Text"
         },
         {
-          "ordinal": 20,
           "name": "rating",
+          "ordinal": 20,
           "type_info": "Int2"
         },
         {
-          "ordinal": 21,
           "name": "likes!",
+          "ordinal": 21,
           "type_info": "Int8"
         },
         {
-          "ordinal": 22,
           "name": "plays!",
+          "ordinal": 22,
           "type_info": "Int8"
         },
         {
-          "ordinal": 23,
           "name": "published_at",
+          "ordinal": 23,
           "type_info": "Timestamptz"
         },
         {
-          "ordinal": 24,
           "name": "blocked!",
+          "ordinal": 24,
           "type_info": "Bool"
         }
       ],
-      "parameters": {
-        "Left": []
-      },
       "nullable": [
         false,
         false,
@@ -3913,245 +3817,183 @@
         null,
         true,
         false
-      ]
-    }
+      ],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "\nselect jig.id,\n       display_name                                                                                                 as \"name\",\n       language                                                                                                     as \"language!\",\n       description                                                                                                  as \"description!\",\n       translated_description                                                                                       as \"translated_description!: Json<HashMap<String, String>>\",\n       array((select affiliation_id\n              from jig_data_affiliation\n              where jig_data_id = jig_data.id))                                                                     as \"affiliations!\",\n       array((select affiliation.display_name\n              from affiliation\n                       inner join jig_data_affiliation on affiliation.id = jig_data_affiliation.affiliation_id\n              where jig_data_affiliation.jig_data_id = jig_data.id))                                                as \"affiliation_names!\",\n        array((select resource_type_id\n                from jig_data_additional_resource\n                where jig_data_id = jig_data.id))                                                                     as \"resource_types!\",\n        array((select resource_type.display_name\n              from resource_type\n                        inner join jig_data_additional_resource on resource_type.id = jig_data_additional_resource.resource_type_id\n             where jig_data_additional_resource.jig_data_id = jig_data.id))                                         as \"resource_type_names!\",\n       array((select age_range_id\n              from jig_data_age_range\n              where jig_data_id = jig_data.id))                                                                     as \"age_ranges!\",\n       array((select age_range.display_name\n              from age_range\n                       inner join jig_data_age_range on age_range.id = jig_data_age_range.age_range_id\n              where jig_data_age_range.jig_data_id = jig_data.id))                                                  as \"age_range_names!\",\n       array((select category_id\n              from jig_data_category\n              where jig_data_id = jig_data.id))                                                                     as \"categories!\",\n       array((select name\n              from category\n                       inner join jig_data_category on category.id = jig_data_category.category_id\n              where jig_data_category.jig_data_id = jig_data.id))                                                   as \"category_names!\",\n       privacy_level                                                                                                as \"privacy_level!: PrivacyLevel\",\n       jig_focus                                                                                                    as \"jig_focus!: JigFocus\",\n       author_id                                                                                                    as \"author_id\",\n       locked                                                                                                       as \"locked!\",\n       other_keywords                                                                                               as \"other_keywords!\",\n       translated_keywords                                                                                          as \"translated_keywords!\",\n       (select given_name || ' '::text || family_name\n        from user_profile\n        where user_profile.user_id = jig.author_id)                                                                 as \"author_name\",\n        rating                                                                                                      as \"rating\",\n        liked_count                                                                                                 as \"likes!\",\n        (\n            select play_count\n            from jig_play_count \"jpc\"\n            where jpc.jig_id = jig.id\n        )                                                                                                           as \"plays!\",\n        published_at                                                                                                as \"published_at\",\n        blocked                                                                                                     as \"blocked!\"\nfrom jig\n         inner join jig_data on live_id = jig_data.id\n         inner join jig_admin_data \"jad\" on jad.jig_id = jig.id\nwhere (last_synced_at is null\n   or (updated_at is not null and last_synced_at < updated_at))\n   and draft_or_live is not NULL\nlimit 100 for no key update skip locked;\n     "
   },
   "8f373a91b6dab0b7b89a03f5479b2ebe6dd2657bc06ebbe3aca37b1bac312f0e": {
-    "query": "\nwith cte as (\n    insert into user_font\n    (user_id, name, index)\n    values ($1, $2, (select count(*) from user_font where user_id = $1)) returning name\n), names as (\n    select name\n    from user_font\n    where user_id = $1\n    order by index\n)\nselect name as \"name!\" from names\nunion all\nselect name as \"name!\" from cte\n        ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "name!",
+          "ordinal": 0,
           "type_info": "Text"
         }
+      ],
+      "nullable": [
+        null
       ],
       "parameters": {
         "Left": [
           "Uuid",
           "Text"
         ]
-      },
-      "nullable": [
-        null
-      ]
-    }
+      }
+    },
+    "query": "\nwith cte as (\n    insert into user_font\n    (user_id, name, index)\n    values ($1, $2, (select count(*) from user_font where user_id = $1)) returning name\n), names as (\n    select name\n    from user_font\n    where user_id = $1\n    order by index\n)\nselect name as \"name!\" from names\nunion all\nselect name as \"name!\" from cte\n        "
   },
   "8ff3594259d04d0786b415f1e6577c3252ad2779bf0a9336d3ea985d54d78556": {
-    "query": "\nselect parent_id, index from category where id = $1 for update\n    ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "parent_id",
+          "ordinal": 0,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 1,
           "name": "index",
+          "ordinal": 1,
           "type_info": "Int2"
         }
+      ],
+      "nullable": [
+        true,
+        false
       ],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": [
-        true,
-        false
-      ]
-    }
+      }
+    },
+    "query": "\nselect parent_id, index from category where id = $1 for update\n    "
   },
   "92e7e3facfda24dfb313e2722bea2617cc539d7355ea50942753fbf85e4f6141": {
-    "query": "\nselect count(*) as \"count!: i64\"\nfrom jig_data\ninner join jig on jig.live_id = jig_data.id\nwhere (privacy_level = coalesce($1, privacy_level))\nand (jig_focus = coalesce($1, jig_focus))\n",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "count!: i64",
+          "ordinal": 0,
           "type_info": "Int8"
         }
+      ],
+      "nullable": [
+        null
       ],
       "parameters": {
         "Left": [
           "Int2"
         ]
-      },
-      "nullable": [
-        null
-      ]
-    }
+      }
+    },
+    "query": "\nselect count(*) as \"count!: i64\"\nfrom jig_data\ninner join jig on jig.live_id = jig_data.id\nwhere (privacy_level = coalesce($1, privacy_level))\nand (jig_focus = coalesce($1, jig_focus))\n"
   },
   "943425e13636b972656a1c40172ae281420bdd0c840c0bac045bc1b1cdbc6957": {
-    "query": "\nupdate jig_data_additional_resource\nset resource_type_id = coalesce($2, resource_type_id)\nwhere id = $1 and $2 is distinct from resource_type_id\n            ",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
-  },
-  "9553db86542471be95f970aca058cef9ebd2f95c8d10f7663b5678c9835f7f0e": {
-    "query": "with recursive path(id, index, parent_id) as (\n    select id, ord, null::uuid\n    from category\n             inner join unnest(\n            $1::uuid[]) with ordinality t(id, ord)\n                        using (id)\n    union all\n    select c.id, c.index, p.id\n    from path p\n             inner join category c on (c.parent_id = p.id)\n)\nselect distinct id as \"id!\",\n       path.index::int2 as \"index!\",\n       path.parent_id,\n       name,\n       created_at,\n       updated_at,\n       (select count(*) from image_category where category_id = id)::int8 as \"image_count!\",\n       (select count(distinct jig.id)::int8\n        from jig\n                 join jig_data_category on (jig.live_id = jig_data_id or jig.draft_id = jig_data_id)\n        where category_id = id)                                           as \"jig_count!\",\n       user_scopes\n\nfrom path\n         inner join category using (id);\n",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id!",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 1,
-          "name": "index!",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 2,
-          "name": "parent_id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 3,
-          "name": "name",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 4,
-          "name": "created_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 5,
-          "name": "updated_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 6,
-          "name": "image_count!",
-          "type_info": "Int8"
-        },
-        {
-          "ordinal": 7,
-          "name": "jig_count!",
-          "type_info": "Int8"
-        },
-        {
-          "ordinal": 8,
-          "name": "user_scopes",
-          "type_info": "Int2Array"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "UuidArray"
-        ]
-      },
-      "nullable": [
-        null,
-        null,
-        null,
-        false,
-        false,
-        true,
-        null,
-        null,
-        false
-      ]
-    }
+      }
+    },
+    "query": "\nupdate jig_data_additional_resource\nset resource_type_id = coalesce($2, resource_type_id)\nwhere id = $1 and $2 is distinct from resource_type_id\n            "
   },
   "95cc52570b87e1413c93a9588cee5f081824028c269803aba12a578cada7395b": {
-    "query": "select user_id from user_auth_basic where user_id <> $1 and email = $2 for update",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "user_id",
+          "ordinal": 0,
           "type_info": "Uuid"
         }
+      ],
+      "nullable": [
+        false
       ],
       "parameters": {
         "Left": [
           "Uuid",
           {
             "Custom": {
-              "name": "citext",
-              "kind": "Simple"
+              "kind": "Simple",
+              "name": "citext"
             }
           }
         ]
-      },
-      "nullable": [
-        false
-      ]
-    }
+      }
+    },
+    "query": "select user_id from user_auth_basic where user_id <> $1 and email = $2 for update"
   },
   "974e49b8fa518e9402ae2494147cd25953503851952b4ba97d635a2aeb5bd729": {
-    "query": "\nwith delete as (\n        delete from user_color\n    where user_id = $1 and index = $2\n)\nselect 1 as discard\nfrom user_color\nwhere user_id = $1 and index > $2\nfor update\n",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "discard",
+          "ordinal": 0,
           "type_info": "Int4"
         }
       ],
+      "nullable": [
+        null
+      ],
       "parameters": {
         "Left": [
           "Uuid",
           "Int2"
         ]
-      },
-      "nullable": [
-        null
-      ]
-    }
+      }
+    },
+    "query": "\nwith delete as (\n        delete from user_color\n    where user_id = $1 and index = $2\n)\nselect 1 as discard\nfrom user_color\nwhere user_id = $1 and index > $2\nfor update\n"
   },
   "9756ed1443684d458b7a28a371aa5f4562dea68d71b181d1f8f8ea5c831c6866": {
-    "query": "\ndelete from jig_data where id = $1\n    ",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\ndelete from jig_data where id = $1\n    "
   },
   "97c54af61fbd13ad8dc24d896a8ea0d71f754666e4c81a1b07f6f9aca6c20f26": {
-    "query": "\nselect kind as \"kind: ImageKind\"\nfrom user_image_library\ninner join user_image_upload on user_image_library.id = user_image_upload.image_id\nwhere (id = $1 and uploaded_at is not null and processed_at >= uploaded_at is not true)\nfor no key update of user_image_upload\nfor share of user_image_library\nskip locked\n        ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "kind: ImageKind",
+          "ordinal": 0,
           "type_info": "Int2"
         }
+      ],
+      "nullable": [
+        false
       ],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": [
-        false
-      ]
-    }
+      }
+    },
+    "query": "\nselect kind as \"kind: ImageKind\"\nfrom user_image_library\ninner join user_image_upload on user_image_library.id = user_image_upload.image_id\nwhere (id = $1 and uploaded_at is not null and processed_at >= uploaded_at is not true)\nfor no key update of user_image_upload\nfor share of user_image_library\nskip locked\n        "
   },
   "984db246395c1b894ff75eba828c2dbf7a73001ecc0dff6547cf0918f7453a3a": {
-    "query": "\nselect index from jig_data_module\nwhere jig_data_module.id is not distinct from $2\n   or (jig_data_id = $1 and stable_id is not distinct from $3)\n",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "index",
+          "ordinal": 0,
           "type_info": "Int2"
         }
+      ],
+      "nullable": [
+        false
       ],
       "parameters": {
         "Left": [
@@ -4159,155 +4001,155 @@
           "Uuid",
           "Uuid"
         ]
-      },
-      "nullable": [
-        false
-      ]
-    }
+      }
+    },
+    "query": "\nselect index from jig_data_module\nwhere jig_data_module.id is not distinct from $2\n   or (jig_data_id = $1 and stable_id is not distinct from $3)\n"
   },
   "986130a83ea19f3782aa5e5c1c0a0a260c515e4aad15cc17d63aba20db572b2f": {
-    "query": "delete from user_image_library where user_id = $1 and id = $2",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "delete from user_image_library where user_id = $1 and id = $2"
   },
   "9b861485e86da04aaa69d4863da15659c65606df112805e833c162510b8aad6d": {
-    "query": "\nselect exists(select 1\nfrom user_audio_library\ninner join user_audio_upload on user_audio_library.id = user_audio_upload.audio_id\nwhere (id = $1 and uploaded_at is not null and processed_at >= uploaded_at is not true)\nfor no key update of user_audio_upload\nfor share of user_audio_library\nskip locked\n) as \"exists!\"\n        ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "exists!",
+          "ordinal": 0,
           "type_info": "Bool"
         }
+      ],
+      "nullable": [
+        null
       ],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": [
-        null
-      ]
-    }
+      }
+    },
+    "query": "\nselect exists(select 1\nfrom user_audio_library\ninner join user_audio_upload on user_audio_library.id = user_audio_upload.audio_id\nwhere (id = $1 and uploaded_at is not null and processed_at >= uploaded_at is not true)\nfor no key update of user_audio_upload\nfor share of user_audio_library\nskip locked\n) as \"exists!\"\n        "
   },
   "9baca0e0cc5e462bafb40e834a5c894d9f02dbb61ec75d81609cc32c946f5857": {
-    "query": "select exists(select 1 from image_metadata where id = $1) as \"exists!\"",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "exists!",
+          "ordinal": 0,
           "type_info": "Bool"
         }
+      ],
+      "nullable": [
+        null
       ],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": [
-        null
-      ]
-    }
+      }
+    },
+    "query": "select exists(select 1 from image_metadata where id = $1) as \"exists!\""
   },
   "9d077a763e28dfcec303320f15227adb9d5786148dbfafe30b79c5b5e8ecc8d8": {
-    "query": "\nselect exists(select 1\nfrom user_pdf_library\ninner join user_pdf_upload on user_pdf_library.id = user_pdf_upload.pdf_id\nwhere (id = $1 and uploaded_at is not null and processed_at >= uploaded_at is not true)\nfor no key update of user_pdf_upload\nfor share of user_pdf_library\nskip locked\n) as \"exists!\"\n        ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "exists!",
+          "ordinal": 0,
           "type_info": "Bool"
         }
+      ],
+      "nullable": [
+        null
       ],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": [
-        null
-      ]
-    }
+      }
+    },
+    "query": "\nselect exists(select 1\nfrom user_pdf_library\ninner join user_pdf_upload on user_pdf_library.id = user_pdf_upload.pdf_id\nwhere (id = $1 and uploaded_at is not null and processed_at >= uploaded_at is not true)\nfor no key update of user_pdf_upload\nfor share of user_pdf_library\nskip locked\n) as \"exists!\"\n        "
   },
   "9d166e1174a30bbd4c9c87544cf9c8403e5fb1dfc00fb312db75c795436f9ea3": {
-    "query": "select exists(select 1 from user_audio_upload where audio_id = $1 for no key update) as \"exists!\"",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "exists!",
+          "ordinal": 0,
           "type_info": "Bool"
         }
+      ],
+      "nullable": [
+        null
       ],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": [
-        null
-      ]
-    }
+      }
+    },
+    "query": "select exists(select 1 from user_audio_upload where audio_id = $1 for no key update) as \"exists!\""
   },
   "9d4752bf9a22f50e73e71079588c4d734ce6b91fe23b217f2f9aa22a16d2c363": {
-    "query": "\nselect exists (\n    select 1\n    from jig_like\n    where\n        jig_id = $1\n        and user_id = $2\n) as \"exists!\"\n    ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "exists!",
+          "ordinal": 0,
           "type_info": "Bool"
         }
+      ],
+      "nullable": [
+        null
       ],
       "parameters": {
         "Left": [
           "Uuid",
           "Uuid"
         ]
-      },
-      "nullable": [
-        null
-      ]
-    }
+      }
+    },
+    "query": "\nselect exists (\n    select 1\n    from jig_like\n    where\n        jig_id = $1\n        and user_id = $2\n) as \"exists!\"\n    "
   },
   "9e3fc9a239cb6ad98628e2f2bf16be1ab3d6db751bb97bedaaf004500f6bcffc": {
-    "query": "select exists(select 1 from global_animation_upload where animation_id = $1 for no key update) as \"exists!\"",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "exists!",
+          "ordinal": 0,
           "type_info": "Bool"
         }
+      ],
+      "nullable": [
+        null
       ],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": [
-        null
-      ]
-    }
+      }
+    },
+    "query": "select exists(select 1 from global_animation_upload where animation_id = $1 for no key update) as \"exists!\""
   },
   "9f99518316804bde4081b2b71e262da9148de6f4a164b674e4bdd130eb34a2ee": {
-    "query": "\nselect user_id\nfrom session\nwhere\n    token = $1 and\n    expires_at < now() is not true and\n    (scope_mask & $2) = $2 and\n    (impersonator_id is null or exists(select 1 from user_scope where user_scope.user_id = impersonator_id and user_scope.scope = $3))\n",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "user_id",
+          "ordinal": 0,
           "type_info": "Uuid"
         }
+      ],
+      "nullable": [
+        false
       ],
       "parameters": {
         "Left": [
@@ -4315,969 +4157,951 @@
           "Int2",
           "Int2"
         ]
-      },
-      "nullable": [
-        false
-      ]
-    }
+      }
+    },
+    "query": "\nselect user_id\nfrom session\nwhere\n    token = $1 and\n    expires_at < now() is not true and\n    (scope_mask & $2) = $2 and\n    (impersonator_id is null or exists(select 1 from user_scope where user_scope.user_id = impersonator_id and user_scope.scope = $3))\n"
   },
   "9fc35349eacb6647e398e2756c8229e73c6b7fbef00988de47589866241487db": {
-    "query": "update image_upload set processed_at = now(), processing_result = false where image_id = $1",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "update image_upload set processed_at = now(), processing_result = false where image_id = $1"
   },
   "a0f81385b9713d0c508a0a5e6658939c1edf5149c2440bd55c07e788dfc2ed2a": {
-    "query": "\ninsert into category (index, parent_id, name, user_scopes)\nVALUES((select count(*)::int2 from category where parent_id is not distinct from $1), $1, $2, array[]::smallint[])\nreturning index, id",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "index",
+          "ordinal": 0,
           "type_info": "Int2"
         },
         {
-          "ordinal": 1,
           "name": "id",
+          "ordinal": 1,
           "type_info": "Uuid"
         }
+      ],
+      "nullable": [
+        false,
+        false
       ],
       "parameters": {
         "Left": [
           "Uuid",
           "Text"
         ]
-      },
-      "nullable": [
-        false,
-        false
-      ]
-    }
+      }
+    },
+    "query": "\ninsert into category (index, parent_id, name, user_scopes)\nVALUES((select count(*)::int2 from category where parent_id is not distinct from $1), $1, $2, array[]::smallint[])\nreturning index, id"
   },
   "a16036b8f5f8431ae1f10fb2ce15ff302ff8667c9bf5d9a769905a3fad069498": {
-    "query": "select exists(select 1 from image_upload where image_id = $1 for no key update) as \"exists!\"",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "exists!",
+          "ordinal": 0,
           "type_info": "Bool"
         }
       ],
-      "parameters": {
-        "Left": [
-          "Uuid"
-        ]
-      },
       "nullable": [
         null
-      ]
-    }
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "select exists(select 1 from image_upload where image_id = $1 for no key update) as \"exists!\""
   },
-  "a4970e4a6b9f203bbc4c123f495e95a26a661265f6a10d19287e1342310aaac6": {
-    "query": "\nselect index     as \"index!: i16\",\n       direction as \"direction: TextDirection\",\n       display_score,\n       track_assessments,\n       drag_assist,\n       expires_at as \"expires_at: DateTime<Utc>\"\nfrom jig_player_session\nwhere jig_id = $1\n",
+  "a293497e635f9a60d77be04ce0babce3020ea53f4a0e230ba5725914125e9120": {
     "describe": {
       "columns": [
         {
+          "name": "id!: CategoryId",
           "ordinal": 0,
-          "name": "index!: i16",
-          "type_info": "Int2"
+          "type_info": "Uuid"
         },
         {
+          "name": "name!",
           "ordinal": 1,
-          "name": "direction: TextDirection",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 2,
-          "name": "display_score",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 3,
-          "name": "track_assessments",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 4,
-          "name": "drag_assist",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 5,
-          "name": "expires_at: DateTime<Utc>",
-          "type_info": "Timestamptz"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid"
-        ]
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false,
-        false
-      ]
-    }
-  },
-  "a5d7bd2b5b78d82c26f75b70d18ae63fb9e27031e080021e21c05cba75db48c9": {
-    "query": "\nselect draft_id from jig join jig_data on jig.draft_id = jig_data.id where jig.id = $1 for update\n",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "draft_id",
-          "type_info": "Uuid"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid"
-        ]
-      },
-      "nullable": [
-        false
-      ]
-    }
-  },
-  "a63ac1a1a79b480f537e93a26809448dd7cfe54bd82fc63e24626521da82f7c8": {
-    "query": "delete from session where token = $1 and (scope_mask & $2) = $2 returning user_id",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "user_id",
-          "type_info": "Uuid"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Text",
-          "Int2"
-        ]
-      },
-      "nullable": [
-        false
-      ]
-    }
-  },
-  "a7597f668f530133865fe74a396da14ff51dcb53fc0537df95964ae98649ce1d": {
-    "query": "\n        update jig_curation_data\n        set updated_at = now()\n        where jig_id = $1\n    ",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Uuid"
-        ]
-      },
-      "nullable": []
-    }
-  },
-  "a85530d1d83a7f3cd3786da68f5b489fbddbf411d735cf114817e4417768520b": {
-    "query": "\nselect index as \"index: ImageTagIndex\", display_name from \"image_tag\"\norder by index\n            ",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "index: ImageTagIndex",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 1,
-          "name": "display_name",
-          "type_info": "Text"
-        }
-      ],
-      "parameters": {
-        "Left": []
-      },
-      "nullable": [
-        false,
-        false
-      ]
-    }
-  },
-  "a87ea4169f26518cbf7f88c1777bd15bbf72f938d6352567cd549bbe970db5f2": {
-    "query": "\nupdate user_color\nset index = index - 1\nwhere index > $2 and user_id = $1\n",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Int2"
-        ]
-      },
-      "nullable": []
-    }
-  },
-  "a88c0449faed385cbc111b4e25068a8dd76a2118de2b5615e6315af23f8ce946": {
-    "query": "update global_animation_upload set processed_at = now(), processing_result = false where animation_id = $1",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Uuid"
-        ]
-      },
-      "nullable": []
-    }
-  },
-  "a927e1b316983d98397a454a3198b08fcd37cb54056c0a5e57c18bbfcaa0985c": {
-    "query": "\nselect exists(select 1 from user_recent_image where user_id = $1 and image_id = $2) as \"exists!\"\n            ",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "exists!",
-          "type_info": "Bool"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Uuid"
-        ]
-      },
-      "nullable": [
-        null
-      ]
-    }
-  },
-  "a9780ea48594dbed705b4df8442e7c58416785833da7e04ef32aa8a3bfcd0e21": {
-    "query": "delete from user_auth_basic where user_id = $1",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Uuid"
-        ]
-      },
-      "nullable": []
-    }
-  },
-  "a9996186c133f11e9d24a68f2f686c99b5f65fc97b4de1ea89411b16b333afb5": {
-    "query": "select exists(\n            select 1\n            from \"user_scope\"\n            where\n                user_id = $1 and\n                (scope = $2 or scope = $3)\n        ) as \"exists!\"",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "exists!",
-          "type_info": "Bool"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Int2",
-          "Int2"
-        ]
-      },
-      "nullable": [
-        null
-      ]
-    }
-  },
-  "ab605fef6d23ea4a74e80999574296f7b4fce2ed0029455be3d6541ee379d329": {
-    "query": "\ninsert into jig_data\n(display_name, created_at, updated_at, language, last_synced_at, description, theme, audio_background,\n audio_feedback_negative, audio_feedback_positive, direction, display_score, drag_assist, track_assessments, privacy_level, other_keywords, translated_keywords, translated_description)\nselect display_name,\n       created_at,\n       updated_at,\n       language,\n       last_synced_at,\n       description,\n       theme,\n       audio_background,\n       audio_feedback_negative,\n       audio_feedback_positive,\n       direction,\n       display_score,\n       drag_assist,\n       track_assessments,\n       privacy_level,\n       other_keywords,\n       translated_keywords,\n       translated_description::jsonb\nfrom jig_data\nwhere id = $1\nreturning id\n        ",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id",
-          "type_info": "Uuid"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid"
-        ]
-      },
-      "nullable": [
-        false
-      ]
-    }
-  },
-  "abd49e91a2a6278531da084d0a7e251bd816eba32da855e0d1eb332ef6dccdf3": {
-    "query": "\n                        update image_metadata \n                        set translated_description = $2,\n                            updated_at = now()\n                        where id = $1\n                        ",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Jsonb"
-        ]
-      },
-      "nullable": []
-    }
-  },
-  "ada31ac34d9d4b99d869df3190ad4e105413aa9db4e285b48d7b04eca85d63ca": {
-    "query": "\ninsert into jig (creator_id, author_id, parents, live_id, draft_id, published_at, jig_focus)\nselect creator_id, $2, array_append(parents, $1), $3, $4, published_at, jig_focus\nfrom jig\nwhere id = $1\nreturning id as \"id!: JigId\"\n",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id!: JigId",
-          "type_info": "Uuid"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Uuid",
-          "Uuid",
-          "Uuid"
-        ]
-      },
-      "nullable": [
-        false
-      ]
-    }
-  },
-  "aec729ae876f9816b6a64f6527c6e8497140391a8bebb7a00fc5418cb07682a8": {
-    "query": "\ndelete from image_tag where index = $1\n            ",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Int2"
-        ]
-      },
-      "nullable": []
-    }
-  },
-  "aef23353cf5529b174a364ec8034d480a7bf91169c379b0a6c4c2267f8cccb3f": {
-    "query": "\nselect jig.id                                       as \"id!: JigId\",\n       creator_id,\n       author_id                                as \"author_id\",\n       (select given_name || ' '::text || family_name\n        from user_profile\n        where user_profile.user_id = author_id) as \"author_name\",\n       live_id                                  as \"live_id!\",\n       draft_id                                 as \"draft_id!\",\n       published_at,\n       liked_count                              as \"liked_count!\",\n       (\n           select play_count\n           from jig_play_count\n           where jig_play_count.jig_id = jig.id\n       )                                        as \"play_count!\",\n       rating                                   as \"rating?: JigRating\",\n       blocked                                  as \"blocked!\",\n       curated                                  as \"curated!\",\n       jig_focus                                as \"jig_focus!: JigFocus\"\nfrom jig\n         inner join unnest($1::uuid[])\n    with ordinality t(id, ord) using (id)\n    inner join jig_admin_data \"admin\" on admin.jig_id = jig.id\n    ",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id!: JigId",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 1,
-          "name": "creator_id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 2,
-          "name": "author_id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 3,
-          "name": "author_name",
           "type_info": "Text"
         },
         {
-          "ordinal": 4,
-          "name": "live_id!",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 5,
-          "name": "draft_id!",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 6,
-          "name": "published_at",
+          "name": "created_at!",
+          "ordinal": 2,
           "type_info": "Timestamptz"
         },
         {
-          "ordinal": 7,
-          "name": "liked_count!",
-          "type_info": "Int8"
-        },
-        {
-          "ordinal": 8,
-          "name": "play_count!",
-          "type_info": "Int8"
-        },
-        {
-          "ordinal": 9,
-          "name": "rating?: JigRating",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 10,
-          "name": "blocked!",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 11,
-          "name": "curated!",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 12,
-          "name": "jig_focus!: JigFocus",
-          "type_info": "Int2"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "UuidArray"
-        ]
-      },
-      "nullable": [
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true
-      ]
-    }
-  },
-  "af80bdb7130c63ac120ca80150882fc17c3cc4d1c24c0f5bb8bde46e25f38bf3": {
-    "query": "\nupdate jig_data\nset draft_or_live = $2\nwhere id = $1\n            ",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Int2"
-        ]
-      },
-      "nullable": []
-    }
-  },
-  "b093762d4b40e825b57962cb833a8144a57270a3029f0cd6362d956b701e0651": {
-    "query": "select token from \"session\" order by created_at limit 1",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "token",
-          "type_info": "Text"
-        }
-      ],
-      "parameters": {
-        "Left": []
-      },
-      "nullable": [
-        false
-      ]
-    }
-  },
-  "b1a15c616e8f86aa4d7bd37701eb692298a9b55afafa797e6ded14ba650f2bb3": {
-    "query": "\ndelete\nfrom jig\nwhere creator_id is not distinct from $1\n",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Uuid"
-        ]
-      },
-      "nullable": []
-    }
-  },
-  "b211b1f87835114b657632739dc3502a1de67cb2c971b0e53c4283b9086eaa9c": {
-    "query": "\nupdate jig_data_module\nset index = index - 1\nwhere jig_data_id = $1\n  and index > $2\n",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Int2"
-        ]
-      },
-      "nullable": []
-    }
-  },
-  "b215f3c20b41f2ac1dbf3c8fdc2a98635a0bad092530bdd53654bb0a53674e24": {
-    "query": "\nupdate user_profile\nset username               = coalesce($2, username),\n    given_name             = coalesce($3, given_name),\n    family_name            = coalesce($4, family_name),\n    language               = coalesce($5, language),\n    locale                 = coalesce($6, locale),\n    timezone               = coalesce($7, timezone),\n    opt_into_edu_resources = coalesce($8, opt_into_edu_resources)\nwhere user_id = $1\n  and (($2::text is not null and $2 is distinct from username) or\n       ($3::text is not null and $3 is distinct from given_name) or\n       ($4::text is not null and $4 is distinct from family_name) or\n       ($5::text is not null and $5 is distinct from language) or\n       ($6::text is not null and $6 is distinct from locale) or\n       ($7::text is not null and $7 is distinct from timezone) or\n       ($8::bool is not null and $8 is distinct from opt_into_edu_resources) )\n    ",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Text",
-          "Text",
-          "Text",
-          "Text",
-          "Text",
-          "Text",
-          "Bool"
-        ]
-      },
-      "nullable": []
-    }
-  },
-  "b4338c9f23e8fad86b9bc505f8d366e02ca2c59cb4ac11255ef3d84e68daf79c": {
-    "query": "\ninsert into jig_curation_comment (jig_id, comment, author_id)\nvalues ($1, $2, $3)\nreturning id as \"id!: CommentId\"\n        ",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id!: CommentId",
-          "type_info": "Uuid"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Text",
-          "Uuid"
-        ]
-      },
-      "nullable": [
-        false
-      ]
-    }
-  },
-  "b4f3858831e1685ac7bf663ebddc340a804437258fce9803fd079c084b38e470": {
-    "query": "update global_animation_upload set processed_at = now(), processing_result = true where animation_id = $1",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Uuid"
-        ]
-      },
-      "nullable": []
-    }
-  },
-  "b5949f227788bc5e36a22b50498a85a8be8cefd31395f4892b2e0932ba05dfaa": {
-    "query": "select id as \"id: PdfId\" from user_pdf_library order by created_at desc",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id: PdfId",
-          "type_info": "Uuid"
-        }
-      ],
-      "parameters": {
-        "Left": []
-      },
-      "nullable": [
-        false
-      ]
-    }
-  },
-  "b73bc1e83d2008fc5b9cc7e9a6c9a6b67b136c45a41e39a8929b554dc5c98485": {
-    "query": "update \"settings\" set algolia_index_version = $1",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Int2"
-        ]
-      },
-      "nullable": []
-    }
-  },
-  "ba59bad8a7aef54f3ee9054118d79bbb2be4ce0371960a979ea74feced71d8e2": {
-    "query": "\nselect name\nfrom user_font\nwhere user_id = $1\norder by index\n        ",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "name",
-          "type_info": "Text"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid"
-        ]
-      },
-      "nullable": [
-        false
-      ]
-    }
-  },
-  "ba7c4c90935d487d2217c74eacc4362e96f8dc07c9f45e3741b4a46b3cf06155": {
-    "query": "\nselect draft_id from jig where jig.id = $1\n",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "draft_id",
-          "type_info": "Uuid"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid"
-        ]
-      },
-      "nullable": [
-        false
-      ]
-    }
-  },
-  "bb5a9faaff748e864bcb9fb956585e7577313b263dbf2fe0e146a8c48af134c9": {
-    "query": "select user_id as \"id\" from user_profile where (user_id = $1 and $1 is not null) or (username = $2 and $2 is not null)",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id",
-          "type_info": "Uuid"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Text"
-        ]
-      },
-      "nullable": [
-        false
-      ]
-    }
-  },
-  "bc33e05c70cc5df3edce2315cbef3214241c5c0f0c06046c1f07e379704d83fc": {
-    "query": "\nselect id                                                                 as \"id: CategoryId\",\n       name,\n       created_at,\n       updated_at,\n       (select count(*)::int8 from image_category where category_id = id) as \"image_count!\",\n       (select count(*)::int8 from jig_data_category where category_id = id) as \"jig_count!\",\n       user_scopes\nfrom category\nwhere parent_id is null\norder by index\n ",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id: CategoryId",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 1,
-          "name": "name",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 2,
-          "name": "created_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 3,
           "name": "updated_at",
+          "ordinal": 3,
           "type_info": "Timestamptz"
         },
         {
+          "name": "user_scopes!",
           "ordinal": 4,
-          "name": "image_count!",
-          "type_info": "Int8"
-        },
-        {
-          "ordinal": 5,
-          "name": "jig_count!",
-          "type_info": "Int8"
-        },
-        {
-          "ordinal": 6,
-          "name": "user_scopes",
           "type_info": "Int2Array"
         }
       ],
-      "parameters": {
-        "Left": []
-      },
       "nullable": [
-        false,
-        false,
-        false,
         true,
-        null,
-        null,
-        false
-      ]
-    }
-  },
-  "bc43edfc2dcbeea691560c655987b29f3a3c919223487912f63be464fec522a4": {
-    "query": "\nselect exists(select 1 from user_profile where user_id = $1 for update) as \"exists!\"\n    ",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "exists!",
-          "type_info": "Bool"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid"
-        ]
-      },
-      "nullable": [
-        null
-      ]
-    }
-  },
-  "bfd314e70437482954c5dfb3a40ab08990a0bea43779d810e9dd903e87e10c81": {
-    "query": "\nupdate jig_admin_data\nset curated = coalesce($2, curated)\nwhere jig_id = $1 and $2 is distinct from curated\n            ",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Bool"
-        ]
-      },
-      "nullable": []
-    }
-  },
-  "c0503b4756010f70f84bfc842758cc356568bcb7324b0c0a8454f49511300942": {
-    "query": "insert into user_scope (user_id, scope) values ($1, $2)",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Int2"
-        ]
-      },
-      "nullable": []
-    }
-  },
-  "c0f2792d2f5f952c0f6becbd49c168ca420c910e6c93102ad8896704aecc39ac": {
-    "query": "\nupdate category\nset updated_at = now(),\n    index = index + 1\nwhere index >= $1 and index < $2 and parent_id is not distinct from $3\n                ",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Int2",
-          "Int2",
-          "Uuid"
-        ]
-      },
-      "nullable": []
-    }
-  },
-  "c112679df052326f66d3b7891480bf331d2748861fcd3f23ffaa9176804ea55b": {
-    "query": "\nwith new_row as (\n    insert into \"settings\" default values on conflict(singleton) do nothing returning algolia_index_version\n)\nselect algolia_index_version as \"algolia_index_version!\" from new_row\nunion\nselect algolia_index_version as \"algolia_index_version!\" from \"settings\"\n",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "algolia_index_version!",
-          "type_info": "Int2"
-        }
-      ],
-      "parameters": {
-        "Left": []
-      },
-      "nullable": [
-        null
-      ]
-    }
-  },
-  "c2ba8ddd6ad6e28535559d4452b655095914cb90514490dac438fc27b686bde5": {
-    "query": "\nupdate jig_data_module\nset\n    index = case when index = $2 then $3 else index + 1 end,\n    updated_at = now()\nwhere jig_data_id = $1 and index between $3 and $2\n",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Int2",
-          "Int2"
-        ]
-      },
-      "nullable": []
-    }
-  },
-  "c340da8122545a5c5cffc7a9b7c8b03d6d7eed1e58ece1d6a462dbcebe030f10": {
-    "query": "\nupdate jig_data\nset audio_background = $2,\nupdated_at = now()\nwhere id = $1 and $2 is distinct from audio_background\n            ",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Int2"
-        ]
-      },
-      "nullable": []
-    }
-  },
-  "c84c613c4d8af5d5228646ffb25c2cd2825699626313634127fc09341ed715ac": {
-    "query": "\nselect id as \"id: ImageId\", kind as \"kind: ImageKind\"\nfrom user_image_library\n         inner join user_image_upload\n                    on user_image_library.id = user_image_upload.image_id\nwhere user_id = $1\n  and id = $2\n  and processing_result is true\n        ",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id: ImageId",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 1,
-          "name": "kind: ImageKind",
-          "type_info": "Int2"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Uuid"
-        ]
-      },
-      "nullable": [
-        false,
-        false
-      ]
-    }
-  },
-  "c877be5757f8787c2da80469a4fc50641fb63358e6516d05c7159d9c8060ac52": {
-    "query": "\nselect kind as \"kind: MediaKind\"\nfrom web_media_library\ninner join web_media_upload on web_media_library.id = web_media_upload.media_id\nwhere (id = $1 and uploaded_at is not null and processed_at >= uploaded_at is not true)\nfor no key update of web_media_upload\nfor share of web_media_library\nskip locked\n        ",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "kind: MediaKind",
-          "type_info": "Int2"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid"
-        ]
-      },
-      "nullable": [
-        false
-      ]
-    }
-  },
-  "c88323000ed380c0fb9c599dc26accc3cbe54b3d82f4c10a8fbc66c4803bbff4": {
-    "query": "\nselect id,\n       display_name                                                                  as \"display_name!\",\n       updated_at,\n       language                                                                      as \"language!\",\n       description                                                                   as \"description!\",\n       translated_description                                                        as \"translated_description!: Json<HashMap<String,String>>\",\n       direction                                                                     as \"direction!: TextDirection\",\n       display_score                                                                 as \"display_score!\",\n       track_assessments                                                             as \"track_assessments!\",\n       drag_assist                                                                   as \"drag_assist!\",\n       theme                                                                         as \"theme!: ThemeId\",\n       audio_background                                                              as \"audio_background!: Option<AudioBackground>\",\n       array(select row (unnest(audio_feedback_positive)))                           as \"audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>\",\n       array(select row (unnest(audio_feedback_negative)))                           as \"audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>\",\n       array(\n               select row (jig_data_module.id, kind, is_complete)\n               from jig_data_module\n               where jig_data_id = jig_data.id\n               order by \"index\"\n           )                                               as \"modules!: Vec<(ModuleId, ModuleKind, bool)>\",\n       array(select row (category_id)\n             from jig_data_category\n             where jig_data_id = jig_data.id)     as \"categories!: Vec<(CategoryId,)>\",\n       array(select row (affiliation_id)\n             from jig_data_affiliation\n             where jig_data_id = jig_data.id)     as \"affiliations!: Vec<(AffiliationId,)>\",\n       array(select row (age_range_id)\n             from jig_data_age_range\n             where jig_data_id = jig_data.id)     as \"age_ranges!: Vec<(AgeRangeId,)>\",\n       array(\n                select row (jdar.id, jdar.display_name, resource_type_id, resource_content)\n                from jig_data_additional_resource \"jdar\"\n                where jdar.jig_data_id = jig_data.id\n            )                                               as \"additional_resource!: Vec<(AddId, String, TypeId, Value)>\",\n       privacy_level                              as \"privacy_level!: PrivacyLevel\",\n       locked                                     as \"locked!\",\n       other_keywords                             as \"other_keywords!\",\n       translated_keywords                        as \"translated_keywords!\"\nfrom jig_data\n         inner join unnest($1::uuid[])\n    with ordinality t(id, ord) using (id)\nwhere draft_or_live is not null\n",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 1,
-          "name": "display_name!",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 2,
-          "name": "updated_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 3,
-          "name": "language!",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 4,
-          "name": "description!",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 5,
-          "name": "translated_description!: Json<HashMap<String,String>>",
-          "type_info": "Jsonb"
-        },
-        {
-          "ordinal": 6,
-          "name": "direction!: TextDirection",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 7,
-          "name": "display_score!",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 8,
-          "name": "track_assessments!",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 9,
-          "name": "drag_assist!",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 10,
-          "name": "theme!: ThemeId",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 11,
-          "name": "audio_background!: Option<AudioBackground>",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 12,
-          "name": "audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 13,
-          "name": "audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 14,
-          "name": "modules!: Vec<(ModuleId, ModuleKind, bool)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 15,
-          "name": "categories!: Vec<(CategoryId,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 16,
-          "name": "affiliations!: Vec<(AffiliationId,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 17,
-          "name": "age_ranges!: Vec<(AgeRangeId,)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 18,
-          "name": "additional_resource!: Vec<(AddId, String, TypeId, Value)>",
-          "type_info": "RecordArray"
-        },
-        {
-          "ordinal": 19,
-          "name": "privacy_level!: PrivacyLevel",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 20,
-          "name": "locked!",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 21,
-          "name": "other_keywords!",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 22,
-          "name": "translated_keywords!",
-          "type_info": "Text"
-        }
+        true,
+        true,
+        true,
+        true
       ],
       "parameters": {
         "Left": [
           "UuidArray"
         ]
-      },
+      }
+    },
+    "query": "\nselect id                                                                 as \"id!: CategoryId\",\n       name                                                               as \"name!\",\n       created_at                                                         as \"created_at!\",\n       updated_at,\n       user_scopes                                                        as \"user_scopes!\"\nfrom category\n         inner join unnest($1::uuid[]) with ordinality t(id, ord) USING (id)\norder by t.ord\n"
+  },
+  "a4970e4a6b9f203bbc4c123f495e95a26a661265f6a10d19287e1342310aaac6": {
+    "describe": {
+      "columns": [
+        {
+          "name": "index!: i16",
+          "ordinal": 0,
+          "type_info": "Int2"
+        },
+        {
+          "name": "direction: TextDirection",
+          "ordinal": 1,
+          "type_info": "Int2"
+        },
+        {
+          "name": "display_score",
+          "ordinal": 2,
+          "type_info": "Bool"
+        },
+        {
+          "name": "track_assessments",
+          "ordinal": 3,
+          "type_info": "Bool"
+        },
+        {
+          "name": "drag_assist",
+          "ordinal": 4,
+          "type_info": "Bool"
+        },
+        {
+          "name": "expires_at: DateTime<Utc>",
+          "ordinal": 5,
+          "type_info": "Timestamptz"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\nselect index     as \"index!: i16\",\n       direction as \"direction: TextDirection\",\n       display_score,\n       track_assessments,\n       drag_assist,\n       expires_at as \"expires_at: DateTime<Utc>\"\nfrom jig_player_session\nwhere jig_id = $1\n"
+  },
+  "a5d7bd2b5b78d82c26f75b70d18ae63fb9e27031e080021e21c05cba75db48c9": {
+    "describe": {
+      "columns": [
+        {
+          "name": "draft_id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\nselect draft_id from jig join jig_data on jig.draft_id = jig_data.id where jig.id = $1 for update\n"
+  },
+  "a63ac1a1a79b480f537e93a26809448dd7cfe54bd82fc63e24626521da82f7c8": {
+    "describe": {
+      "columns": [
+        {
+          "name": "user_id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Text",
+          "Int2"
+        ]
+      }
+    },
+    "query": "delete from session where token = $1 and (scope_mask & $2) = $2 returning user_id"
+  },
+  "a7597f668f530133865fe74a396da14ff51dcb53fc0537df95964ae98649ce1d": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\n        update jig_curation_data\n        set updated_at = now()\n        where jig_id = $1\n    "
+  },
+  "a85530d1d83a7f3cd3786da68f5b489fbddbf411d735cf114817e4417768520b": {
+    "describe": {
+      "columns": [
+        {
+          "name": "index: ImageTagIndex",
+          "ordinal": 0,
+          "type_info": "Int2"
+        },
+        {
+          "name": "display_name",
+          "ordinal": 1,
+          "type_info": "Text"
+        }
+      ],
+      "nullable": [
+        false,
+        false
+      ],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "\nselect index as \"index: ImageTagIndex\", display_name from \"image_tag\"\norder by index\n            "
+  },
+  "a87ea4169f26518cbf7f88c1777bd15bbf72f938d6352567cd549bbe970db5f2": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Int2"
+        ]
+      }
+    },
+    "query": "\nupdate user_color\nset index = index - 1\nwhere index > $2 and user_id = $1\n"
+  },
+  "a88c0449faed385cbc111b4e25068a8dd76a2118de2b5615e6315af23f8ce946": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "update global_animation_upload set processed_at = now(), processing_result = false where animation_id = $1"
+  },
+  "a927e1b316983d98397a454a3198b08fcd37cb54056c0a5e57c18bbfcaa0985c": {
+    "describe": {
+      "columns": [
+        {
+          "name": "exists!",
+          "ordinal": 0,
+          "type_info": "Bool"
+        }
+      ],
+      "nullable": [
+        null
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\nselect exists(select 1 from user_recent_image where user_id = $1 and image_id = $2) as \"exists!\"\n            "
+  },
+  "a9780ea48594dbed705b4df8442e7c58416785833da7e04ef32aa8a3bfcd0e21": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "delete from user_auth_basic where user_id = $1"
+  },
+  "a9996186c133f11e9d24a68f2f686c99b5f65fc97b4de1ea89411b16b333afb5": {
+    "describe": {
+      "columns": [
+        {
+          "name": "exists!",
+          "ordinal": 0,
+          "type_info": "Bool"
+        }
+      ],
+      "nullable": [
+        null
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Int2",
+          "Int2"
+        ]
+      }
+    },
+    "query": "select exists(\n            select 1\n            from \"user_scope\"\n            where\n                user_id = $1 and\n                (scope = $2 or scope = $3)\n        ) as \"exists!\""
+  },
+  "ab605fef6d23ea4a74e80999574296f7b4fce2ed0029455be3d6541ee379d329": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\ninsert into jig_data\n(display_name, created_at, updated_at, language, last_synced_at, description, theme, audio_background,\n audio_feedback_negative, audio_feedback_positive, direction, display_score, drag_assist, track_assessments, privacy_level, other_keywords, translated_keywords, translated_description)\nselect display_name,\n       created_at,\n       updated_at,\n       language,\n       last_synced_at,\n       description,\n       theme,\n       audio_background,\n       audio_feedback_negative,\n       audio_feedback_positive,\n       direction,\n       display_score,\n       drag_assist,\n       track_assessments,\n       privacy_level,\n       other_keywords,\n       translated_keywords,\n       translated_description::jsonb\nfrom jig_data\nwhere id = $1\nreturning id\n        "
+  },
+  "abd49e91a2a6278531da084d0a7e251bd816eba32da855e0d1eb332ef6dccdf3": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Jsonb"
+        ]
+      }
+    },
+    "query": "\n                        update image_metadata \n                        set translated_description = $2,\n                            updated_at = now()\n                        where id = $1\n                        "
+  },
+  "ada31ac34d9d4b99d869df3190ad4e105413aa9db4e285b48d7b04eca85d63ca": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id!: JigId",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Uuid",
+          "Uuid",
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\ninsert into jig (creator_id, author_id, parents, live_id, draft_id, published_at, jig_focus)\nselect creator_id, $2, array_append(parents, $1), $3, $4, published_at, jig_focus\nfrom jig\nwhere id = $1\nreturning id as \"id!: JigId\"\n"
+  },
+  "aec729ae876f9816b6a64f6527c6e8497140391a8bebb7a00fc5418cb07682a8": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Int2"
+        ]
+      }
+    },
+    "query": "\ndelete from image_tag where index = $1\n            "
+  },
+  "aef23353cf5529b174a364ec8034d480a7bf91169c379b0a6c4c2267f8cccb3f": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id!: JigId",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "creator_id",
+          "ordinal": 1,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "author_id",
+          "ordinal": 2,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "author_name",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "live_id!",
+          "ordinal": 4,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "draft_id!",
+          "ordinal": 5,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "published_at",
+          "ordinal": 6,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "liked_count!",
+          "ordinal": 7,
+          "type_info": "Int8"
+        },
+        {
+          "name": "play_count!",
+          "ordinal": 8,
+          "type_info": "Int8"
+        },
+        {
+          "name": "rating?: JigRating",
+          "ordinal": 9,
+          "type_info": "Int2"
+        },
+        {
+          "name": "blocked!",
+          "ordinal": 10,
+          "type_info": "Bool"
+        },
+        {
+          "name": "curated!",
+          "ordinal": 11,
+          "type_info": "Bool"
+        },
+        {
+          "name": "jig_focus!: JigFocus",
+          "ordinal": 12,
+          "type_info": "Int2"
+        }
+      ],
+      "nullable": [
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true
+      ],
+      "parameters": {
+        "Left": [
+          "UuidArray"
+        ]
+      }
+    },
+    "query": "\nselect jig.id                                       as \"id!: JigId\",\n       creator_id,\n       author_id                                as \"author_id\",\n       (select given_name || ' '::text || family_name\n        from user_profile\n        where user_profile.user_id = author_id) as \"author_name\",\n       live_id                                  as \"live_id!\",\n       draft_id                                 as \"draft_id!\",\n       published_at,\n       liked_count                              as \"liked_count!\",\n       (\n           select play_count\n           from jig_play_count\n           where jig_play_count.jig_id = jig.id\n       )                                        as \"play_count!\",\n       rating                                   as \"rating?: JigRating\",\n       blocked                                  as \"blocked!\",\n       curated                                  as \"curated!\",\n       jig_focus                                as \"jig_focus!: JigFocus\"\nfrom jig\n         inner join unnest($1::uuid[])\n    with ordinality t(id, ord) using (id)\n    inner join jig_admin_data \"admin\" on admin.jig_id = jig.id\n    "
+  },
+  "af80bdb7130c63ac120ca80150882fc17c3cc4d1c24c0f5bb8bde46e25f38bf3": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Int2"
+        ]
+      }
+    },
+    "query": "\nupdate jig_data\nset draft_or_live = $2\nwhere id = $1\n            "
+  },
+  "b093762d4b40e825b57962cb833a8144a57270a3029f0cd6362d956b701e0651": {
+    "describe": {
+      "columns": [
+        {
+          "name": "token",
+          "ordinal": 0,
+          "type_info": "Text"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "select token from \"session\" order by created_at limit 1"
+  },
+  "b1a15c616e8f86aa4d7bd37701eb692298a9b55afafa797e6ded14ba650f2bb3": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\ndelete\nfrom jig\nwhere creator_id is not distinct from $1\n"
+  },
+  "b211b1f87835114b657632739dc3502a1de67cb2c971b0e53c4283b9086eaa9c": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Int2"
+        ]
+      }
+    },
+    "query": "\nupdate jig_data_module\nset index = index - 1\nwhere jig_data_id = $1\n  and index > $2\n"
+  },
+  "b215f3c20b41f2ac1dbf3c8fdc2a98635a0bad092530bdd53654bb0a53674e24": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Text",
+          "Text",
+          "Text",
+          "Text",
+          "Text",
+          "Text",
+          "Bool"
+        ]
+      }
+    },
+    "query": "\nupdate user_profile\nset username               = coalesce($2, username),\n    given_name             = coalesce($3, given_name),\n    family_name            = coalesce($4, family_name),\n    language               = coalesce($5, language),\n    locale                 = coalesce($6, locale),\n    timezone               = coalesce($7, timezone),\n    opt_into_edu_resources = coalesce($8, opt_into_edu_resources)\nwhere user_id = $1\n  and (($2::text is not null and $2 is distinct from username) or\n       ($3::text is not null and $3 is distinct from given_name) or\n       ($4::text is not null and $4 is distinct from family_name) or\n       ($5::text is not null and $5 is distinct from language) or\n       ($6::text is not null and $6 is distinct from locale) or\n       ($7::text is not null and $7 is distinct from timezone) or\n       ($8::bool is not null and $8 is distinct from opt_into_edu_resources) )\n    "
+  },
+  "b4338c9f23e8fad86b9bc505f8d366e02ca2c59cb4ac11255ef3d84e68daf79c": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id!: CommentId",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Text",
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\ninsert into jig_curation_comment (jig_id, comment, author_id)\nvalues ($1, $2, $3)\nreturning id as \"id!: CommentId\"\n        "
+  },
+  "b4f3858831e1685ac7bf663ebddc340a804437258fce9803fd079c084b38e470": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "update global_animation_upload set processed_at = now(), processing_result = true where animation_id = $1"
+  },
+  "b5949f227788bc5e36a22b50498a85a8be8cefd31395f4892b2e0932ba05dfaa": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id: PdfId",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "select id as \"id: PdfId\" from user_pdf_library order by created_at desc"
+  },
+  "b73bc1e83d2008fc5b9cc7e9a6c9a6b67b136c45a41e39a8929b554dc5c98485": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Int2"
+        ]
+      }
+    },
+    "query": "update \"settings\" set algolia_index_version = $1"
+  },
+  "ba59bad8a7aef54f3ee9054118d79bbb2be4ce0371960a979ea74feced71d8e2": {
+    "describe": {
+      "columns": [
+        {
+          "name": "name",
+          "ordinal": 0,
+          "type_info": "Text"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\nselect name\nfrom user_font\nwhere user_id = $1\norder by index\n        "
+  },
+  "ba7c4c90935d487d2217c74eacc4362e96f8dc07c9f45e3741b4a46b3cf06155": {
+    "describe": {
+      "columns": [
+        {
+          "name": "draft_id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\nselect draft_id from jig where jig.id = $1\n"
+  },
+  "bb5a9faaff748e864bcb9fb956585e7577313b263dbf2fe0e146a8c48af134c9": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Text"
+        ]
+      }
+    },
+    "query": "select user_id as \"id\" from user_profile where (user_id = $1 and $1 is not null) or (username = $2 and $2 is not null)"
+  },
+  "bc43edfc2dcbeea691560c655987b29f3a3c919223487912f63be464fec522a4": {
+    "describe": {
+      "columns": [
+        {
+          "name": "exists!",
+          "ordinal": 0,
+          "type_info": "Bool"
+        }
+      ],
+      "nullable": [
+        null
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\nselect exists(select 1 from user_profile where user_id = $1 for update) as \"exists!\"\n    "
+  },
+  "bfd314e70437482954c5dfb3a40ab08990a0bea43779d810e9dd903e87e10c81": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Bool"
+        ]
+      }
+    },
+    "query": "\nupdate jig_admin_data\nset curated = coalesce($2, curated)\nwhere jig_id = $1 and $2 is distinct from curated\n            "
+  },
+  "c0503b4756010f70f84bfc842758cc356568bcb7324b0c0a8454f49511300942": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Int2"
+        ]
+      }
+    },
+    "query": "insert into user_scope (user_id, scope) values ($1, $2)"
+  },
+  "c0f2792d2f5f952c0f6becbd49c168ca420c910e6c93102ad8896704aecc39ac": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Int2",
+          "Int2",
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\nupdate category\nset updated_at = now(),\n    index = index + 1\nwhere index >= $1 and index < $2 and parent_id is not distinct from $3\n                "
+  },
+  "c112679df052326f66d3b7891480bf331d2748861fcd3f23ffaa9176804ea55b": {
+    "describe": {
+      "columns": [
+        {
+          "name": "algolia_index_version!",
+          "ordinal": 0,
+          "type_info": "Int2"
+        }
+      ],
+      "nullable": [
+        null
+      ],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "\nwith new_row as (\n    insert into \"settings\" default values on conflict(singleton) do nothing returning algolia_index_version\n)\nselect algolia_index_version as \"algolia_index_version!\" from new_row\nunion\nselect algolia_index_version as \"algolia_index_version!\" from \"settings\"\n"
+  },
+  "c2ba8ddd6ad6e28535559d4452b655095914cb90514490dac438fc27b686bde5": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Int2",
+          "Int2"
+        ]
+      }
+    },
+    "query": "\nupdate jig_data_module\nset\n    index = case when index = $2 then $3 else index + 1 end,\n    updated_at = now()\nwhere jig_data_id = $1 and index between $3 and $2\n"
+  },
+  "c340da8122545a5c5cffc7a9b7c8b03d6d7eed1e58ece1d6a462dbcebe030f10": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Int2"
+        ]
+      }
+    },
+    "query": "\nupdate jig_data\nset audio_background = $2,\nupdated_at = now()\nwhere id = $1 and $2 is distinct from audio_background\n            "
+  },
+  "c84c613c4d8af5d5228646ffb25c2cd2825699626313634127fc09341ed715ac": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id: ImageId",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "kind: ImageKind",
+          "ordinal": 1,
+          "type_info": "Int2"
+        }
+      ],
+      "nullable": [
+        false,
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\nselect id as \"id: ImageId\", kind as \"kind: ImageKind\"\nfrom user_image_library\n         inner join user_image_upload\n                    on user_image_library.id = user_image_upload.image_id\nwhere user_id = $1\n  and id = $2\n  and processing_result is true\n        "
+  },
+  "c877be5757f8787c2da80469a4fc50641fb63358e6516d05c7159d9c8060ac52": {
+    "describe": {
+      "columns": [
+        {
+          "name": "kind: MediaKind",
+          "ordinal": 0,
+          "type_info": "Int2"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\nselect kind as \"kind: MediaKind\"\nfrom web_media_library\ninner join web_media_upload on web_media_library.id = web_media_upload.media_id\nwhere (id = $1 and uploaded_at is not null and processed_at >= uploaded_at is not true)\nfor no key update of web_media_upload\nfor share of web_media_library\nskip locked\n        "
+  },
+  "c88323000ed380c0fb9c599dc26accc3cbe54b3d82f4c10a8fbc66c4803bbff4": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "display_name!",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "updated_at",
+          "ordinal": 2,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "language!",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "description!",
+          "ordinal": 4,
+          "type_info": "Text"
+        },
+        {
+          "name": "translated_description!: Json<HashMap<String,String>>",
+          "ordinal": 5,
+          "type_info": "Jsonb"
+        },
+        {
+          "name": "direction!: TextDirection",
+          "ordinal": 6,
+          "type_info": "Int2"
+        },
+        {
+          "name": "display_score!",
+          "ordinal": 7,
+          "type_info": "Bool"
+        },
+        {
+          "name": "track_assessments!",
+          "ordinal": 8,
+          "type_info": "Bool"
+        },
+        {
+          "name": "drag_assist!",
+          "ordinal": 9,
+          "type_info": "Bool"
+        },
+        {
+          "name": "theme!: ThemeId",
+          "ordinal": 10,
+          "type_info": "Int2"
+        },
+        {
+          "name": "audio_background!: Option<AudioBackground>",
+          "ordinal": 11,
+          "type_info": "Int2"
+        },
+        {
+          "name": "audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>",
+          "ordinal": 12,
+          "type_info": "RecordArray"
+        },
+        {
+          "name": "audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>",
+          "ordinal": 13,
+          "type_info": "RecordArray"
+        },
+        {
+          "name": "modules!: Vec<(ModuleId, ModuleKind, bool)>",
+          "ordinal": 14,
+          "type_info": "RecordArray"
+        },
+        {
+          "name": "categories!: Vec<(CategoryId,)>",
+          "ordinal": 15,
+          "type_info": "RecordArray"
+        },
+        {
+          "name": "affiliations!: Vec<(AffiliationId,)>",
+          "ordinal": 16,
+          "type_info": "RecordArray"
+        },
+        {
+          "name": "age_ranges!: Vec<(AgeRangeId,)>",
+          "ordinal": 17,
+          "type_info": "RecordArray"
+        },
+        {
+          "name": "additional_resource!: Vec<(AddId, String, TypeId, Value)>",
+          "ordinal": 18,
+          "type_info": "RecordArray"
+        },
+        {
+          "name": "privacy_level!: PrivacyLevel",
+          "ordinal": 19,
+          "type_info": "Int2"
+        },
+        {
+          "name": "locked!",
+          "ordinal": 20,
+          "type_info": "Bool"
+        },
+        {
+          "name": "other_keywords!",
+          "ordinal": 21,
+          "type_info": "Text"
+        },
+        {
+          "name": "translated_keywords!",
+          "ordinal": 22,
+          "type_info": "Text"
+        }
+      ],
       "nullable": [
         true,
         true,
@@ -5302,106 +5126,112 @@
         true,
         true,
         true
-      ]
-    }
+      ],
+      "parameters": {
+        "Left": [
+          "UuidArray"
+        ]
+      }
+    },
+    "query": "\nselect id,\n       display_name                                                                  as \"display_name!\",\n       updated_at,\n       language                                                                      as \"language!\",\n       description                                                                   as \"description!\",\n       translated_description                                                        as \"translated_description!: Json<HashMap<String,String>>\",\n       direction                                                                     as \"direction!: TextDirection\",\n       display_score                                                                 as \"display_score!\",\n       track_assessments                                                             as \"track_assessments!\",\n       drag_assist                                                                   as \"drag_assist!\",\n       theme                                                                         as \"theme!: ThemeId\",\n       audio_background                                                              as \"audio_background!: Option<AudioBackground>\",\n       array(select row (unnest(audio_feedback_positive)))                           as \"audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>\",\n       array(select row (unnest(audio_feedback_negative)))                           as \"audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>\",\n       array(\n               select row (jig_data_module.id, kind, is_complete)\n               from jig_data_module\n               where jig_data_id = jig_data.id\n               order by \"index\"\n           )                                               as \"modules!: Vec<(ModuleId, ModuleKind, bool)>\",\n       array(select row (category_id)\n             from jig_data_category\n             where jig_data_id = jig_data.id)     as \"categories!: Vec<(CategoryId,)>\",\n       array(select row (affiliation_id)\n             from jig_data_affiliation\n             where jig_data_id = jig_data.id)     as \"affiliations!: Vec<(AffiliationId,)>\",\n       array(select row (age_range_id)\n             from jig_data_age_range\n             where jig_data_id = jig_data.id)     as \"age_ranges!: Vec<(AgeRangeId,)>\",\n       array(\n                select row (jdar.id, jdar.display_name, resource_type_id, resource_content)\n                from jig_data_additional_resource \"jdar\"\n                where jdar.jig_data_id = jig_data.id\n            )                                               as \"additional_resource!: Vec<(AddId, String, TypeId, Value)>\",\n       privacy_level                              as \"privacy_level!: PrivacyLevel\",\n       locked                                     as \"locked!\",\n       other_keywords                             as \"other_keywords!\",\n       translated_keywords                        as \"translated_keywords!\"\nfrom jig_data\n         inner join unnest($1::uuid[])\n    with ordinality t(id, ord) using (id)\nwhere draft_or_live is not null\n"
   },
   "c8b56c12795686a4ecf068a13f44acab1b3382515c4b21024d95cb867e76fed1": {
-    "query": "\nselect id as \"jig_id!: JigId\" from jig where creator_id = $1\n",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "jig_id!: JigId",
+          "ordinal": 0,
           "type_info": "Uuid"
         }
+      ],
+      "nullable": [
+        false
       ],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": [
-        false
-      ]
-    }
+      }
+    },
+    "query": "\nselect id as \"jig_id!: JigId\" from jig where creator_id = $1\n"
   },
   "c978fbc346982e56b18ba41565e30eeab9e54d71e05d93a0444bd496a1ea7a91": {
-    "query": "\n                            update jig_data \n                            set translated_description = $2,\n                                updated_at = now()\n                            where id = $1\n                            ",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Jsonb"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\n                            update jig_data \n                            set translated_description = $2,\n                                updated_at = now()\n                            where id = $1\n                            "
   },
   "c9871e12739d5ae1acd8e3026e00ed927a54f717d5e5cd12f78456b99a7aa23b": {
-    "query": "delete from session where user_id = $1",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "delete from session where user_id = $1"
   },
   "c991e500948ede0aba8f2a8bd11f43aa266ae6c986cf0fa9ce1c48f64d4dde5c": {
-    "query": "\nselect exists(select 1 from jig_data_additional_resource \"jdar\" where jig_data_id = $1\n    and jdar.id = $2) as \"exists!\"\n    ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "exists!",
+          "ordinal": 0,
           "type_info": "Bool"
         }
+      ],
+      "nullable": [
+        null
       ],
       "parameters": {
         "Left": [
           "Uuid",
           "Uuid"
         ]
-      },
-      "nullable": [
-        null
-      ]
-    }
+      }
+    },
+    "query": "\nselect exists(select 1 from jig_data_additional_resource \"jdar\" where jig_data_id = $1\n    and jdar.id = $2) as \"exists!\"\n    "
   },
   "ca807853c119226252820e8cd0f9476d114f3e5e98ffed0dcd059d05063760a4": {
-    "query": "\nupdate jig_admin_data\nset rating = coalesce($2, rating)\nwhere jig_id = $1 and $2 is distinct from rating\n            ",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Int2"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\nupdate jig_admin_data\nset rating = coalesce($2, rating)\nwhere jig_id = $1 and $2 is distinct from rating\n            "
   },
   "cb1eb42e7bcc8143deb3eec658b4a6d23278f99ce5bf5062886d0b18c1b2b1d3": {
-    "query": "\nupdate user_font\n    set name = $3\n    where user_id = $1\n    and index = $2\n        ",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Int2",
           "Text"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\nupdate user_font\n    set name = $3\n    where user_id = $1\n    and index = $2\n        "
   },
   "cbe91f67c21c82fba293fc2b95ea89ad4e7a5c29eadc612db2809bf4f0eda980": {
-    "query": "\nupdate jig_data\nset display_name     = coalesce($2, display_name),\n    language         = coalesce($3, language),\n    theme            = coalesce($4, theme),\n    updated_at = now()\n\nwhere id = $1\n  and (($2::text is not null and $2 is distinct from display_name) or\n       ($3::text is not null and $3 is distinct from language) or\n       ($4::smallint is not null and $4 is distinct from theme))\n",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
@@ -5409,228 +5239,373 @@
           "Text",
           "Int2"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\nupdate jig_data\nset display_name     = coalesce($2, display_name),\n    language         = coalesce($3, language),\n    theme            = coalesce($4, theme),\n    updated_at = now()\n\nwhere id = $1\n  and (($2::text is not null and $2 is distinct from display_name) or\n       ($3::text is not null and $3 is distinct from language) or\n       ($4::smallint is not null and $4 is distinct from theme))\n"
   },
   "cbf72977b86cfd79cc5b3577cad8ce2b11394b783608e0f7d947e271bc1d2663": {
-    "query": "\nselect exists (\n    select 1 from jig where id = $1\n) as \"authed!\"\n",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "authed!",
+          "ordinal": 0,
           "type_info": "Bool"
         }
+      ],
+      "nullable": [
+        null
       ],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
+      }
+    },
+    "query": "\nselect exists (\n    select 1 from jig where id = $1\n) as \"authed!\"\n"
+  },
+  "cc1e8bf236f943c1b78344e1685ed3020de3e00960f7e59be6320ce9538904a3": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "parent_id",
+          "ordinal": 1,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "name",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "index",
+          "ordinal": 3,
+          "type_info": "Int2"
+        },
+        {
+          "name": "created_at",
+          "ordinal": 4,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "updated_at",
+          "ordinal": 5,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "user_scopes",
+          "ordinal": 6,
+          "type_info": "Int2Array"
+        }
+      ],
       "nullable": [
-        null
-      ]
-    }
+        false,
+        true,
+        false,
+        false,
+        false,
+        true,
+        false
+      ],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "\nselect id,\n       parent_id,\n       name,\n       index,\n       created_at,\n       updated_at,\n       user_scopes\nfrom category\norder by index\n"
+  },
+  "ccaab803ac7df84e46c738158dc62311d906d6da57a8b1c701855e2a8bd4c2f8": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "parent_id",
+          "ordinal": 1,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "name",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "index",
+          "ordinal": 3,
+          "type_info": "Int2"
+        },
+        {
+          "name": "created_at",
+          "ordinal": 4,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "updated_at",
+          "ordinal": 5,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "user_scopes",
+          "ordinal": 6,
+          "type_info": "Int2Array"
+        }
+      ],
+      "nullable": [
+        false,
+        true,
+        false,
+        false,
+        false,
+        true,
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "UuidArray"
+        ]
+      }
+    },
+    "query": "with recursive links as\n(\n    select id,\n    parent_id\n    from category co\n    where id = any ($1::uuid[])\n    union all\n    select co.id,\n    co.parent_id\n    from category co\n    inner join links ct on (ct.parent_id = co.id)\n)\n\nselect\n    distinct id,\n    category.parent_id,\n    name,\n    category.index,\n    created_at,\n    updated_at,\n    user_scopes\nfrom category\ninner join links using (id);\n"
   },
   "cd49cef54182b43dd7943bcd51fd3c535f4a8ec0dae95cbc8ceb39f7f757fe02": {
-    "query": "delete from locale_entry where id = $1",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Int4"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "delete from locale_entry where id = $1"
   },
   "ceee83d2943409d2f3a3e5a70b7ae3d423d39cf2b15af44565c6f4100abcfc31": {
-    "query": "insert into user_pdf_upload (pdf_id) values($1)",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "insert into user_pdf_upload (pdf_id) values($1)"
   },
   "d1755b3eae871811d2c69c1129b47db6c5414f62f6264b11eb610f1bc24ee92a": {
-    "query": "\nwith cte as (\n    select array(select jd.id as \"id!\"\n    from jig_data \"jd\"\n          left join jig on (draft_id = jd.id or (live_id = jd.id and jd.last_synced_at is not null))\n          left join jig_admin_data \"admin\" on admin.jig_id = jig.id\n          left join jig_data_additional_resource \"resource\" on jd.id = resource.jig_data_id\n    where (jd.draft_or_live = $3 or $3 is null)\n        and (author_id = $1 or $1 is null)\n        and (jig_focus = $2 or $2 is null)\n        and (blocked = $4 or $4 is null)\n        and (jd.privacy_level = any($5) or $5 = array[]::smallint[])\n        and (resource.resource_type_id = any($8) or $8 = array[]::uuid[])\n    order by coalesce(updated_at, created_at) desc) as id\n),\ncte1 as (\n    select * from unnest((select distinct id from cte)) with ordinality t(id\n   , ord) order by ord\n)\nselect jig.id                                              as \"jig_id: JigId\",\n    privacy_level                                       as \"privacy_level: PrivacyLevel\",\n    jig_focus                                           as \"jig_focus!: JigFocus\",\n    creator_id,\n    author_id,\n    (select given_name || ' '::text || family_name\n     from user_profile\n     where user_profile.user_id = author_id)            as \"author_name\",\n    published_at,\n    liked_count,\n    (\n         select play_count\n         from jig_play_count\n         where jig_play_count.jig_id = jig.id\n    )                                                   as \"play_count!\",\n   display_name                                                                  as \"display_name!\",\n   updated_at,\n   language                                                                      as \"language!\",\n   description                                                                   as \"description!\",\n   translated_description                                                        as \"translated_description!: Json<HashMap<String,String>>\",\n   direction                                                                     as \"direction!: TextDirection\",\n   display_score                                                                 as \"display_score!\",\n   track_assessments                                                             as \"track_assessments!\",\n   drag_assist                                                                   as \"drag_assist!\",\n   theme                                                                         as \"theme!: ThemeId\",\n   audio_background                                                              as \"audio_background!: Option<AudioBackground>\",\n   draft_or_live                                                                 as \"draft_or_live!: DraftOrLive\",\n   array(select row (unnest(audio_feedback_positive)))                           as \"audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>\",\n   array(select row (unnest(audio_feedback_negative)))                           as \"audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>\",\n   array(\n           select row (jig_data_module.id, kind, is_complete)\n           from jig_data_module\n           where jig_data_id = jig_data.id\n           order by \"index\"\n       )                                               as \"modules!: Vec<(ModuleId, ModuleKind, bool)>\",\n   array(select row (category_id)\n         from jig_data_category\n         where jig_data_id = jig_data.id)     as \"categories!: Vec<(CategoryId,)>\",\n   array(select row (affiliation_id)\n         from jig_data_affiliation\n         where jig_data_id = jig_data.id)     as \"affiliations!: Vec<(AffiliationId,)>\",\n   array(select row (age_range_id)\n         from jig_data_age_range\n         where jig_data_id = jig_data.id)     as \"age_ranges!: Vec<(AgeRangeId,)>\",\n   array(\n            select row (jdar.id, jdar.display_name, resource_type_id, resource_content)\n            from jig_data_additional_resource \"jdar\"\n            where jdar.jig_data_id = jig_data.id\n        )                                               as \"additional_resource!: Vec<(AddId, String, TypeId, Value)>\",\n   locked                                     as \"locked!\",\n   other_keywords                             as \"other_keywords!\",\n   translated_keywords                        as \"translated_keywords!\",\n   rating                                     as \"rating!: Option<JigRating>\",\n   blocked                                    as \"blocked!\",\n   curated                                    as \"curated!\"\nfrom cte1\nleft join jig_data on cte1.id = jig_data.id\nleft join jig on (jig_data.id = jig.draft_id or (jig_data.id = jig.live_id and last_synced_at is not null))\nleft join jig_admin_data \"admin\" on admin.jig_id = jig.id\nwhere cte1.ord > (1 * $6 * $7)\nlimit $7 \n",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "jig_id: JigId",
+          "ordinal": 0,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 1,
           "name": "privacy_level: PrivacyLevel",
+          "ordinal": 1,
           "type_info": "Int2"
         },
         {
-          "ordinal": 2,
           "name": "jig_focus!: JigFocus",
+          "ordinal": 2,
           "type_info": "Int2"
         },
         {
-          "ordinal": 3,
           "name": "creator_id",
+          "ordinal": 3,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 4,
           "name": "author_id",
+          "ordinal": 4,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 5,
           "name": "author_name",
+          "ordinal": 5,
           "type_info": "Text"
         },
         {
-          "ordinal": 6,
           "name": "published_at",
+          "ordinal": 6,
           "type_info": "Timestamptz"
         },
         {
-          "ordinal": 7,
           "name": "liked_count",
+          "ordinal": 7,
           "type_info": "Int8"
         },
         {
-          "ordinal": 8,
           "name": "play_count!",
+          "ordinal": 8,
           "type_info": "Int8"
         },
         {
-          "ordinal": 9,
           "name": "display_name!",
+          "ordinal": 9,
           "type_info": "Text"
         },
         {
-          "ordinal": 10,
           "name": "updated_at",
+          "ordinal": 10,
           "type_info": "Timestamptz"
         },
         {
-          "ordinal": 11,
           "name": "language!",
+          "ordinal": 11,
           "type_info": "Text"
         },
         {
-          "ordinal": 12,
           "name": "description!",
+          "ordinal": 12,
           "type_info": "Text"
         },
         {
-          "ordinal": 13,
           "name": "translated_description!: Json<HashMap<String,String>>",
+          "ordinal": 13,
           "type_info": "Jsonb"
         },
         {
-          "ordinal": 14,
           "name": "direction!: TextDirection",
+          "ordinal": 14,
           "type_info": "Int2"
         },
         {
-          "ordinal": 15,
           "name": "display_score!",
+          "ordinal": 15,
           "type_info": "Bool"
         },
         {
-          "ordinal": 16,
           "name": "track_assessments!",
+          "ordinal": 16,
           "type_info": "Bool"
         },
         {
-          "ordinal": 17,
           "name": "drag_assist!",
+          "ordinal": 17,
           "type_info": "Bool"
         },
         {
-          "ordinal": 18,
           "name": "theme!: ThemeId",
+          "ordinal": 18,
           "type_info": "Int2"
         },
         {
-          "ordinal": 19,
           "name": "audio_background!: Option<AudioBackground>",
+          "ordinal": 19,
           "type_info": "Int2"
         },
         {
-          "ordinal": 20,
           "name": "draft_or_live!: DraftOrLive",
+          "ordinal": 20,
           "type_info": "Int2"
         },
         {
-          "ordinal": 21,
           "name": "audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>",
+          "ordinal": 21,
           "type_info": "RecordArray"
         },
         {
-          "ordinal": 22,
           "name": "audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>",
+          "ordinal": 22,
           "type_info": "RecordArray"
         },
         {
-          "ordinal": 23,
           "name": "modules!: Vec<(ModuleId, ModuleKind, bool)>",
+          "ordinal": 23,
           "type_info": "RecordArray"
         },
         {
-          "ordinal": 24,
           "name": "categories!: Vec<(CategoryId,)>",
+          "ordinal": 24,
           "type_info": "RecordArray"
         },
         {
-          "ordinal": 25,
           "name": "affiliations!: Vec<(AffiliationId,)>",
+          "ordinal": 25,
           "type_info": "RecordArray"
         },
         {
-          "ordinal": 26,
           "name": "age_ranges!: Vec<(AgeRangeId,)>",
+          "ordinal": 26,
           "type_info": "RecordArray"
         },
         {
-          "ordinal": 27,
           "name": "additional_resource!: Vec<(AddId, String, TypeId, Value)>",
+          "ordinal": 27,
           "type_info": "RecordArray"
         },
         {
-          "ordinal": 28,
           "name": "locked!",
+          "ordinal": 28,
           "type_info": "Bool"
         },
         {
-          "ordinal": 29,
           "name": "other_keywords!",
+          "ordinal": 29,
           "type_info": "Text"
         },
         {
-          "ordinal": 30,
           "name": "translated_keywords!",
+          "ordinal": 30,
           "type_info": "Text"
         },
         {
-          "ordinal": 31,
           "name": "rating!: Option<JigRating>",
+          "ordinal": 31,
           "type_info": "Int2"
         },
         {
-          "ordinal": 32,
           "name": "blocked!",
+          "ordinal": 32,
           "type_info": "Bool"
         },
         {
-          "ordinal": 33,
           "name": "curated!",
+          "ordinal": 33,
           "type_info": "Bool"
         }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        true,
+        true,
+        null,
+        true,
+        false,
+        null,
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false
       ],
       "parameters": {
         "Left": [
@@ -5643,247 +5618,206 @@
           "Int4",
           "UuidArray"
         ]
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        true,
-        true,
-        null,
-        true,
-        false,
-        null,
-        false,
-        true,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        true,
-        true,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        false,
-        false,
-        false,
-        true,
-        false,
-        false
-      ]
-    }
+      }
+    },
+    "query": "\nwith cte as (\n    select array(select jd.id as \"id!\"\n    from jig_data \"jd\"\n          left join jig on (draft_id = jd.id or (live_id = jd.id and jd.last_synced_at is not null))\n          left join jig_admin_data \"admin\" on admin.jig_id = jig.id\n          left join jig_data_additional_resource \"resource\" on jd.id = resource.jig_data_id\n    where (jd.draft_or_live = $3 or $3 is null)\n        and (author_id = $1 or $1 is null)\n        and (jig_focus = $2 or $2 is null)\n        and (blocked = $4 or $4 is null)\n        and (jd.privacy_level = any($5) or $5 = array[]::smallint[])\n        and (resource.resource_type_id = any($8) or $8 = array[]::uuid[])\n    order by coalesce(updated_at, created_at) desc) as id\n),\ncte1 as (\n    select * from unnest((select distinct id from cte)) with ordinality t(id\n   , ord) order by ord\n)\nselect jig.id                                              as \"jig_id: JigId\",\n    privacy_level                                       as \"privacy_level: PrivacyLevel\",\n    jig_focus                                           as \"jig_focus!: JigFocus\",\n    creator_id,\n    author_id,\n    (select given_name || ' '::text || family_name\n     from user_profile\n     where user_profile.user_id = author_id)            as \"author_name\",\n    published_at,\n    liked_count,\n    (\n         select play_count\n         from jig_play_count\n         where jig_play_count.jig_id = jig.id\n    )                                                   as \"play_count!\",\n   display_name                                                                  as \"display_name!\",\n   updated_at,\n   language                                                                      as \"language!\",\n   description                                                                   as \"description!\",\n   translated_description                                                        as \"translated_description!: Json<HashMap<String,String>>\",\n   direction                                                                     as \"direction!: TextDirection\",\n   display_score                                                                 as \"display_score!\",\n   track_assessments                                                             as \"track_assessments!\",\n   drag_assist                                                                   as \"drag_assist!\",\n   theme                                                                         as \"theme!: ThemeId\",\n   audio_background                                                              as \"audio_background!: Option<AudioBackground>\",\n   draft_or_live                                                                 as \"draft_or_live!: DraftOrLive\",\n   array(select row (unnest(audio_feedback_positive)))                           as \"audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>\",\n   array(select row (unnest(audio_feedback_negative)))                           as \"audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>\",\n   array(\n           select row (jig_data_module.id, kind, is_complete)\n           from jig_data_module\n           where jig_data_id = jig_data.id\n           order by \"index\"\n       )                                               as \"modules!: Vec<(ModuleId, ModuleKind, bool)>\",\n   array(select row (category_id)\n         from jig_data_category\n         where jig_data_id = jig_data.id)     as \"categories!: Vec<(CategoryId,)>\",\n   array(select row (affiliation_id)\n         from jig_data_affiliation\n         where jig_data_id = jig_data.id)     as \"affiliations!: Vec<(AffiliationId,)>\",\n   array(select row (age_range_id)\n         from jig_data_age_range\n         where jig_data_id = jig_data.id)     as \"age_ranges!: Vec<(AgeRangeId,)>\",\n   array(\n            select row (jdar.id, jdar.display_name, resource_type_id, resource_content)\n            from jig_data_additional_resource \"jdar\"\n            where jdar.jig_data_id = jig_data.id\n        )                                               as \"additional_resource!: Vec<(AddId, String, TypeId, Value)>\",\n   locked                                     as \"locked!\",\n   other_keywords                             as \"other_keywords!\",\n   translated_keywords                        as \"translated_keywords!\",\n   rating                                     as \"rating!: Option<JigRating>\",\n   blocked                                    as \"blocked!\",\n   curated                                    as \"curated!\"\nfrom cte1\nleft join jig_data on cte1.id = jig_data.id\nleft join jig on (jig_data.id = jig.draft_id or (jig_data.id = jig.live_id and last_synced_at is not null))\nleft join jig_admin_data \"admin\" on admin.jig_id = jig.id\nwhere cte1.ord > (1 * $6 * $7)\nlimit $7 \n"
   },
   "d201d9e5aec8be8b9ecf9a698f834a73a0fabc887886d198e12d387b8e9d78f5": {
-    "query": "\nselect kind as \"kind: ImageKind\"\nfrom image_metadata\ninner join image_upload on image_metadata.id = image_upload.image_id\nwhere (id = $1 and uploaded_at is not null and processed_at >= uploaded_at is not true)\nfor no key update of image_upload\nfor share of image_metadata\nskip locked\n        ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "kind: ImageKind",
+          "ordinal": 0,
           "type_info": "Int2"
         }
+      ],
+      "nullable": [
+        false
       ],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": [
-        false
-      ]
-    }
+      }
+    },
+    "query": "\nselect kind as \"kind: ImageKind\"\nfrom image_metadata\ninner join image_upload on image_metadata.id = image_upload.image_id\nwhere (id = $1 and uploaded_at is not null and processed_at >= uploaded_at is not true)\nfor no key update of image_upload\nfor share of image_metadata\nskip locked\n        "
   },
   "d25b7fd117db9d6b42dde5f7c8e16e1e6e48f450a00c62c2bf4e8bd7bab2815a": {
-    "query": "\nselect user_id              as \"id!\",\n    username                as \"username!\",\n    user_email.email::text  as \"email!\",\n    given_name              as \"given_name!\",\n    family_name             as \"family_name!\",\n    profile_image_id        as \"profile_image?: ImageId\",\n    language                as \"language!\",\n    user_profile.created_at as \"created_at!\",\n    user_profile.updated_at,\n    organization,\n    persona                 as \"persona!: Vec<String>\",\n    location,\n    array(\n        select subject.display_name\n        from subject\n        inner join user_subject on subject.subject_id = user_subject.subject_id\n        where user_subject.user_id = \"user\".id\n    ) as \"subjects!: Vec<String>\",\n    array(\n        select affiliation.display_name\n        from affiliation\n        inner join user_affiliation on affiliation.id = user_affiliation.affiliation_id\n        where user_affiliation.user_id = \"user\".id\n    ) as \"affiliations!: Vec<String>\",\n    array(\n        select age_range.display_name\n        from age_range\n        inner join user_age_range on age_range.id = user_age_range.age_range_id\n        where user_age_range.user_id = \"user\".id\n    ) as \"age_ranges!: Vec<String>\"\nfrom \"user\"\n    inner join user_profile on \"user\".id = user_profile.user_id\n    inner join user_email using(user_id)\nwhere\n    (\n        user_profile.created_at >= case when $1::timestamptz is null then to_timestamp('-infinity') else $1 end\n        and user_profile.created_at < case when $2::timestamptz is null then to_timestamp('infinity') else $2 end\n    )\n    or (\n        user_profile.updated_at >= case when $1::timestamptz is null then to_timestamp('-infinity') else $1 end\n        and user_profile.updated_at < case when $2::timestamptz is null then to_timestamp('infinity') else $2 end\n    )\n",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id!",
+          "ordinal": 0,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 1,
           "name": "username!",
+          "ordinal": 1,
           "type_info": "Text"
         },
         {
-          "ordinal": 2,
           "name": "email!",
+          "ordinal": 2,
           "type_info": "Text"
         },
         {
-          "ordinal": 3,
           "name": "given_name!",
+          "ordinal": 3,
           "type_info": "Text"
         },
         {
-          "ordinal": 4,
           "name": "family_name!",
+          "ordinal": 4,
           "type_info": "Text"
         },
         {
-          "ordinal": 5,
           "name": "profile_image?: ImageId",
+          "ordinal": 5,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 6,
           "name": "language!",
+          "ordinal": 6,
           "type_info": "Text"
         },
         {
-          "ordinal": 7,
           "name": "created_at!",
+          "ordinal": 7,
           "type_info": "Timestamptz"
         },
         {
-          "ordinal": 8,
           "name": "updated_at",
+          "ordinal": 8,
           "type_info": "Timestamptz"
         },
         {
-          "ordinal": 9,
           "name": "organization",
+          "ordinal": 9,
           "type_info": "Text"
         },
         {
-          "ordinal": 10,
           "name": "persona!: Vec<String>",
+          "ordinal": 10,
           "type_info": "TextArray"
         },
         {
-          "ordinal": 11,
           "name": "location",
+          "ordinal": 11,
           "type_info": "Jsonb"
         },
         {
-          "ordinal": 12,
           "name": "subjects!: Vec<String>",
+          "ordinal": 12,
           "type_info": "TextArray"
         },
         {
-          "ordinal": 13,
           "name": "affiliations!: Vec<String>",
+          "ordinal": 13,
           "type_info": "TextArray"
         },
         {
-          "ordinal": 14,
           "name": "age_ranges!: Vec<String>",
+          "ordinal": 14,
           "type_info": "TextArray"
         }
+      ],
+      "nullable": [
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true
       ],
       "parameters": {
         "Left": [
           "Timestamptz",
           "Timestamptz"
         ]
-      },
-      "nullable": [
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true
-      ]
-    }
+      }
+    },
+    "query": "\nselect user_id              as \"id!\",\n    username                as \"username!\",\n    user_email.email::text  as \"email!\",\n    given_name              as \"given_name!\",\n    family_name             as \"family_name!\",\n    profile_image_id        as \"profile_image?: ImageId\",\n    language                as \"language!\",\n    user_profile.created_at as \"created_at!\",\n    user_profile.updated_at,\n    organization,\n    persona                 as \"persona!: Vec<String>\",\n    location,\n    array(\n        select subject.display_name\n        from subject\n        inner join user_subject on subject.subject_id = user_subject.subject_id\n        where user_subject.user_id = \"user\".id\n    ) as \"subjects!: Vec<String>\",\n    array(\n        select affiliation.display_name\n        from affiliation\n        inner join user_affiliation on affiliation.id = user_affiliation.affiliation_id\n        where user_affiliation.user_id = \"user\".id\n    ) as \"affiliations!: Vec<String>\",\n    array(\n        select age_range.display_name\n        from age_range\n        inner join user_age_range on age_range.id = user_age_range.age_range_id\n        where user_age_range.user_id = \"user\".id\n    ) as \"age_ranges!: Vec<String>\"\nfrom \"user\"\n    inner join user_profile on \"user\".id = user_profile.user_id\n    inner join user_email using(user_id)\nwhere\n    (\n        user_profile.created_at >= case when $1::timestamptz is null then to_timestamp('-infinity') else $1 end\n        and user_profile.created_at < case when $2::timestamptz is null then to_timestamp('infinity') else $2 end\n    )\n    or (\n        user_profile.updated_at >= case when $1::timestamptz is null then to_timestamp('-infinity') else $1 end\n        and user_profile.updated_at < case when $2::timestamptz is null then to_timestamp('infinity') else $2 end\n    )\n"
   },
   "d29f849b3862377aad3694dc91bdff912732b6fe883120658234884ccf2d6ca6": {
-    "query": "update web_media_upload set uploaded_at = now(), processing_result = null where media_id = $1",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "update web_media_upload set uploaded_at = now(), processing_result = null where media_id = $1"
   },
   "d2d8130135ba5fcf56cd25706a0c1d4bceef2c7c3c984c7827ec29ee32106dc9": {
-    "query": "\nselect jig_id                               as \"jig_id!: JigId\",\n       display_name,\n       language,\n       categories,\n       description,\n       age_ranges,\n       affiliations,\n       additional_resources,\n       curation_status                          as \"curation_status!: JigCurationStatus\",\n       array(\n            select row (jcc.id, jcc.jig_id, comment, created_at, author_id)\n            from jig_curation_comment  \"jcc\"\n            where jcd.jig_id = jcc.jig_id\n            order by created_at desc\n       )                                                    as \"comments!: Vec<(CommentId, JigId, String, DateTime<Utc>, Uuid)>\",\n       array(\n           select row (jr.id, jr.jig_id, report_type, reporter_id,        \n                        (\n                        select given_name || ' '::text || family_name\n                        from user_profile\n                        where user_profile.user_id = reporter_id\n                        ),\n                        (\n                            select email::text\n                            from user_email\n                            where user_email.user_id = reporter_id\n                        ),\n                        created_at                                                                         \n            )\n           from jig_report \"jr\"\n           where jcd.jig_id = jr.jig_id\n           order by created_at desc\n       )                                                    as \"reports!: Vec<(JigReport)>\"\nfrom jig_curation_data \"jcd\"\nwhere jig_id = $1\n",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "jig_id!: JigId",
+          "ordinal": 0,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 1,
           "name": "display_name",
+          "ordinal": 1,
           "type_info": "Bool"
         },
         {
-          "ordinal": 2,
           "name": "language",
+          "ordinal": 2,
           "type_info": "Bool"
         },
         {
-          "ordinal": 3,
           "name": "categories",
+          "ordinal": 3,
           "type_info": "Bool"
         },
         {
-          "ordinal": 4,
           "name": "description",
+          "ordinal": 4,
           "type_info": "Bool"
         },
         {
-          "ordinal": 5,
           "name": "age_ranges",
+          "ordinal": 5,
           "type_info": "Bool"
         },
         {
-          "ordinal": 6,
           "name": "affiliations",
+          "ordinal": 6,
           "type_info": "Bool"
         },
         {
-          "ordinal": 7,
           "name": "additional_resources",
+          "ordinal": 7,
           "type_info": "Bool"
         },
         {
-          "ordinal": 8,
           "name": "curation_status!: JigCurationStatus",
+          "ordinal": 8,
           "type_info": "Int2"
         },
         {
-          "ordinal": 9,
           "name": "comments!: Vec<(CommentId, JigId, String, DateTime<Utc>, Uuid)>",
+          "ordinal": 9,
           "type_info": "RecordArray"
         },
         {
-          "ordinal": 10,
           "name": "reports!: Vec<(JigReport)>",
+          "ordinal": 10,
           "type_info": "RecordArray"
         }
       ],
-      "parameters": {
-        "Left": [
-          "Uuid"
-        ]
-      },
       "nullable": [
         false,
         false,
@@ -5896,95 +5830,103 @@
         false,
         null,
         null
-      ]
-    }
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\nselect jig_id                               as \"jig_id!: JigId\",\n       display_name,\n       language,\n       categories,\n       description,\n       age_ranges,\n       affiliations,\n       additional_resources,\n       curation_status                          as \"curation_status!: JigCurationStatus\",\n       array(\n            select row (jcc.id, jcc.jig_id, comment, created_at, author_id)\n            from jig_curation_comment  \"jcc\"\n            where jcd.jig_id = jcc.jig_id\n            order by created_at desc\n       )                                                    as \"comments!: Vec<(CommentId, JigId, String, DateTime<Utc>, Uuid)>\",\n       array(\n           select row (jr.id, jr.jig_id, report_type, reporter_id,        \n                        (\n                        select given_name || ' '::text || family_name\n                        from user_profile\n                        where user_profile.user_id = reporter_id\n                        ),\n                        (\n                            select email::text\n                            from user_email\n                            where user_email.user_id = reporter_id\n                        ),\n                        created_at                                                                         \n            )\n           from jig_report \"jr\"\n           where jcd.jig_id = jr.jig_id\n           order by created_at desc\n       )                                                    as \"reports!: Vec<(JigReport)>\"\nfrom jig_curation_data \"jcd\"\nwhere jig_id = $1\n"
   },
   "d32e3899d7c0ea60a1ea6d88446a9b182763d14c95a5c7f3084d2928aa286406": {
-    "query": "\nwith cte as (\n    insert into user_color\n    (user_id, color, index)\n    values ($1, $2, (select count(*) from user_color where user_id = $1)) returning color\n), colors as (\n    select color\n    from user_color\n    where user_id = $1\n    order by index\n)\nselect color as \"color!\" from colors\nunion all\nselect color as \"color!\" from cte\n    ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "color!",
+          "ordinal": 0,
           "type_info": "Int4"
         }
+      ],
+      "nullable": [
+        null
       ],
       "parameters": {
         "Left": [
           "Uuid",
           "Int4"
         ]
-      },
-      "nullable": [
-        null
-      ]
-    }
+      }
+    },
+    "query": "\nwith cte as (\n    insert into user_color\n    (user_id, color, index)\n    values ($1, $2, (select count(*) from user_color where user_id = $1)) returning color\n), colors as (\n    select color\n    from user_color\n    where user_id = $1\n    order by index\n)\nselect color as \"color!\" from colors\nunion all\nselect color as \"color!\" from cte\n    "
   },
   "d5f7bcda61b8abb751cc560960d08dbc327b476eb3b9ee8b7e8acb627833fbce": {
-    "query": "\nupdate jig_data_additional_resource\nset resource_content = $3\nwhere jig_data_id = $1 and id = $2\n            ",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Uuid",
           "Jsonb"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\nupdate jig_data_additional_resource\nset resource_content = $3\nwhere jig_data_id = $1 and id = $2\n            "
   },
   "d8032d2eb89764dbd098df12c400d66030d32259400b2f539d60658605ca7648": {
-    "query": "\nselect count(*) as \"count!: i64\" \nfrom image_metadata\n        inner join image_upload on image_id = id \nwhere processing_result is not distinct from true \n    and (publish_at < now() is not distinct from $1 or $1 is null)\n    and (kind is not distinct from $2 or $2 is null)",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "count!: i64",
+          "ordinal": 0,
           "type_info": "Int8"
         }
+      ],
+      "nullable": [
+        null
       ],
       "parameters": {
         "Left": [
           "Bool",
           "Int2"
         ]
-      },
-      "nullable": [
-        null
-      ]
-    }
+      }
+    },
+    "query": "\nselect count(*) as \"count!: i64\" \nfrom image_metadata\n        inner join image_upload on image_id = id \nwhere processing_result is not distinct from true \n    and (publish_at < now() is not distinct from $1 or $1 is null)\n    and (kind is not distinct from $2 or $2 is null)"
   },
   "d887591f2db05a599975d03c3f5adec7074d0d085e2f89c3482a93e74a42d524": {
-    "query": "\ninsert into user_email (user_id, email)\nselect session.user_id, user_auth_basic.email\nfrom session\ninner join user_auth_basic on user_auth_basic.user_id = session.user_id\nwhere\n    session.token = $1 and\n    session.expires_at > now() and\n    (session.scope_mask & $2) = $2\nreturning user_id\n",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "user_id",
+          "ordinal": 0,
           "type_info": "Uuid"
         }
+      ],
+      "nullable": [
+        false
       ],
       "parameters": {
         "Left": [
           "Text",
           "Int2"
         ]
-      },
-      "nullable": [
-        false
-      ]
-    }
+      }
+    },
+    "query": "\ninsert into user_email (user_id, email)\nselect session.user_id, user_auth_basic.email\nfrom session\ninner join user_auth_basic on user_auth_basic.user_id = session.user_id\nwhere\n    session.token = $1 and\n    session.expires_at > now() and\n    (session.scope_mask & $2) = $2\nreturning user_id\n"
   },
   "d935de8ff747d8408644105a61f99219aee129fd49e240cd3843d8374b02ea29": {
-    "query": "\n    insert into jig_report(jig_id, report_type, reporter_id)\n    values ($1, $2, $3)\n    returning id as \"id!: ReportId\"\n            ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id!: ReportId",
+          "ordinal": 0,
           "type_info": "Uuid"
         }
+      ],
+      "nullable": [
+        false
       ],
       "parameters": {
         "Left": [
@@ -5992,245 +5934,243 @@
           "Int2",
           "Uuid"
         ]
-      },
-      "nullable": [
-        false
-      ]
-    }
+      }
+    },
+    "query": "\n    insert into jig_report(jig_id, report_type, reporter_id)\n    values ($1, $2, $3)\n    returning id as \"id!: ReportId\"\n            "
   },
   "dc462c844af0d21cfc19babd04a01f7937c0b7d085ebedff4dfeb2733de028f5": {
-    "query": "\n            update jig_curation_data\n            set curation_status = $2\n            where jig_id = $1 and $2 is distinct from curation_status\n             ",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Int2"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\n            update jig_curation_data\n            set curation_status = $2\n            where jig_id = $1 and $2 is distinct from curation_status\n             "
   },
   "dce1ba23b612bd8fa029a70a2e43b93f5158cbf0f24377b079e70d5d6c29a97c": {
-    "query": "\nupdate user_profile\nset organization = $2\nwhere user_id = $1 and organization is distinct from $2",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Text"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\nupdate user_profile\nset organization = $2\nwhere user_id = $1 and organization is distinct from $2"
   },
   "dda8d8d2bc07da17016ae44616deda2fe94bf8a0db546e60b07200c95caa40f1": {
-    "query": "select uploaded_at from user_image_upload where image_id = $1 for update",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "uploaded_at",
+          "ordinal": 0,
           "type_info": "Timestamptz"
         }
+      ],
+      "nullable": [
+        true
       ],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": [
-        true
-      ]
-    }
+      }
+    },
+    "query": "select uploaded_at from user_image_upload where image_id = $1 for update"
   },
   "e2879fa5a3c098c9cbcea806e2d51168ba02e91b8f928a7bc2cd1f7f36872faa": {
-    "query": "\nwith cte as (\n    select distinct style_id as id\n    from image_style\n)\nselect id as \"id: ImageStyleId\", display_name, created_at, updated_at\nfrom cte inner join style using (id)\norder by index\n        ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id: ImageStyleId",
+          "ordinal": 0,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 1,
           "name": "display_name",
+          "ordinal": 1,
           "type_info": "Text"
         },
         {
-          "ordinal": 2,
           "name": "created_at",
+          "ordinal": 2,
           "type_info": "Timestamptz"
         },
         {
-          "ordinal": 3,
           "name": "updated_at",
+          "ordinal": 3,
           "type_info": "Timestamptz"
         }
       ],
-      "parameters": {
-        "Left": []
-      },
       "nullable": [
         false,
         false,
         false,
         true
-      ]
-    }
+      ],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "\nwith cte as (\n    select distinct style_id as id\n    from image_style\n)\nselect id as \"id: ImageStyleId\", display_name, created_at, updated_at\nfrom cte inner join style using (id)\norder by index\n        "
   },
   "e3c98457c7018a7cdea192aea153a3581104136a7aa2a2c7f02a5c884f8e517e": {
-    "query": "\nupdate user_profile\nset persona = $2\nwhere user_id = $1 and persona is distinct from $2\n        ",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "TextArray"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\nupdate user_profile\nset persona = $2\nwhere user_id = $1 and persona is distinct from $2\n        "
   },
   "e3ee149ba3066bd72758e68b8e0437b9a3e3e1dfa3e8b1d940ae002d4b285805": {
-    "query": "update image_upload set processed_at = now(), processing_result = true where image_id = $1",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "update image_upload set processed_at = now(), processing_result = true where image_id = $1"
   },
   "e418a5ae9bbbbfa0526d7d90d699ae1e4d2edb798ecf3434a1ed4529770c8faf": {
-    "query": "update user_image_upload set uploaded_at = now(), processing_result = null where image_id = $1",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "update user_image_upload set uploaded_at = now(), processing_result = null where image_id = $1"
   },
   "e476295de7bbf205eb11c2a4046c46c9352f30eb4c32bad44714b9053841fd58": {
-    "query": "delete from \"user\" where id = $1",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "delete from \"user\" where id = $1"
   },
   "e57b7c587be57d904c82ee82ea48df2b8e02a38dd1a4c1c7fee015385d66d155": {
-    "query": "update user_pdf_upload set processed_at = now(), processing_result = true where pdf_id = $1",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "update user_pdf_upload set processed_at = now(), processing_result = true where pdf_id = $1"
   },
   "e5ce362b6edf11adff2f1261b9b1c92c6bf77ae823f8dd2b58befb23761f0254": {
-    "query": "\nselect published_at  as \"published_at?\"\nfrom jig\nwhere id = $1\n    ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "published_at?",
+          "ordinal": 0,
           "type_info": "Timestamptz"
         }
+      ],
+      "nullable": [
+        true
       ],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": [
-        true
-      ]
-    }
+      }
+    },
+    "query": "\nselect published_at  as \"published_at?\"\nfrom jig\nwhere id = $1\n    "
   },
   "e8cac1c4331f80bc9b4d3eb878d98fb1650ea401e669cfa5154971251776f17d": {
-    "query": "\nupdate jig_data\nset other_keywords = $2,\n    translated_keywords = (case when ($3::text is not null) then $3::text else (translated_keywords) end),\n    updated_at = now()\nwhere id = $1 and $2 is distinct from other_keywords",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Text",
           "Text"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\nupdate jig_data\nset other_keywords = $2,\n    translated_keywords = (case when ($3::text is not null) then $3::text else (translated_keywords) end),\n    updated_at = now()\nwhere id = $1 and $2 is distinct from other_keywords"
   },
   "e961766dfce8a38444d9a0a15ac7a05f90d85ba7f4a12d47e5cb860e8a6e37e0": {
-    "query": "\nselect author_id,\n       published_at  as \"published_at?\"\nfrom jig\nwhere id = $1\n    ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "author_id",
+          "ordinal": 0,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 1,
           "name": "published_at?",
+          "ordinal": 1,
           "type_info": "Timestamptz"
         }
+      ],
+      "nullable": [
+        true,
+        true
       ],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": [
-        true,
-        true
-      ]
-    }
+      }
+    },
+    "query": "\nselect author_id,\n       published_at  as \"published_at?\"\nfrom jig\nwhere id = $1\n    "
   },
   "eb85238e221f20b3ad291f2bc9f6db1c632136d7e15358dbf5d0947c60a3aaa6": {
-    "query": "insert into web_media_library_url (media_id, media_url) values ($1, $2)",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Text"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "insert into web_media_library_url (media_id, media_url) values ($1, $2)"
   },
   "ec58db6f7417f0821c8a35acb1da226c7206c7614b4b5f9ab890693e0b9d9e41": {
-    "query": "\n    update jig_curation_data\n    set affiliations = $2\n    where jig_id = $1 and $2 is distinct from affiliations\n                ",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Bool"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\n    update jig_curation_data\n    set affiliations = $2\n    where jig_id = $1 and $2 is distinct from affiliations\n                "
   },
   "ed33c777a7166f4c7db4075c12401c927fb2abd75eb4cd1c30be257e1844ed0d": {
-    "query": "\nupdate jig_data\nset direction = $2,\n    display_score = $3,\n    track_assessments = $4,\n    drag_assist = $5,\n    updated_at = now()\nwhere id = $1 and\n    (($2 is distinct from direction) or\n     ($3 is distinct from display_score) or\n     ($4 is distinct from track_assessments) or\n     ($5 is distinct from drag_assist))\n            ",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
@@ -6239,254 +6179,246 @@
           "Bool",
           "Bool"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\nupdate jig_data\nset direction = $2,\n    display_score = $3,\n    track_assessments = $4,\n    drag_assist = $5,\n    updated_at = now()\nwhere id = $1 and\n    (($2 is distinct from direction) or\n     ($3 is distinct from display_score) or\n     ($4 is distinct from track_assessments) or\n     ($5 is distinct from drag_assist))\n            "
   },
   "edf5cb94b8714ed9995df1c7266d8837390d35250f6c20f3d65b73974e50da4b": {
-    "query": "\nwith recursive cte(parent_id) as (\nselect parent_id from category where id = $1\nunion all\nselect c.parent_id from category c inner join cte on cte.parent_id = c.id\n) select exists(select 1 from cte where parent_id = $2) as \"would_cycle!\"\n    ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "would_cycle!",
+          "ordinal": 0,
           "type_info": "Bool"
         }
+      ],
+      "nullable": [
+        null
       ],
       "parameters": {
         "Left": [
           "Uuid",
           "Uuid"
         ]
-      },
-      "nullable": [
-        null
-      ]
-    }
+      }
+    },
+    "query": "\nwith recursive cte(parent_id) as (\nselect parent_id from category where id = $1\nunion all\nselect c.parent_id from category c inner join cte on cte.parent_id = c.id\n) select exists(select 1 from cte where parent_id = $2) as \"would_cycle!\"\n    "
   },
   "f4463110f5544135bbcbb441792aad08a4e34be4dbf2994b9525b6ae031e3b5f": {
-    "query": "\nupdate jig_curation_data\nset language = $2\nwhere jig_id = $1 and $2 is distinct from language\n            ",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Bool"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\nupdate jig_curation_data\nset language = $2\nwhere jig_id = $1 and $2 is distinct from language\n            "
   },
   "f4d6632fc60abf4351be966b89b2490a3c3aef6f9f59d9ab4ea2eecc68d8cb72": {
-    "query": "update user_image_upload set processed_at = now(), processing_result = true where image_id = $1",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "update user_image_upload set processed_at = now(), processing_result = true where image_id = $1"
   },
   "f61ec8402e7de26b770073be29eee23dd893751db1fe71f55def28f880b32e3a": {
-    "query": "select id, display_name as name from locale_item_kind order by created_at",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id",
+          "ordinal": 0,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 1,
           "name": "name",
+          "ordinal": 1,
           "type_info": "Text"
         }
       ],
-      "parameters": {
-        "Left": []
-      },
       "nullable": [
         false,
         false
-      ]
-    }
-  },
-  "f7803338a676de1c4fad713fa774406743480aea8ceb9a4b6ba8ec80b74f9b3d": {
-    "query": "update image_metadata set last_synced_at = null",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": []
-      },
-      "nullable": []
-    }
-  },
-  "f885c76fd750edde5adbd1d426d6f92c91f336d5ffbbcee318e1f18cf31ca72b": {
-    "query": "insert into \"user\" default values returning id",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id",
-          "type_info": "Uuid"
-        }
       ],
       "parameters": {
         "Left": []
-      },
-      "nullable": [
-        false
-      ]
-    }
+      }
+    },
+    "query": "select id, display_name as name from locale_item_kind order by created_at"
   },
-  "f90a07640ce81e04a63b25e118a991e3024756c008c760212a86b949b2dbd3b3": {
-    "query": "\nwith del_data as (\n    delete from jig_data\n        where id is not distinct from $1 or id is not distinct from $2)\ndelete\nfrom jig\nwhere id is not distinct from $3\n\n",
+  "f7803338a676de1c4fad713fa774406743480aea8ceb9a4b6ba8ec80b74f9b3d": {
     "describe": {
       "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "update image_metadata set last_synced_at = null"
+  },
+  "f885c76fd750edde5adbd1d426d6f92c91f336d5ffbbcee318e1f18cf31ca72b": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "insert into \"user\" default values returning id"
+  },
+  "f90a07640ce81e04a63b25e118a991e3024756c008c760212a86b949b2dbd3b3": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Uuid",
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\nwith del_data as (\n    delete from jig_data\n        where id is not distinct from $1 or id is not distinct from $2)\ndelete\nfrom jig\nwhere id is not distinct from $3\n\n"
   },
   "f917dd67e6adf095a4c6da8d9338a2c5772af4635fc7343add1e2f58ee06908b": {
-    "query": "select exists(select 1 from user_email where email = lower($1)) as \"exists!\"",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "exists!",
+          "ordinal": 0,
           "type_info": "Bool"
         }
+      ],
+      "nullable": [
+        null
       ],
       "parameters": {
         "Left": [
           "Text"
         ]
-      },
-      "nullable": [
-        null
-      ]
-    }
+      }
+    },
+    "query": "select exists(select 1 from user_email where email = lower($1)) as \"exists!\""
   },
   "f92c14a182afb0bbc54cf4ce449d6d5c124ef1f3b7c364178247a28a1371fe4c": {
-    "query": "\ninsert into jig_play_count (jig_id, play_count)\nvalues ($1, 0)\n        ",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\ninsert into jig_play_count (jig_id, play_count)\nvalues ($1, 0)\n        "
   },
   "f9df2f28e8d06b6804d2bfc813d94ee93bbebe9148b2d2f5e00857adfed502ed": {
-    "query": "select email::text as \"email!\" from user_email where user_id = $1 for share",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "email!",
+          "ordinal": 0,
           "type_info": "Text"
         }
       ],
-      "parameters": {
-        "Left": [
-          "Uuid"
-        ]
-      },
       "nullable": [
         null
-      ]
-    }
-  },
-  "fb0694a24ef38695af5be6116509287bb61b1d70653bdc55100af75abbef275c": {
-    "query": "delete from web_media_library where id = $1 returning kind as \"kind: MediaKind\"",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "kind: MediaKind",
-          "type_info": "Int2"
-        }
       ],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
+      }
+    },
+    "query": "select email::text as \"email!\" from user_email where user_id = $1 for share"
+  },
+  "fb0694a24ef38695af5be6116509287bb61b1d70653bdc55100af75abbef275c": {
+    "describe": {
+      "columns": [
+        {
+          "name": "kind: MediaKind",
+          "ordinal": 0,
+          "type_info": "Int2"
+        }
+      ],
       "nullable": [
         false
-      ]
-    }
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "delete from web_media_library where id = $1 returning kind as \"kind: MediaKind\""
   },
   "fc6bfe176017b10253bc42ecb9f96f0533953b10ea0ad57299f99a3a17bc6721": {
-    "query": "\nupdate image_metadata\nset publish_at = $2, updated_at = now()\nwhere id = $1 and $2 is distinct from publish_at",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Timestamptz"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\nupdate image_metadata\nset publish_at = $2, updated_at = now()\nwhere id = $1 and $2 is distinct from publish_at"
   },
   "fd58f2216a6150d7137f7f3ddad9fe021c033eb2fa29e691e579cfa4e460fe00": {
-    "query": "\nselect id          as \"id: ModuleId\",\n       stable_id   as \"stable_id: StableModuleId\",\n       contents    as \"body\",\n       created_at  as \"created_at\",\n       updated_at  as \"updated_at\",\n       kind        as \"kind: ModuleKind\",\n       is_complete as \"is_complete\"\nfrom jig_data_module\nwhere jig_data_module.id is not distinct from $2\n   or (jig_data_id = (select draft_id from jig where jig.id = $1) and stable_id is not distinct from $3)\n",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id: ModuleId",
+          "ordinal": 0,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 1,
           "name": "stable_id: StableModuleId",
+          "ordinal": 1,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 2,
           "name": "body",
+          "ordinal": 2,
           "type_info": "Jsonb"
         },
         {
-          "ordinal": 3,
           "name": "created_at",
+          "ordinal": 3,
           "type_info": "Timestamptz"
         },
         {
-          "ordinal": 4,
           "name": "updated_at",
+          "ordinal": 4,
           "type_info": "Timestamptz"
         },
         {
-          "ordinal": 5,
           "name": "kind: ModuleKind",
+          "ordinal": 5,
           "type_info": "Int2"
         },
         {
-          "ordinal": 6,
           "name": "is_complete",
+          "ordinal": 6,
           "type_info": "Bool"
         }
       ],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Uuid",
-          "Uuid"
-        ]
-      },
       "nullable": [
         false,
         false,
@@ -6495,21 +6427,29 @@
         false,
         false,
         false
-      ]
-    }
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Uuid",
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\nselect id          as \"id: ModuleId\",\n       stable_id   as \"stable_id: StableModuleId\",\n       contents    as \"body\",\n       created_at  as \"created_at\",\n       updated_at  as \"updated_at\",\n       kind        as \"kind: ModuleKind\",\n       is_complete as \"is_complete\"\nfrom jig_data_module\nwhere jig_data_module.id is not distinct from $2\n   or (jig_data_id = (select draft_id from jig where jig.id = $1) and stable_id is not distinct from $3)\n"
   },
   "fe196f274875c6e293c5e80be927ac1e35c46f7699975b24a28b8cc1c136881d": {
-    "query": "\ninsert into user_auth_basic (user_id, email, password)\nvalues ($1, $2::text, $3)\n",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Text",
           "Text"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\ninsert into user_auth_basic (user_id, email, password)\nvalues ($1, $2::text, $3)\n"
   }
 }

--- a/backend/api/src/db/category.rs
+++ b/backend/api/src/db/category.rs
@@ -18,8 +18,6 @@ select id                                                                 as "id
        name,
        created_at,
        updated_at,
-       (select count(*)::int8 from image_category where category_id = id) as "image_count!",
-       (select count(*)::int8 from jig_data_category where category_id = id) as "jig_count!",
        user_scopes
 from category
 where parent_id is null
@@ -33,8 +31,6 @@ order by index
         updated_at: it.updated_at,
         name: it.name,
         children: vec![],
-        image_count: it.image_count as u64,
-        jig_count: it.jig_count as u64,
         user_scopes: {
             let scopes = it
                 .user_scopes
@@ -59,8 +55,6 @@ select id                                                                 as "id
        name                                                               as "name!",
        created_at                                                         as "created_at!",
        updated_at,
-       (select count(*)::int8 from image_category where category_id = id) as "image_count!",
-       (select count(*)::int8 from jig_data_category where category_id = id)   as "jig_count!",
        user_scopes                                                        as "user_scopes!"
 from category
          inner join unnest($1::uuid[]) with ordinality t(id, ord) USING (id)
@@ -75,8 +69,6 @@ order by t.ord
         created_at: it.created_at,
         updated_at: it.updated_at,
         children: vec![],
-        image_count: it.image_count as u64,
-        jig_count: it.jig_count as u64,
         user_scopes: {
             it.user_scopes
                 .into_iter()
@@ -107,8 +99,6 @@ select id,
        index,
        created_at,
        updated_at,
-       (select count(*) from image_category where category_id = id)::int8 as "image_count!",
-       (select count(*) from jig_data_category where category_id = id)::int8 as "jig_count!",
        user_scopes
 from category
 order by index

--- a/backend/api/src/domain.rs
+++ b/backend/api/src/domain.rs
@@ -22,8 +22,6 @@ pub struct RawCategory {
     pub index: i16,
     pub created_at: DateTime<Utc>,
     pub updated_at: Option<DateTime<Utc>>,
-    pub image_count: i64,
-    pub jig_count: i64,
     pub user_scopes: Vec<i16>,
 }
 
@@ -33,8 +31,6 @@ struct CategoryNode {
     pub name: String,
     pub created_at: DateTime<Utc>,
     pub updated_at: Option<DateTime<Utc>>,
-    pub image_count: i64,
-    pub jig_count: i64,
     pub user_scopes: Vec<i16>,
     pub children: Vec<Rc<RefCell<CategoryNode>>>,
 }
@@ -46,8 +42,6 @@ impl From<CategoryNode> for Category {
             name: category_node.name,
             created_at: category_node.created_at,
             updated_at: category_node.updated_at,
-            image_count: category_node.image_count as u64,
-            jig_count: category_node.jig_count as u64,
             user_scopes: {
                 category_node
                     .user_scopes
@@ -83,8 +77,6 @@ pub fn build_tree(categories: Vec<RawCategory>) -> Vec<Category> {
                 name: raw.name.clone(),
                 created_at: raw.created_at,
                 updated_at: raw.updated_at,
-                image_count: raw.image_count,
-                jig_count: raw.jig_count,
                 user_scopes: raw.user_scopes.clone(),
                 children: Vec::new(),
             })),

--- a/backend/api/tests/integration/snapshots/integration__category__delete.snap
+++ b/backend/api/tests/integration/snapshots/integration__category__delete.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/category.rs
 expression: body
-
 ---
 {
   "categories": [
@@ -14,9 +13,7 @@ expression: body
       ],
       "name": "One",
       "created_at": "2020-08-27T16:36:44.133612Z",
-      "updated_at": "[timestamp]",
-      "image_count": 0,
-      "jig_count": 0
+      "updated_at": "[timestamp]"
     },
     {
       "id": "81c4796a-e883-11ea-93f0-df2484ab6b11",
@@ -26,9 +23,7 @@ expression: body
       ],
       "name": "Three",
       "created_at": "2020-08-27T16:36:50.371709Z",
-      "updated_at": "[timestamp]",
-      "image_count": 0,
-      "jig_count": 0
+      "updated_at": "[timestamp]"
     }
   ]
 }

--- a/backend/api/tests/integration/snapshots/integration__category__get.snap
+++ b/backend/api/tests/integration/snapshots/integration__category__get.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/category.rs
 expression: body
-
 ---
 {
   "categories": [
@@ -14,9 +13,7 @@ expression: body
       ],
       "name": "One",
       "created_at": "2020-08-27T16:36:44.133612Z",
-      "updated_at": null,
-      "image_count": 0,
-      "jig_count": 0
+      "updated_at": null
     },
     {
       "id": "7fe19326-e883-11ea-93f0-5343493c17c4",
@@ -25,9 +22,7 @@ expression: body
       ],
       "name": "Two",
       "created_at": "2020-08-27T16:36:47.206959Z",
-      "updated_at": null,
-      "image_count": 0,
-      "jig_count": 0
+      "updated_at": null
     },
     {
       "id": "81c4796a-e883-11ea-93f0-df2484ab6b11",
@@ -37,9 +32,7 @@ expression: body
       ],
       "name": "Three",
       "created_at": "2020-08-27T16:36:50.371709Z",
-      "updated_at": null,
-      "image_count": 0,
-      "jig_count": 0
+      "updated_at": null
     }
   ]
 }

--- a/backend/api/tests/integration/snapshots/integration__category__nested_ancestors.snap
+++ b/backend/api/tests/integration/snapshots/integration__category__nested_ancestors.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/category.rs
 expression: body
-
 ---
 {
   "categories": [
@@ -18,15 +17,11 @@ expression: body
           "user_scopes": [],
           "name": "A",
           "created_at": "2020-08-28T09:21:43.186002Z",
-          "updated_at": null,
-          "image_count": 0,
-          "jig_count": 0
+          "updated_at": null
         }
       ],
       "created_at": "2020-08-28T09:20:17.039205Z",
-      "updated_at": null,
-      "image_count": 0,
-      "jig_count": 0
+      "updated_at": null
     }
   ]
 }

--- a/backend/api/tests/integration/snapshots/integration__category__nested_exact.snap
+++ b/backend/api/tests/integration/snapshots/integration__category__nested_exact.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/category.rs
 expression: body
-
 ---
 {
   "categories": [
@@ -13,9 +12,7 @@ expression: body
       ],
       "name": "Parent",
       "created_at": "2020-08-28T09:20:17.039205Z",
-      "updated_at": null,
-      "image_count": 0,
-      "jig_count": 0
+      "updated_at": null
     },
     {
       "id": "01cff7d8-e910-11ea-8281-7f86c625a156",
@@ -26,9 +23,7 @@ expression: body
       ],
       "name": "A.1",
       "created_at": "2020-08-28T09:22:34.737562Z",
-      "updated_at": null,
-      "image_count": 0,
-      "jig_count": 0
+      "updated_at": null
     }
   ]
 }

--- a/backend/api/tests/integration/snapshots/integration__category__nested_overlapping.snap
+++ b/backend/api/tests/integration/snapshots/integration__category__nested_overlapping.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/category.rs
 expression: body
-
 ---
 {
   "categories": [
@@ -13,6 +12,17 @@ expression: body
       ],
       "name": "Parent",
       "children": [
+        {
+          "id": "ee749392-e90f-11ea-8281-67d19ffa6107",
+          "user_scopes": [
+            "ManageAnimation",
+            "ManageEntry",
+            "ManageSelfJig"
+          ],
+          "name": "B",
+          "created_at": "2020-08-28T09:22:02.261811Z",
+          "updated_at": null
+        },
         {
           "id": "e315d3b2-e90f-11ea-8281-73cd69c14821",
           "user_scopes": [],
@@ -27,34 +37,15 @@ expression: body
               ],
               "name": "A.1",
               "created_at": "2020-08-28T09:22:34.737562Z",
-              "updated_at": null,
-              "image_count": 0,
-              "jig_count": 0
+              "updated_at": null
             }
           ],
           "created_at": "2020-08-28T09:21:43.186002Z",
-          "updated_at": null,
-          "image_count": 0,
-          "jig_count": 0
-        },
-        {
-          "id": "ee749392-e90f-11ea-8281-67d19ffa6107",
-          "user_scopes": [
-            "ManageAnimation",
-            "ManageEntry",
-            "ManageSelfJig"
-          ],
-          "name": "B",
-          "created_at": "2020-08-28T09:22:02.261811Z",
-          "updated_at": null,
-          "image_count": 0,
-          "jig_count": 0
+          "updated_at": null
         }
       ],
       "created_at": "2020-08-28T09:20:17.039205Z",
-      "updated_at": null,
-      "image_count": 0,
-      "jig_count": 0
+      "updated_at": null
     },
     {
       "id": "e315d3b2-e90f-11ea-8281-73cd69c14821",
@@ -70,15 +61,11 @@ expression: body
           ],
           "name": "A.1",
           "created_at": "2020-08-28T09:22:34.737562Z",
-          "updated_at": null,
-          "image_count": 0,
-          "jig_count": 0
+          "updated_at": null
         }
       ],
       "created_at": "2020-08-28T09:21:43.186002Z",
-      "updated_at": null,
-      "image_count": 0,
-      "jig_count": 0
+      "updated_at": null
     }
   ]
 }

--- a/backend/api/tests/integration/snapshots/integration__category__nested_top_level.snap
+++ b/backend/api/tests/integration/snapshots/integration__category__nested_top_level.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/category.rs
 expression: body
-
 ---
 {
   "categories": [
@@ -13,9 +12,7 @@ expression: body
       ],
       "name": "Parent",
       "created_at": "2020-08-28T09:20:17.039205Z",
-      "updated_at": null,
-      "image_count": 0,
-      "jig_count": 0
+      "updated_at": null
     }
   ]
 }

--- a/backend/api/tests/integration/snapshots/integration__category__nested_whole_tree.snap
+++ b/backend/api/tests/integration/snapshots/integration__category__nested_whole_tree.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/category.rs
 expression: body
-
 ---
 {
   "categories": [
@@ -27,15 +26,11 @@ expression: body
               ],
               "name": "A.1",
               "created_at": "2020-08-28T09:22:34.737562Z",
-              "updated_at": null,
-              "image_count": 0,
-              "jig_count": 0
+              "updated_at": null
             }
           ],
           "created_at": "2020-08-28T09:21:43.186002Z",
-          "updated_at": null,
-          "image_count": 0,
-          "jig_count": 0
+          "updated_at": null
         },
         {
           "id": "ee749392-e90f-11ea-8281-67d19ffa6107",
@@ -46,15 +41,11 @@ expression: body
           ],
           "name": "B",
           "created_at": "2020-08-28T09:22:02.261811Z",
-          "updated_at": null,
-          "image_count": 0,
-          "jig_count": 0
+          "updated_at": null
         }
       ],
       "created_at": "2020-08-28T09:20:17.039205Z",
-      "updated_at": null,
-      "image_count": 0,
-      "jig_count": 0
+      "updated_at": null
     }
   ]
 }

--- a/backend/api/tests/integration/snapshots/integration__category__update_move.snap
+++ b/backend/api/tests/integration/snapshots/integration__category__update_move.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/category.rs
 expression: body
-
 ---
 {
   "categories": [
@@ -14,9 +13,7 @@ expression: body
       ],
       "name": "One",
       "created_at": "2020-08-27T16:36:44.133612Z",
-      "updated_at": "[timestamp]",
-      "image_count": 0,
-      "jig_count": 0
+      "updated_at": "[timestamp]"
     },
     {
       "id": "81c4796a-e883-11ea-93f0-df2484ab6b11",
@@ -26,9 +23,7 @@ expression: body
       ],
       "name": "Three",
       "created_at": "2020-08-27T16:36:50.371709Z",
-      "updated_at": "[timestamp]",
-      "image_count": 0,
-      "jig_count": 0
+      "updated_at": "[timestamp]"
     },
     {
       "id": "7fe19326-e883-11ea-93f0-5343493c17c4",
@@ -37,9 +32,7 @@ expression: body
       ],
       "name": "Two",
       "created_at": "2020-08-27T16:36:47.206959Z",
-      "updated_at": "[timestamp]",
-      "image_count": 0,
-      "jig_count": 0
+      "updated_at": "[timestamp]"
     }
   ]
 }

--- a/backend/api/tests/integration/snapshots/integration__category__update_parent.snap
+++ b/backend/api/tests/integration/snapshots/integration__category__update_parent.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/category.rs
 expression: body
-
 ---
 {
   "categories": [
@@ -14,9 +13,7 @@ expression: body
       ],
       "name": "One",
       "created_at": "2020-08-27T16:36:44.133612Z",
-      "updated_at": "[timestamp]",
-      "image_count": 0,
-      "jig_count": 0
+      "updated_at": "[timestamp]"
     },
     {
       "id": "81c4796a-e883-11ea-93f0-df2484ab6b11",
@@ -33,15 +30,11 @@ expression: body
           ],
           "name": "Two",
           "created_at": "2020-08-27T16:36:47.206959Z",
-          "updated_at": "[timestamp]",
-          "image_count": 0,
-          "jig_count": 0
+          "updated_at": "[timestamp]"
         }
       ],
       "created_at": "2020-08-27T16:36:50.371709Z",
-      "updated_at": "[timestamp]",
-      "image_count": 0,
-      "jig_count": 0
+      "updated_at": "[timestamp]"
     }
   ]
 }

--- a/backend/api/tests/integration/snapshots/integration__category__update_rename.snap
+++ b/backend/api/tests/integration/snapshots/integration__category__update_rename.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/category.rs
 expression: body
-
 ---
 {
   "categories": [
@@ -14,9 +13,7 @@ expression: body
       ],
       "name": "One",
       "created_at": "2020-08-27T16:36:44.133612Z",
-      "updated_at": "[timestamp]",
-      "image_count": 0,
-      "jig_count": 0
+      "updated_at": "[timestamp]"
     },
     {
       "id": "7fe19326-e883-11ea-93f0-5343493c17c4",
@@ -25,9 +22,7 @@ expression: body
       ],
       "name": "Two",
       "created_at": "2020-08-27T16:36:47.206959Z",
-      "updated_at": "[timestamp]",
-      "image_count": 0,
-      "jig_count": 0
+      "updated_at": "[timestamp]"
     },
     {
       "id": "81c4796a-e883-11ea-93f0-df2484ab6b11",
@@ -37,9 +32,7 @@ expression: body
       ],
       "name": "abc123",
       "created_at": "2020-08-27T16:36:50.371709Z",
-      "updated_at": "[timestamp]",
-      "image_count": 0,
-      "jig_count": 0
+      "updated_at": "[timestamp]"
     }
   ]
 }

--- a/backend/api/tests/integration/snapshots/integration__category__update_reparent_move.snap
+++ b/backend/api/tests/integration/snapshots/integration__category__update_reparent_move.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/category.rs
 expression: body
-
 ---
 {
   "categories": [
@@ -12,9 +11,7 @@ expression: body
       ],
       "name": "Two",
       "created_at": "2020-08-27T16:36:47.206959Z",
-      "updated_at": "[timestamp]",
-      "image_count": 0,
-      "jig_count": 0
+      "updated_at": "[timestamp]"
     },
     {
       "id": "7e0cc6e2-e883-11ea-93f0-cb82f9b3da95",
@@ -25,9 +22,7 @@ expression: body
       ],
       "name": "One",
       "created_at": "2020-08-27T16:36:44.133612Z",
-      "updated_at": "[timestamp]",
-      "image_count": 0,
-      "jig_count": 0
+      "updated_at": "[timestamp]"
     },
     {
       "id": "81c4796a-e883-11ea-93f0-df2484ab6b11",
@@ -37,9 +32,7 @@ expression: body
       ],
       "name": "Three",
       "created_at": "2020-08-27T16:36:50.371709Z",
-      "updated_at": "[timestamp]",
-      "image_count": 0,
-      "jig_count": 0
+      "updated_at": "[timestamp]"
     }
   ]
 }

--- a/backend/api/tests/integration/snapshots/integration__category__update_scope.snap
+++ b/backend/api/tests/integration/snapshots/integration__category__update_scope.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/category.rs
 expression: body
-
 ---
 {
   "categories": [
@@ -14,9 +13,7 @@ expression: body
       ],
       "name": "One",
       "created_at": "2020-08-27T16:36:44.133612Z",
-      "updated_at": "[timestamp]",
-      "image_count": 0,
-      "jig_count": 0
+      "updated_at": "[timestamp]"
     },
     {
       "id": "7fe19326-e883-11ea-93f0-5343493c17c4",
@@ -25,9 +22,7 @@ expression: body
       ],
       "name": "Two",
       "created_at": "2020-08-27T16:36:47.206959Z",
-      "updated_at": "[timestamp]",
-      "image_count": 0,
-      "jig_count": 0
+      "updated_at": "[timestamp]"
     },
     {
       "id": "81c4796a-e883-11ea-93f0-df2484ab6b11",
@@ -39,9 +34,7 @@ expression: body
       ],
       "name": "Three",
       "created_at": "2020-08-27T16:36:50.371709Z",
-      "updated_at": "[timestamp]",
-      "image_count": 0,
-      "jig_count": 0
+      "updated_at": "[timestamp]"
     }
   ]
 }

--- a/backend/api/tests/integration/snapshots/integration__category__upgdate_ordering-2.snap
+++ b/backend/api/tests/integration/snapshots/integration__category__upgdate_ordering-2.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/category.rs
 expression: body
-
 ---
 {
   "categories": [
@@ -14,9 +13,7 @@ expression: body
       ],
       "name": "One",
       "created_at": "2020-08-27T16:36:44.133612Z",
-      "updated_at": "[timestamp]",
-      "image_count": 0,
-      "jig_count": 0
+      "updated_at": "[timestamp]"
     },
     {
       "id": "7fe19326-e883-11ea-93f0-5343493c17c4",
@@ -25,9 +22,7 @@ expression: body
       ],
       "name": "Two",
       "created_at": "2020-08-27T16:36:47.206959Z",
-      "updated_at": "[timestamp]",
-      "image_count": 0,
-      "jig_count": 0
+      "updated_at": "[timestamp]"
     },
     {
       "id": "81c4796a-e883-11ea-93f0-df2484ab6b11",
@@ -37,9 +32,7 @@ expression: body
       ],
       "name": "Three",
       "created_at": "2020-08-27T16:36:50.371709Z",
-      "updated_at": "[timestamp]",
-      "image_count": 0,
-      "jig_count": 0
+      "updated_at": "[timestamp]"
     }
   ]
 }

--- a/backend/api/tests/integration/snapshots/integration__category__upgdate_ordering.snap
+++ b/backend/api/tests/integration/snapshots/integration__category__upgdate_ordering.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/category.rs
 expression: body
-
 ---
 {
   "categories": [
@@ -13,9 +12,7 @@ expression: body
       ],
       "name": "Three",
       "created_at": "2020-08-27T16:36:50.371709Z",
-      "updated_at": "[timestamp]",
-      "image_count": 0,
-      "jig_count": 0
+      "updated_at": "[timestamp]"
     },
     {
       "id": "7e0cc6e2-e883-11ea-93f0-cb82f9b3da95",
@@ -26,9 +23,7 @@ expression: body
       ],
       "name": "One",
       "created_at": "2020-08-27T16:36:44.133612Z",
-      "updated_at": "[timestamp]",
-      "image_count": 0,
-      "jig_count": 0
+      "updated_at": "[timestamp]"
     },
     {
       "id": "7fe19326-e883-11ea-93f0-5343493c17c4",
@@ -37,9 +32,7 @@ expression: body
       ],
       "name": "Two",
       "created_at": "2020-08-27T16:36:47.206959Z",
-      "updated_at": "[timestamp]",
-      "image_count": 0,
-      "jig_count": 0
+      "updated_at": "[timestamp]"
     }
   ]
 }

--- a/shared/rust/src/domain/category.rs
+++ b/shared/rust/src/domain/category.rs
@@ -45,12 +45,6 @@ pub struct Category {
 
     /// When the category was last updated.
     pub updated_at: Option<DateTime<Utc>>,
-
-    /// The number of images associated with the category.
-    pub image_count: u64,
-
-    /// The number of JIGs associated with the category.
-    pub jig_count: u64,
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
- Removes the image_count and jig_count fields from Category which is not used anywhere in the system.

#### Release trace

![image](https://user-images.githubusercontent.com/4161106/159418218-3aca141c-50a5-4093-8cce-84eed5372044.png)

### `explain analyze` on release database

#### Before

```
 Index Scan using category_index_parent_id_key on category  (cost=0.27..38543.94 rows=331 width=110) (actual time=0.557..155.846 rows=331 loops=1)
   SubPlan 1
     ->  Aggregate  (cost=109.33..109.34 rows=1 width=8) (actual time=0.444..0.444 rows=1 loops=331)
           ->  Seq Scan on image_category  (cost=0.00..109.26 rows=27 width=0) (actual time=0.262..0.442 rows=15 loops=331)
                 Filter: (category_id = category.id)
                 Rows Removed by Filter: 5096
   SubPlan 2
     ->  Aggregate  (cost=6.94..6.95 rows=1 width=8) (actual time=0.024..0.024 rows=1 loops=331)
           ->  Seq Scan on jig_data_category  (cost=0.00..6.93 rows=5 width=0) (actual time=0.020..0.022 rows=1 loops=331)
                 Filter: (category_id = category.id)
                 Rows Removed by Filter: 233
 Planning Time: 0.698 ms
 Execution Time: 156.009 ms
(13 rows)
```

#### After

```
 Sort  (cost=24.16..24.99 rows=331 width=94) (actual time=0.279..0.296 rows=331 loops=1)
   Sort Key: index
   Sort Method: quicksort  Memory: 71kB
   ->  Seq Scan on category  (cost=0.00..10.31 rows=331 width=94) (actual time=0.014..0.083 rows=331 loops=1)
 Planning Time: 0.078 ms
 Execution Time: 0.329 ms
(6 rows)
```