### PR TITLE
feat(fe): Restructure jiggling content json file format

### DIFF
--- a/frontend/apps/crates/components/src/module/_common/edit/entry/base/state.rs
+++ b/frontend/apps/crates/components/src/module/_common/edit/entry/base/state.rs
@@ -16,6 +16,7 @@ use std::future::Future;
 use utils::prelude::*;
 
 use crate::module::_common::edit::post_preview::state::PostPreview;
+use crate::tabs::MenuTabKind;
 
 /// This is passed *to* the consumer in order to get a BaseInit
 pub struct BaseInitFromRawArgs<RawData, Mode, Step>
@@ -237,9 +238,8 @@ pub trait MainDomRenderable: DomRenderable {
 }
 
 pub trait SidebarExt: DomRenderable {
-    type TabIndexSignal: Signal<Item = Option<usize>>;
-
-    fn tab_index(&self) -> Self::TabIndexSignal;
+    type TabKindSignal: Signal<Item = Option<MenuTabKind>>;
+    fn tab_kind(&self) -> Self::TabKindSignal;
 }
 
 pub trait HeaderExt: DomRenderable {}

--- a/frontend/apps/crates/components/src/module/_groups/cards/edit/sidebar/dom.rs
+++ b/frontend/apps/crates/components/src/module/_groups/cards/edit/sidebar/dom.rs
@@ -24,17 +24,17 @@ where
     ) -> Dom {
         html!("empty-fragment", {
             .future(state.base.step.signal_cloned().dedupe().for_each(clone!(state => move |_step| {
-                state.tab_index.set(None);
+                state.tab_kind.set(None);
                 async move {}
             })))
             .style("display", "contents")
             .child_signal(state.base.step.signal_cloned().map(clone!(state => move |step| {
                 match step {
-                    Step::One => Some(render_step_1(Step1::new(state.base.clone(), state.tab_index.clone()))),
-                    Step::Two => Some(render_step_2(Step2::new(state.base.clone(), state.tab_index.clone()))),
+                    Step::One => Some(render_step_1(Step1::new(state.base.clone(), state.tab_kind.clone()))),
+                    Step::Two => Some(render_step_2(Step2::new(state.base.clone(), state.tab_kind.clone()))),
                     Step::Three => Some(
                         render_step_3(
-                            Step3::new(state.base.clone(), state.get_settings.clone(), state.tab_index.clone()),
+                            Step3::new(state.base.clone(), state.get_settings.clone(), state.tab_kind.clone()),
                             state.render_settings.clone()
                         )
                     ),

--- a/frontend/apps/crates/components/src/module/_groups/cards/edit/sidebar/state.rs
+++ b/frontend/apps/crates/components/src/module/_groups/cards/edit/sidebar/state.rs
@@ -1,4 +1,4 @@
-use crate::module::{_common::edit::prelude::*, _groups::cards::edit::state::*};
+use crate::{module::{_common::edit::prelude::*, _groups::cards::edit::state::*}, tabs::MenuTabKind};
 use dominator::Dom;
 use futures_signals::signal::{Mutable, Signal};
 use std::rc::Rc;
@@ -14,7 +14,7 @@ where
     pub base: Rc<CardsBase<RawData, E>>,
     pub get_settings: GetSettingsStateFn,
     pub render_settings: RenderSettingsStateFn,
-    pub tab_index: Mutable<Option<usize>>,
+    pub tab_kind: Mutable<Option<MenuTabKind>>,
 }
 
 impl<RawData, E, GetSettingsStateFn, RenderSettingsStateFn, SettingsState>
@@ -35,7 +35,7 @@ where
             base,
             get_settings,
             render_settings,
-            tab_index: Mutable::new(None),
+            tab_kind: Mutable::new(None),
         }
     }
 }
@@ -49,9 +49,9 @@ where
     RenderSettingsStateFn: Fn(Rc<SettingsState>) -> Dom + Clone + 'static,
     SettingsState: 'static,
 {
-    type TabIndexSignal = impl Signal<Item = Option<usize>>;
+    type TabKindSignal = impl Signal<Item = Option<MenuTabKind>>;
 
-    fn tab_index(&self) -> Self::TabIndexSignal {
-        self.tab_index.signal()
+    fn tab_kind(&self) -> Self::TabKindSignal {
+        self.tab_kind.signal()
     }
 }

--- a/frontend/apps/crates/components/src/module/_groups/cards/edit/sidebar/step_1/dom.rs
+++ b/frontend/apps/crates/components/src/module/_groups/cards/edit/sidebar/step_1/dom.rs
@@ -27,14 +27,14 @@ pub fn render<RawData: RawDataExt, E: ExtraExt>(state: Rc<Step1<RawData, E>>) ->
             Some(html!("menu-tabs", {
                 .children(state.tabs.get().unwrap_ji().iter().enumerate().map(|(idx, tab)| {
                     let enabled = idx == 0 || (idx > 0 && !is_empty);
-                    render_tab(state.clone(), tab.kind(), idx, enabled)
+                    render_tab(state.clone(), tab.kind(), enabled)
                 }))
                 .child(html!("module-sidebar-body", {
                         .property("slot", "body")
-                        .child_signal(state.tab_index.signal_cloned().map(clone!(state, is_empty => move |current_tab_idx| {
-                            let tab = match current_tab_idx {
-                                Some(current_tab_idx) => match state.tabs.get() {
-                                    Some(tabs) => tabs.get(current_tab_idx),
+                        .child_signal(state.tab_kind.signal_cloned().map(clone!(state, is_empty => move |current_tab_kind| {
+                            let tab = match current_tab_kind {
+                                Some(current_tab_kind) => match state.tabs.get() {
+                                    Some(tabs) => tabs.iter().find(|tab| tab.kind() == current_tab_kind),
                                     None => None,
                                 },
                                 None => None,
@@ -220,7 +220,6 @@ fn render_non_empty<RawData: RawDataExt, E: ExtraExt>(state: Rc<Step1<RawData, E
 fn render_tab<RawData: RawDataExt, E: ExtraExt>(
     state: Rc<Step1<RawData, E>>,
     tab_kind: MenuTabKind,
-    idx: usize,
     enabled: bool,
 ) -> Dom {
     MenuTab::render(
@@ -228,11 +227,11 @@ fn render_tab<RawData: RawDataExt, E: ExtraExt>(
             tab_kind,
             false,
             enabled,
-            clone!(state => move || state.tab_index.signal_ref(move |current_tab_idx| {
-                current_tab_idx.as_ref().map_or(false, |current_tab_idx| *current_tab_idx == idx)
+            clone!(state => move || state.tab_kind.signal_ref(move |current_tab_kind| {
+                current_tab_kind.as_ref().map_or(false, |current_tab_kind| *current_tab_kind == tab_kind)
             })),
             clone!(state => move || {
-                state.tab_index.set_neq(Some(idx))
+                state.tab_kind.set_neq(Some(tab_kind))
             }),
         ),
         Some("tabs"),

--- a/frontend/apps/crates/components/src/module/_groups/cards/edit/sidebar/step_2/actions.rs
+++ b/frontend/apps/crates/components/src/module/_groups/cards/edit/sidebar/step_2/actions.rs
@@ -2,7 +2,7 @@ use std::rc::Rc;
 
 use dominator::clone;
 
-use crate::module::_groups::cards::edit::state::{RawDataExt, ExtraExt};
+use crate::{module::_groups::cards::edit::state::{RawDataExt, ExtraExt}, tabs::MenuTabKind};
 
 use super::{custom_background::CustomBackground, state::Step2};
 
@@ -12,13 +12,16 @@ impl<RawData: RawDataExt, E: ExtraExt> Step2<RawData, E> {
 
         let on_close = Box::new(clone!(state => move || {
             state.custom_background.set(None);
+            state.tab_kind.set_neq(None);
         }));
 
         let custom_background = CustomBackground::new(
             Rc::clone(&state.base),
-            on_close
+            state.tab_kind.clone(),
+            on_close,
         );
 
         state.custom_background.set(Some(custom_background));
+        state.tab_kind.set_neq(Some(MenuTabKind::BackgroundImage));
     }
 }

--- a/frontend/apps/crates/components/src/module/_groups/cards/edit/sidebar/step_2/custom_background/state.rs
+++ b/frontend/apps/crates/components/src/module/_groups/cards/edit/sidebar/step_2/custom_background/state.rs
@@ -9,7 +9,7 @@ use crate::{
         state::{ImageSearchKind, ImageSearchOptions, State as ImageSearchState},
     },
     module::_groups::cards::edit::state::{RawDataExt, ExtraExt, CardsBase},
-    color_select::state::State as ColorPickerState,
+    color_select::state::State as ColorPickerState, tabs::MenuTabKind,
 };
 
 const STR_FILL_COLOR: &str = "Fill color";
@@ -20,11 +20,16 @@ pub struct CustomBackground<RawData: RawDataExt, E: ExtraExt> {
     pub colors_open: Mutable<bool>,
     pub color_state: Rc<ColorPickerState>,
     pub background_state: Rc<ImageSearchState>,
+    pub tab_kind: Mutable<Option<MenuTabKind>>,
 }
 
 
 impl<RawData: RawDataExt, E: ExtraExt> CustomBackground<RawData, E> {
-    pub fn new(base: Rc<CardsBase<RawData, E>>, on_close: Box<dyn Fn()>) -> Rc<Self> {
+    pub fn new(
+        base: Rc<CardsBase<RawData, E>>,
+        tab_kind: Mutable<Option<MenuTabKind>>,
+        on_close: Box<dyn Fn()>
+    ) -> Rc<Self> {
         let color_state = Rc::new(ColorPickerState::new(
             base.theme_id.read_only(),
             None,
@@ -50,6 +55,7 @@ impl<RawData: RawDataExt, E: ExtraExt> CustomBackground<RawData, E> {
             colors_open: Mutable::new(false),
             color_state,
             background_state,
+            tab_kind,
         })
     }
 }

--- a/frontend/apps/crates/components/src/module/_groups/cards/edit/sidebar/step_2/state.rs
+++ b/frontend/apps/crates/components/src/module/_groups/cards/edit/sidebar/step_2/state.rs
@@ -1,4 +1,4 @@
-use crate::{module::_groups::cards::edit::state::*, theme_selector::state::{ThemeSelectorCallbacks, ThemeSelector}};
+use crate::{module::_groups::cards::edit::state::*, theme_selector::state::{ThemeSelectorCallbacks, ThemeSelector}, tabs::MenuTabKind};
 use dominator::clone;
 use futures_signals::signal::Mutable;
 use shared::{api::{endpoints, ApiEndpoint}, domain::jig::JigUpdateDraftDataRequest, error::EmptyError};
@@ -14,10 +14,11 @@ pub struct Step2<RawData: RawDataExt, E: ExtraExt> {
     pub base: Rc<CardsBase<RawData, E>>,
     pub theme_selector: Rc<ThemeSelector>,
     pub custom_background: Mutable<Option<Rc<CustomBackground<RawData, E>>>>,
+    pub tab_kind: Mutable<Option<MenuTabKind>>,
 }
 
 impl<RawData: RawDataExt, E: ExtraExt> Step2<RawData, E> {
-    pub fn new(base: Rc<CardsBase<RawData, E>>, _tab_index: Mutable<Option<usize>>) -> Rc<Self> {
+    pub fn new(base: Rc<CardsBase<RawData, E>>, tab_kind: Mutable<Option<MenuTabKind>>) -> Rc<Self> {
         let callbacks = ThemeSelectorCallbacks::new(clone!(base => move |theme_id| {
             base.set_theme(theme_id);
 
@@ -48,6 +49,7 @@ impl<RawData: RawDataExt, E: ExtraExt> Step2<RawData, E> {
             base,
             theme_selector,
             custom_background: Mutable::new(None),
+            tab_kind,
         })
     }
 }

--- a/frontend/apps/crates/components/src/module/_groups/cards/edit/sidebar/step_3/dom.rs
+++ b/frontend/apps/crates/components/src/module/_groups/cards/edit/sidebar/step_3/dom.rs
@@ -20,8 +20,8 @@ where
     RenderSettingsFn: Fn(Rc<SettingsState>) -> Dom + Clone + 'static,
 {
     html!("menu-tabs", {
-        .future(state.tab.signal_ref(|tab| tab.as_index()).dedupe().for_each(clone!(state => move |index| {
-            state.tab_index.set(Some(index));
+        .future(state.tab.signal_ref(|tab| tab.kind()).dedupe().for_each(clone!(state => move |kind| {
+            state.tab_kind.set(Some(kind));
             async move {}
         })))
         .children(&mut [

--- a/frontend/apps/crates/components/src/module/_groups/cards/edit/sidebar/step_3/state.rs
+++ b/frontend/apps/crates/components/src/module/_groups/cards/edit/sidebar/step_3/state.rs
@@ -20,7 +20,7 @@ where
     pub base: Rc<CardsBase<RawData, E>>,
     pub tab: Mutable<Tab<SettingsState>>,
     pub get_settings: GetSettingsStateFn,
-    pub tab_index: Mutable<Option<usize>>,
+    pub tab_kind: Mutable<Option<MenuTabKind>>,
 }
 
 impl<RawData, E, GetSettingsStateFn, SettingsState>
@@ -34,7 +34,7 @@ where
     pub fn new(
         base: Rc<CardsBase<RawData, E>>,
         get_settings: GetSettingsStateFn,
-        tab_index: Mutable<Option<usize>>,
+        tab_kind: Mutable<Option<MenuTabKind>>,
     ) -> Rc<Self> {
         let kind = match base.debug.step3_tab {
             Some(kind) => kind,
@@ -47,7 +47,7 @@ where
             base,
             tab,
             get_settings,
-            tab_index,
+            tab_kind,
         })
     }
 }

--- a/frontend/apps/crates/components/src/module/_groups/design/edit/theme_background/actions.rs
+++ b/frontend/apps/crates/components/src/module/_groups/design/edit/theme_background/actions.rs
@@ -16,10 +16,11 @@ impl<Step, Base> ThemeBackground<Step, Base> where
 
         let on_close = Box::new(clone!(state => move || {
             state.custom_background.set(None);
+            state.tab_kind.set_neq(None);
         }));
 
         let custom_background = CustomBackground::new(
-            Rc::clone(&state.base),
+            Rc::clone(&state),
             on_close
         );
 

--- a/frontend/apps/crates/components/src/module/_groups/design/edit/theme_background/custom_background/dom.rs
+++ b/frontend/apps/crates/components/src/module/_groups/design/edit/theme_background/custom_background/dom.rs
@@ -38,8 +38,8 @@ impl<Step, Base> CustomBackground<Step, Base> where
                 }))
             }))
             .child(html!("menu-tabs", {
-                .future(state.tab.signal_ref(|tab| tab.as_index()).dedupe().for_each(clone!(state => move |index| {
-                    state.tab_index.set(Some(index));
+                .future(state.tab.signal_ref(|tab| tab.kind()).dedupe().for_each(clone!(state => move |kind| {
+                    state.tab_kind.set(Some(kind));
                     async move {}
                 })))
                 .children(&mut [

--- a/frontend/apps/crates/components/src/module/_groups/design/edit/theme_background/custom_background/state.rs
+++ b/frontend/apps/crates/components/src/module/_groups/design/edit/theme_background/custom_background/state.rs
@@ -10,7 +10,7 @@ use crate::{
         state::{ImageSearchKind, ImageSearchOptions, State as ImageSearchState},
     },
     tabs::MenuTabKind,
-    module::{_common::edit::entry::prelude::BaseExt, _groups::design::edit::design_ext::DesignExt},
+    module::{_common::edit::entry::prelude::BaseExt, _groups::design::edit::{design_ext::DesignExt, theme_background::ThemeBackground}},
     color_select::state::State as ColorPickerState,
 };
 
@@ -26,7 +26,7 @@ where
     pub colors_open: Mutable<bool>,
     pub color_state: Rc<ColorPickerState>,
     pub tab: Mutable<Tab>,
-    pub tab_index: Mutable<Option<usize>>,
+    pub tab_kind: Mutable<Option<MenuTabKind>>,
     _step: PhantomData<Step>,
 }
 
@@ -35,25 +35,25 @@ impl<Step, Base> CustomBackground<Step, Base> where
     Step: StepExt + 'static,
     Base: BaseExt<Step> + DesignExt + 'static,
 {
-    pub fn new(base: Rc<Base>, on_close: Box<dyn Fn()>) -> Rc<Self> {
+    pub fn new(state: Rc<ThemeBackground<Step, Base>>, on_close: Box<dyn Fn()>) -> Rc<Self> {
         let color_state = Rc::new(ColorPickerState::new(
-            base.get_theme().read_only(),
+            state.base.get_theme().read_only(),
             None,
             Some(String::from(STR_FILL_COLOR)),
-            Some(clone!(base => move |color| {
-                base.get_backgrounds().set_layer(Layer::One, Background::Color(color));
+            Some(clone!(state => move |color| {
+                state.base.get_backgrounds().set_layer(Layer::One, Background::Color(color));
             })),
         ));
 
-        let tab = Mutable::new(Tab::new(base.clone(), MenuTabKind::BackgroundImage));
+        let tab = Mutable::new(Tab::new(state.base.clone(), MenuTabKind::BackgroundImage));
 
         Rc::new(Self {
-            base,
+            base: state.base.clone(),
             on_close,
             colors_open: Mutable::new(false),
             color_state,
             tab,
-            tab_index: Mutable::new(None),
+            tab_kind: state.tab_kind.clone(),
             _step: PhantomData,
         })
     }

--- a/frontend/apps/crates/components/src/module/_groups/design/edit/theme_background/state.rs
+++ b/frontend/apps/crates/components/src/module/_groups/design/edit/theme_background/state.rs
@@ -9,6 +9,7 @@ use wasm_bindgen_futures::spawn_local;
 use std::marker::PhantomData;
 use std::rc::Rc;
 use crate::module::_groups::design::edit::design_ext::DesignExt;
+use crate::tabs::MenuTabKind;
 use crate::theme_selector::state::{ThemeSelector, ThemeSelectorCallbacks};
 use crate::module::_common::edit::entry::prelude::BaseExt;
 
@@ -23,6 +24,7 @@ pub struct ThemeBackground<Step, Base> where
     pub base: Rc<Base>,
     pub theme_selector: Rc<ThemeSelector>,
     pub custom_background: Mutable<Option<Rc<CustomBackground<Step, Base>>>>,
+    pub tab_kind: Mutable<Option<MenuTabKind>>,
     _step: PhantomData<Step>,
 }
 
@@ -30,7 +32,7 @@ impl<Step, Base> ThemeBackground<Step, Base> where
     Step: StepExt + 'static,
     Base: BaseExt<Step> + DesignExt + 'static,
 {
-    pub fn new(base: Rc<Base>) -> Rc<Self> {
+    pub fn new(base: Rc<Base>, tab_kind: Mutable<Option<MenuTabKind>>) -> Rc<Self> {
 
         let callbacks = ThemeSelectorCallbacks::new(clone!(base => move |theme_id| {
             base.set_theme(theme_id);
@@ -62,6 +64,7 @@ impl<Step, Base> ThemeBackground<Step, Base> where
             base,
             theme_selector,
             custom_background: Mutable::new(None),
+            tab_kind,
             _step: PhantomData,
         })
     }

--- a/frontend/apps/crates/components/src/tabs/dom.rs
+++ b/frontend/apps/crates/components/src/tabs/dom.rs
@@ -8,7 +8,7 @@ impl MenuTab {
     pub fn render(state: Rc<Self>, slot: Option<&str>) -> Dom {
         html!("menu-tab-with-title", {
             .apply_if(slot.is_some(), |dom| dom.property("slot", slot.unwrap_ji()))
-            .property("kind", state.kind.as_str())
+            .property("kind", format!("{}", state.kind))
             .property("disabled", !state.enabled)
             .apply_if(state.sizeable, |dom| {
                 dom.property_signal("small", (state.active_signal) ().map(|active| !active))

--- a/frontend/apps/crates/components/src/tabs/state.rs
+++ b/frontend/apps/crates/components/src/tabs/state.rs
@@ -1,5 +1,6 @@
 use dominator_helpers::signals::{box_signal_fn, BoxSignalFn};
 use futures_signals::signal::Signal;
+use strum_macros::Display;
 use std::rc::Rc;
 
 pub struct MenuTab {
@@ -33,7 +34,8 @@ impl MenuTab {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Display)]
+#[strum(serialize_all = "kebab-case")]
 pub enum MenuTabKind {
     Answer,
     Audio,
@@ -48,32 +50,9 @@ pub enum MenuTabKind {
     Question,
     Select,
     Text,
+    #[strum(serialize = "text")]
     DualList,
     Theme,
     Tooltip,
     Video,
-}
-
-impl MenuTabKind {
-    pub const fn as_str(&self) -> &'static str {
-        match self {
-            Self::Answer => "answer",
-            Self::Audio => "audio",
-            Self::BackgroundImage => "background-image",
-            Self::FillColor => "fill-color",
-            Self::Feedback => "feedback",
-            Self::Image => "image",
-            Self::Instructions => "instructions",
-            Self::Label => "label",
-            Self::Overlay => "overlay",
-            Self::PlaySettings => "play-settings",
-            Self::Question => "question",
-            Self::Select => "select",
-            Self::Text => "text",
-            Self::DualList => "text", // Same str value as Self::Text
-            Self::Theme => "theme",
-            Self::Tooltip => "tooltip",
-            Self::Video => "video",
-        }
-    }
 }

--- a/frontend/apps/crates/entry/module/cover/edit/src/base/sidebar/dom.rs
+++ b/frontend/apps/crates/entry/module/cover/edit/src/base/sidebar/dom.rs
@@ -14,7 +14,7 @@ impl DomRenderable for Sidebar {
     fn render(state: Rc<Sidebar>) -> Dom {
         html!("empty-fragment", {
             .future(state.base.step.signal_cloned().dedupe().for_each(clone!(state => move |_step| {
-                state.tab_index.set(None);
+                state.tab_kind.set(None);
                 async move {}
             })))
             .style("display", "contents")

--- a/frontend/apps/crates/entry/module/cover/edit/src/base/sidebar/state.rs
+++ b/frontend/apps/crates/entry/module/cover/edit/src/base/sidebar/state.rs
@@ -1,27 +1,27 @@
 use crate::base::state::Base;
-use components::module::_common::edit::prelude::*;
+use components::{module::_common::edit::prelude::*, tabs::MenuTabKind};
 use std::rc::Rc;
 
 use futures_signals::signal::{Mutable, Signal};
 
 pub struct Sidebar {
     pub base: Rc<Base>,
-    pub tab_index: Mutable<Option<usize>>,
+    pub tab_kind: Mutable<Option<MenuTabKind>>,
 }
 
 impl Sidebar {
     pub fn new(base: Rc<Base>) -> Self {
         Self {
             base,
-            tab_index: Mutable::new(None),
+            tab_kind: Mutable::new(None),
         }
     }
 }
 
 impl SidebarExt for Sidebar {
-    type TabIndexSignal = impl Signal<Item = Option<usize>>;
+    type TabKindSignal = impl Signal<Item = Option<MenuTabKind>>;
 
-    fn tab_index(&self) -> Self::TabIndexSignal {
-        self.tab_index.signal()
+    fn tab_kind(&self) -> Self::TabKindSignal {
+        self.tab_kind.signal()
     }
 }

--- a/frontend/apps/crates/entry/module/cover/edit/src/base/sidebar/step_1/dom.rs
+++ b/frontend/apps/crates/entry/module/cover/edit/src/base/sidebar/step_1/dom.rs
@@ -6,7 +6,8 @@ use components::module::_groups::design::edit::theme_background::ThemeBackground
 
 pub fn render(state: Rc<Step1>) -> Dom {
     let theme_background = ThemeBackground::new(
-        state.sidebar.base.clone()
+        state.sidebar.base.clone(),
+        state.sidebar.tab_kind.clone(),
     );
 
     theme_background.render()

--- a/frontend/apps/crates/entry/module/cover/edit/src/base/sidebar/step_2/dom.rs
+++ b/frontend/apps/crates/entry/module/cover/edit/src/base/sidebar/step_2/dom.rs
@@ -11,8 +11,8 @@ use std::rc::Rc;
 
 pub fn render(state: Rc<Step2>) -> Dom {
     html!("menu-tabs", {
-        .future(state.tab.signal_ref(|tab| tab.as_index()).dedupe().for_each(clone!(state => move |index| {
-            state.sidebar.tab_index.set(Some(index));
+        .future(state.tab.signal_ref(|tab| tab.kind()).dedupe().for_each(clone!(state => move |kind| {
+            state.sidebar.tab_kind.set_neq(Some(kind));
             async move {}
         })))
         .children(&mut [

--- a/frontend/apps/crates/entry/module/cover/edit/src/base/sidebar/step_2/state.rs
+++ b/frontend/apps/crates/entry/module/cover/edit/src/base/sidebar/step_2/state.rs
@@ -88,12 +88,4 @@ impl Tab {
             Self::Audio(_) => MenuTabKind::Audio,
         }
     }
-
-    pub fn as_index(&self) -> usize {
-        match self {
-            Self::Text => 0,
-            Self::Image(_) => 1,
-            Self::Audio(_) => 2,
-        }
-    }
 }

--- a/frontend/apps/crates/entry/module/drag-drop/edit/src/base/sidebar/dom.rs
+++ b/frontend/apps/crates/entry/module/drag-drop/edit/src/base/sidebar/dom.rs
@@ -17,7 +17,7 @@ impl DomRenderable for Sidebar {
     fn render(state: Rc<Sidebar>) -> Dom {
         html!("empty-fragment", {
             .future(state.base.step.signal_cloned().dedupe().for_each(clone!(state => move |_step| {
-                state.tab_index.set(None);
+                state.tab_kind.set(None);
                 async move {}
             })))
             .style("display", "contents")

--- a/frontend/apps/crates/entry/module/drag-drop/edit/src/base/sidebar/state.rs
+++ b/frontend/apps/crates/entry/module/drag-drop/edit/src/base/sidebar/state.rs
@@ -1,27 +1,27 @@
 use crate::base::state::Base;
-use components::module::_common::edit::prelude::*;
+use components::{module::_common::edit::prelude::*, tabs::MenuTabKind};
 use std::rc::Rc;
 
 use futures_signals::signal::{Mutable, Signal};
 
 pub struct Sidebar {
     pub base: Rc<Base>,
-    pub tab_index: Mutable<Option<usize>>,
+    pub tab_kind: Mutable<Option<MenuTabKind>>,
 }
 
 impl Sidebar {
     pub fn new(base: Rc<Base>) -> Self {
         Self {
             base,
-            tab_index: Mutable::new(None),
+            tab_kind: Mutable::new(None),
         }
     }
 }
 
 impl SidebarExt for Sidebar {
-    type TabIndexSignal = impl Signal<Item = Option<usize>>;
+    type TabKindSignal = impl Signal<Item = Option<MenuTabKind>>;
 
-    fn tab_index(&self) -> Self::TabIndexSignal {
-        self.tab_index.signal()
+    fn tab_kind(&self) -> Self::TabKindSignal {
+        self.tab_kind.signal()
     }
 }

--- a/frontend/apps/crates/entry/module/drag-drop/edit/src/base/sidebar/step_1/dom.rs
+++ b/frontend/apps/crates/entry/module/drag-drop/edit/src/base/sidebar/step_1/dom.rs
@@ -11,8 +11,8 @@ use std::rc::Rc;
 
 pub fn render_step_1(state: Rc<Step1>) -> Dom {
     html!("menu-tabs", {
-        .future(state.tab.signal_ref(|tab| tab.as_index()).dedupe().for_each(clone!(state => move |index| {
-            state.sidebar.tab_index.set(Some(index));
+        .future(state.tab.signal_ref(|tab| tab.kind()).dedupe().for_each(clone!(state => move |kind| {
+            state.sidebar.tab_kind.set(Some(kind));
             async move {}
         })))
         .children(&mut [

--- a/frontend/apps/crates/entry/module/drag-drop/edit/src/base/sidebar/step_1/state.rs
+++ b/frontend/apps/crates/entry/module/drag-drop/edit/src/base/sidebar/step_1/state.rs
@@ -114,14 +114,4 @@ impl Tab {
             Self::StickerText => MenuTabKind::Text,
         }
     }
-
-    pub fn as_index(&self) -> usize {
-        match self {
-            Self::BackgroundImage(_) => 0,
-            Self::FillColor(_) => 1,
-            Self::BgOverlay(_) => 2,
-            Self::StickerImage(_) => 3,
-            Self::StickerText => 4,
-        }
-    }
 }

--- a/frontend/apps/crates/entry/module/drag-drop/edit/src/base/sidebar/step_2/dom.rs
+++ b/frontend/apps/crates/entry/module/drag-drop/edit/src/base/sidebar/step_2/dom.rs
@@ -9,8 +9,8 @@ use std::rc::Rc;
 
 pub fn render_step_2(state: Rc<Step2>) -> Dom {
     html!("menu-tabs", {
-        .future(state.tab.signal_ref(|tab| tab.as_index()).dedupe().for_each(clone!(state => move |index| {
-            state.sidebar.tab_index.set(Some(index));
+        .future(state.tab.signal_ref(|tab| tab.kind()).dedupe().for_each(clone!(state => move |kind| {
+            state.sidebar.tab_kind.set(Some(kind));
             async move {}
         })))
         .children(&mut [

--- a/frontend/apps/crates/entry/module/drag-drop/edit/src/base/sidebar/step_2/state.rs
+++ b/frontend/apps/crates/entry/module/drag-drop/edit/src/base/sidebar/step_2/state.rs
@@ -81,11 +81,4 @@ impl Tab {
             Self::Audio(_) => MenuTabKind::Audio,
         }
     }
-
-    pub fn as_index(&self) -> usize {
-        match self {
-            Self::Select => 0,
-            Self::Audio(_) => 1,
-        }
-    }
 }

--- a/frontend/apps/crates/entry/module/drag-drop/edit/src/base/sidebar/step_5/dom.rs
+++ b/frontend/apps/crates/entry/module/drag-drop/edit/src/base/sidebar/step_5/dom.rs
@@ -9,8 +9,8 @@ use std::rc::Rc;
 
 pub fn render_step_5(state: Rc<Step5>) -> Dom {
     html!("menu-tabs", {
-        .future(state.tab.signal_ref(|tab| tab.as_index()).dedupe().for_each(clone!(state => move |index| {
-            state.sidebar.tab_index.set(Some(index));
+        .future(state.tab.signal_ref(|tab| tab.kind()).dedupe().for_each(clone!(state => move |kind| {
+            state.sidebar.tab_kind.set(Some(kind));
             async move {}
         })))
         .children(&mut [

--- a/frontend/apps/crates/entry/module/drag-drop/edit/src/base/sidebar/step_5/state.rs
+++ b/frontend/apps/crates/entry/module/drag-drop/edit/src/base/sidebar/step_5/state.rs
@@ -99,12 +99,4 @@ impl Tab {
             Self::Feedback(_) => MenuTabKind::Feedback,
         }
     }
-
-    pub fn as_index(&self) -> usize {
-        match self {
-            Self::Settings(_) => 0,
-            Self::Instructions(_) => 1,
-            Self::Feedback(_) => 2,
-        }
-    }
 }

--- a/frontend/apps/crates/entry/module/poster/edit/src/base/sidebar/dom.rs
+++ b/frontend/apps/crates/entry/module/poster/edit/src/base/sidebar/dom.rs
@@ -15,7 +15,7 @@ impl DomRenderable for Sidebar {
     fn render(state: Rc<Sidebar>) -> Dom {
         html!("empty-fragment", {
             .future(state.base.step.signal_cloned().dedupe().for_each(clone!(state => move |_step| {
-                state.tab_index.set(None);
+                state.tab_kind.set(None);
                 async move {}
             })))
             .style("display", "contents")

--- a/frontend/apps/crates/entry/module/poster/edit/src/base/sidebar/state.rs
+++ b/frontend/apps/crates/entry/module/poster/edit/src/base/sidebar/state.rs
@@ -1,27 +1,27 @@
 use crate::base::state::Base;
-use components::module::_common::edit::prelude::*;
+use components::{module::_common::edit::prelude::*, tabs::MenuTabKind};
 use std::rc::Rc;
 
 use futures_signals::signal::{Mutable, Signal};
 
 pub struct Sidebar {
     pub base: Rc<Base>,
-    pub tab_index: Mutable<Option<usize>>,
+    pub tab_kind: Mutable<Option<MenuTabKind>>,
 }
 
 impl Sidebar {
     pub fn new(base: Rc<Base>) -> Self {
         Self {
             base,
-            tab_index: Mutable::new(None),
+            tab_kind: Mutable::new(None),
         }
     }
 }
 
 impl SidebarExt for Sidebar {
-    type TabIndexSignal = impl Signal<Item = Option<usize>>;
+    type TabKindSignal = impl Signal<Item = Option<MenuTabKind>>;
 
-    fn tab_index(&self) -> Self::TabIndexSignal {
-        self.tab_index.signal()
+    fn tab_kind(&self) -> Self::TabKindSignal {
+        self.tab_kind.signal()
     }
 }

--- a/frontend/apps/crates/entry/module/poster/edit/src/base/sidebar/step_1/dom.rs
+++ b/frontend/apps/crates/entry/module/poster/edit/src/base/sidebar/step_1/dom.rs
@@ -5,7 +5,8 @@ use std::rc::Rc;
 
 pub fn render(state: Rc<Step1>) -> Dom {
     let theme_background = ThemeBackground::new(
-        state.sidebar.base.clone()
+        state.sidebar.base.clone(),
+        state.sidebar.tab_kind.clone(),
     );
 
     theme_background.render()

--- a/frontend/apps/crates/entry/module/poster/edit/src/base/sidebar/step_2/dom.rs
+++ b/frontend/apps/crates/entry/module/poster/edit/src/base/sidebar/step_2/dom.rs
@@ -10,8 +10,8 @@ use std::rc::Rc;
 
 pub fn render(state: Rc<Step2>) -> Dom {
     html!("menu-tabs", {
-        .future(state.tab.signal_ref(|tab| tab.as_index()).dedupe().for_each(clone!(state => move |index| {
-            state.sidebar.tab_index.set(Some(index));
+        .future(state.tab.signal_ref(|tab| tab.kind()).dedupe().for_each(clone!(state => move |kind| {
+            state.sidebar.tab_kind.set(Some(kind));
             async move {}
         })))
         .children(&mut [

--- a/frontend/apps/crates/entry/module/poster/edit/src/base/sidebar/step_2/state.rs
+++ b/frontend/apps/crates/entry/module/poster/edit/src/base/sidebar/step_2/state.rs
@@ -64,11 +64,4 @@ impl Tab {
             Self::Image(_) => MenuTabKind::Image,
         }
     }
-
-    pub fn as_index(&self) -> usize {
-        match self {
-            Self::Text => 0,
-            Self::Image(_) => 1,
-        }
-    }
 }

--- a/frontend/apps/crates/entry/module/resource-cover/edit/src/base/sidebar/dom.rs
+++ b/frontend/apps/crates/entry/module/resource-cover/edit/src/base/sidebar/dom.rs
@@ -14,7 +14,7 @@ impl DomRenderable for Sidebar {
     fn render(state: Rc<Sidebar>) -> Dom {
         html!("empty-fragment", {
             .future(state.base.step.signal_cloned().dedupe().for_each(clone!(state => move |_step| {
-                state.tab_index.set(None);
+                state.tab_kind.set(None);
                 async move {}
             })))
             .style("display", "contents")

--- a/frontend/apps/crates/entry/module/resource-cover/edit/src/base/sidebar/state.rs
+++ b/frontend/apps/crates/entry/module/resource-cover/edit/src/base/sidebar/state.rs
@@ -1,27 +1,27 @@
 use crate::base::state::Base;
-use components::module::_common::edit::prelude::*;
+use components::{module::_common::edit::prelude::*, tabs::MenuTabKind};
 use std::rc::Rc;
 
 use futures_signals::signal::{Mutable, Signal};
 
 pub struct Sidebar {
     pub base: Rc<Base>,
-    pub tab_index: Mutable<Option<usize>>,
+    pub tab_kind: Mutable<Option<MenuTabKind>>,
 }
 
 impl Sidebar {
     pub fn new(base: Rc<Base>) -> Self {
         Self {
             base,
-            tab_index: Mutable::new(None),
+            tab_kind: Mutable::new(None),
         }
     }
 }
 
 impl SidebarExt for Sidebar {
-    type TabIndexSignal = impl Signal<Item = Option<usize>>;
+    type TabKindSignal = impl Signal<Item = Option<MenuTabKind>>;
 
-    fn tab_index(&self) -> Self::TabIndexSignal {
-        self.tab_index.signal()
+    fn tab_kind(&self) -> Self::TabKindSignal {
+        self.tab_kind.signal()
     }
 }

--- a/frontend/apps/crates/entry/module/resource-cover/edit/src/base/sidebar/step_1/dom.rs
+++ b/frontend/apps/crates/entry/module/resource-cover/edit/src/base/sidebar/step_1/dom.rs
@@ -10,8 +10,8 @@ use std::rc::Rc;
 
 pub fn render(state: Rc<Step1>) -> Dom {
     html!("menu-tabs", {
-        .future(state.tab.signal_ref(|tab| tab.as_index()).dedupe().for_each(clone!(state => move |index| {
-            state.sidebar.tab_index.set(Some(index));
+        .future(state.tab.signal_ref(|tab| tab.kind()).dedupe().for_each(clone!(state => move |kind| {
+            state.sidebar.tab_kind.set(Some(kind));
             async move {}
         })))
         .children(&mut [

--- a/frontend/apps/crates/entry/module/resource-cover/edit/src/base/sidebar/step_1/state.rs
+++ b/frontend/apps/crates/entry/module/resource-cover/edit/src/base/sidebar/step_1/state.rs
@@ -92,12 +92,4 @@ impl Tab {
             Self::Overlay(_) => MenuTabKind::Overlay,
         }
     }
-
-    pub fn as_index(&self) -> usize {
-        match self {
-            Self::BackgroundImage(_) => 0,
-            Self::FillColor(_) => 1,
-            Self::Overlay(_) => 2,
-        }
-    }
 }

--- a/frontend/apps/crates/entry/module/resource-cover/edit/src/base/sidebar/step_2/dom.rs
+++ b/frontend/apps/crates/entry/module/resource-cover/edit/src/base/sidebar/step_2/dom.rs
@@ -10,8 +10,8 @@ use std::rc::Rc;
 
 pub fn render(state: Rc<Step2>) -> Dom {
     html!("menu-tabs", {
-        .future(state.tab.signal_ref(|tab| tab.as_index()).dedupe().for_each(clone!(state => move |index| {
-            state.sidebar.tab_index.set(Some(index));
+        .future(state.tab.signal_ref(|tab| tab.kind()).dedupe().for_each(clone!(state => move |kind| {
+            state.sidebar.tab_kind.set(Some(kind));
             async move {}
         })))
         .children(&mut [

--- a/frontend/apps/crates/entry/module/resource-cover/edit/src/base/sidebar/step_2/state.rs
+++ b/frontend/apps/crates/entry/module/resource-cover/edit/src/base/sidebar/step_2/state.rs
@@ -63,11 +63,4 @@ impl Tab {
             Self::Image(_) => MenuTabKind::Image,
         }
     }
-
-    pub fn as_index(&self) -> usize {
-        match self {
-            Self::Text => 0,
-            Self::Image(_) => 1,
-        }
-    }
 }

--- a/frontend/apps/crates/entry/module/tapping-board/edit/src/base/sidebar/dom.rs
+++ b/frontend/apps/crates/entry/module/tapping-board/edit/src/base/sidebar/dom.rs
@@ -16,7 +16,7 @@ impl DomRenderable for Sidebar {
     fn render(state: Rc<Sidebar>) -> Dom {
         html!("empty-fragment", {
             .future(state.base.step.signal_cloned().dedupe().for_each(clone!(state => move |_step| {
-                state.tab_index.set(None);
+                state.tab_kind.set(None);
                 async move {}
             })))
             .style("display", "contents")

--- a/frontend/apps/crates/entry/module/tapping-board/edit/src/base/sidebar/state.rs
+++ b/frontend/apps/crates/entry/module/tapping-board/edit/src/base/sidebar/state.rs
@@ -1,27 +1,27 @@
 use crate::base::state::Base;
-use components::module::_common::edit::prelude::*;
+use components::{module::_common::edit::prelude::*, tabs::MenuTabKind};
 use std::rc::Rc;
 
 use futures_signals::signal::{Mutable, Signal};
 
 pub struct Sidebar {
     pub base: Rc<Base>,
-    pub tab_index: Mutable<Option<usize>>,
+    pub tab_kind: Mutable<Option<MenuTabKind>>,
 }
 
 impl Sidebar {
     pub fn new(base: Rc<Base>) -> Self {
         Self {
             base,
-            tab_index: Mutable::new(None),
+            tab_kind: Mutable::new(None),
         }
     }
 }
 
 impl SidebarExt for Sidebar {
-    type TabIndexSignal = impl Signal<Item = Option<usize>>;
+    type TabKindSignal = impl Signal<Item = Option<MenuTabKind>>;
 
-    fn tab_index(&self) -> Self::TabIndexSignal {
-        self.tab_index.signal()
+    fn tab_kind(&self) -> Self::TabKindSignal {
+        self.tab_kind.signal()
     }
 }

--- a/frontend/apps/crates/entry/module/tapping-board/edit/src/base/sidebar/step_1/dom.rs
+++ b/frontend/apps/crates/entry/module/tapping-board/edit/src/base/sidebar/step_1/dom.rs
@@ -5,7 +5,8 @@ use std::rc::Rc;
 
 pub fn render(state: Rc<Step1>) -> Dom {
     let theme_background = ThemeBackground::new(
-        state.sidebar.base.clone()
+        state.sidebar.base.clone(),
+        state.sidebar.tab_kind.clone(),
     );
 
     theme_background.render()

--- a/frontend/apps/crates/entry/module/tapping-board/edit/src/base/sidebar/step_2/dom.rs
+++ b/frontend/apps/crates/entry/module/tapping-board/edit/src/base/sidebar/step_2/dom.rs
@@ -10,8 +10,8 @@ use std::rc::Rc;
 
 pub fn render(state: Rc<Step2>) -> Dom {
     html!("menu-tabs", {
-        .future(state.tab.signal_ref(|tab| tab.as_index()).dedupe().for_each(clone!(state => move |index| {
-            state.sidebar.tab_index.set(Some(index));
+        .future(state.tab.signal_ref(|tab| tab.kind()).dedupe().for_each(clone!(state => move |kind| {
+            state.sidebar.tab_kind.set(Some(kind));
             async move {}
         })))
         .children(&mut [

--- a/frontend/apps/crates/entry/module/tapping-board/edit/src/base/sidebar/step_2/state.rs
+++ b/frontend/apps/crates/entry/module/tapping-board/edit/src/base/sidebar/step_2/state.rs
@@ -65,11 +65,4 @@ impl Tab {
             Self::Image(_) => MenuTabKind::Image,
         }
     }
-
-    pub fn as_index(&self) -> usize {
-        match self {
-            Self::Text => 0,
-            Self::Image(_) => 1,
-        }
-    }
 }

--- a/frontend/apps/crates/entry/module/tapping-board/edit/src/base/sidebar/step_3/dom.rs
+++ b/frontend/apps/crates/entry/module/tapping-board/edit/src/base/sidebar/step_3/dom.rs
@@ -27,21 +27,10 @@ pub fn render(state: Rc<Step3>) -> Dom {
                         Some(_) => {
                             //otherwise, it means a trace is selected
                             Some(html!("menu-tabs", {
-                                // just for setting the tooltip index
-                                .future(
-                                    state
-                                        .tab_signal(selected_tab.signal())
-                                        .map(|tab|
-                                            tab
-                                                .map(|tab| tab.as_index())
-                                                .unwrap_or_default()
-                                        )
-                                        .dedupe()
-                                        .for_each(clone!(state => move |index| {
-                                            state.sidebar.tab_index.set(Some(index));
-                                            async move {}
-                                        }))
-                                )
+                                .future(selected_tab.signal_cloned().dedupe().for_each(clone!(state => move |kind| {
+                                    state.sidebar.tab_kind.set(kind.clone());
+                                    async move {}
+                                })))
                                 .children(&mut [
                                     //pass down our mutable so that we can switch tabs
                                     render_tab(state.clone(), MenuTabKind::Audio, selected_tab.clone()),

--- a/frontend/apps/crates/entry/module/tapping-board/edit/src/base/sidebar/step_3/state.rs
+++ b/frontend/apps/crates/entry/module/tapping-board/edit/src/base/sidebar/step_3/state.rs
@@ -109,11 +109,4 @@ impl Tab {
             Self::Audio(_) => MenuTabKind::Audio,
         }
     }
-
-    pub fn as_index(&self) -> usize {
-        match self {
-            Self::Audio(_) => 0,
-            Self::Label(_, _) => 1,
-        }
-    }
 }

--- a/frontend/apps/crates/entry/module/tapping-board/edit/src/base/sidebar/step_4/dom.rs
+++ b/frontend/apps/crates/entry/module/tapping-board/edit/src/base/sidebar/step_4/dom.rs
@@ -9,8 +9,8 @@ use std::rc::Rc;
 
 pub fn render(state: Rc<Step4>) -> Dom {
     html!("menu-tabs", {
-        .future(state.tab.signal_ref(|tab| tab.as_index()).dedupe().for_each(clone!(state => move |index| {
-            state.sidebar.tab_index.set(Some(index));
+        .future(state.tab.signal_ref(|tab| tab.kind()).dedupe().for_each(clone!(state => move |kind| {
+            state.sidebar.tab_kind.set(Some(kind));
             async move {}
         })))
         .children(&mut [

--- a/frontend/apps/crates/entry/module/tapping-board/edit/src/base/sidebar/step_4/state.rs
+++ b/frontend/apps/crates/entry/module/tapping-board/edit/src/base/sidebar/step_4/state.rs
@@ -75,11 +75,4 @@ impl Tab {
             Self::Instructions(_) => MenuTabKind::Instructions,
         }
     }
-
-    pub fn as_index(&self) -> usize {
-        match self {
-            Self::Settings(_) => 0,
-            Self::Instructions(_) => 1,
-        }
-    }
 }

--- a/frontend/apps/crates/entry/module/video/edit/src/base/sidebar/dom.rs
+++ b/frontend/apps/crates/entry/module/video/edit/src/base/sidebar/dom.rs
@@ -15,7 +15,7 @@ impl DomRenderable for Sidebar {
     fn render(state: Rc<Sidebar>) -> Dom {
         html!("empty-fragment", {
             .future(state.base.step.signal_cloned().dedupe().for_each(clone!(state => move |_step| {
-                state.tab_index.set(None);
+                state.tab_kind.set(None);
                 async move {}
             })))
             .style("display", "contents")

--- a/frontend/apps/crates/entry/module/video/edit/src/base/sidebar/state.rs
+++ b/frontend/apps/crates/entry/module/video/edit/src/base/sidebar/state.rs
@@ -1,26 +1,26 @@
 use crate::base::state::Base;
-use components::module::_common::edit::prelude::*;
+use components::{module::_common::edit::prelude::*, tabs::MenuTabKind};
 use futures_signals::signal::{Mutable, Signal};
 use std::rc::Rc;
 
 pub struct Sidebar {
     pub base: Rc<Base>,
-    pub tab_index: Mutable<Option<usize>>,
+    pub tab_kind: Mutable<Option<MenuTabKind>>,
 }
 
 impl Sidebar {
     pub fn new(base: Rc<Base>) -> Self {
         Self {
             base,
-            tab_index: Mutable::new(None),
+            tab_kind: Mutable::new(None),
         }
     }
 }
 
 impl SidebarExt for Sidebar {
-    type TabIndexSignal = impl Signal<Item = Option<usize>>;
+    type TabKindSignal = impl Signal<Item = Option<MenuTabKind>>;
 
-    fn tab_index(&self) -> Self::TabIndexSignal {
-        self.tab_index.signal()
+    fn tab_kind(&self) -> Self::TabKindSignal {
+        self.tab_kind.signal()
     }
 }

--- a/frontend/apps/crates/entry/module/video/edit/src/base/sidebar/step_1/dom.rs
+++ b/frontend/apps/crates/entry/module/video/edit/src/base/sidebar/step_1/dom.rs
@@ -5,7 +5,8 @@ use std::rc::Rc;
 
 pub fn render(state: Rc<Step1>) -> Dom {
     let theme_background = ThemeBackground::new(
-        state.sidebar.base.clone()
+        state.sidebar.base.clone(),
+        state.sidebar.tab_kind.clone(),
     );
 
     theme_background.render()

--- a/frontend/apps/crates/entry/module/video/edit/src/base/sidebar/step_2/dom.rs
+++ b/frontend/apps/crates/entry/module/video/edit/src/base/sidebar/step_2/dom.rs
@@ -10,8 +10,8 @@ use std::rc::Rc;
 
 pub fn render(state: Rc<Step2>) -> Dom {
     html!("menu-tabs", {
-        .future(state.tab.signal_ref(|tab| tab.as_index()).dedupe().for_each(clone!(state => move |index| {
-            state.sidebar.tab_index.set(Some(index));
+        .future(state.tab.signal_ref(|tab| tab.kind()).dedupe().for_each(clone!(state => move |kind| {
+            state.sidebar.tab_kind.set(Some(kind));
             async move {}
         })))
         .children(&mut [

--- a/frontend/apps/crates/entry/module/video/edit/src/base/sidebar/step_2/state.rs
+++ b/frontend/apps/crates/entry/module/video/edit/src/base/sidebar/step_2/state.rs
@@ -68,12 +68,4 @@ impl Tab {
             Self::Image(_) => MenuTabKind::Image,
         }
     }
-
-    pub fn as_index(&self) -> usize {
-        match self {
-            Self::Video => 0,
-            Self::Text => 1,
-            Self::Image(_) => 2,
-        }
-    }
 }

--- a/frontend/apps/crates/entry/module/video/edit/src/base/sidebar/step_3/dom.rs
+++ b/frontend/apps/crates/entry/module/video/edit/src/base/sidebar/step_3/dom.rs
@@ -9,8 +9,8 @@ use std::rc::Rc;
 
 pub fn render(state: Rc<Step3>) -> Dom {
     html!("menu-tabs", {
-        .future(state.tab.signal_ref(|tab| tab.as_index()).dedupe().for_each(clone!(state => move |index| {
-            state.sidebar.tab_index.set(Some(index));
+        .future(state.tab.signal_ref(|tab| tab.kind()).dedupe().for_each(clone!(state => move |kind| {
+            state.sidebar.tab_kind.set(Some(kind));
             async move {}
         })))
         .children(&mut [

--- a/frontend/apps/crates/entry/module/video/edit/src/base/sidebar/step_3/state.rs
+++ b/frontend/apps/crates/entry/module/video/edit/src/base/sidebar/step_3/state.rs
@@ -76,11 +76,4 @@ impl Tab {
             Self::Instructions(_) => MenuTabKind::Instructions,
         }
     }
-
-    pub fn as_index(&self) -> usize {
-        match self {
-            Self::Settings(_) => 0,
-            Self::Instructions(_) => 1,
-        }
-    }
 }


### PR DESCRIPTION
Closes #2341 

- Implements a new format for Jiggling content JSON files:

#### Example

```json
{
    "title": "Create a cover",
    "steps": [
        {
            "default": {
                "title": "Design your JIG cover!",
                "body": "Choose one of our themes with a preset cover or skip to create with our HUGE library of backgrounds and images."
            },
            "tabs": {
                "background-image": {
                    "title": "Custom image background",
                    "body": "Don't love the theme's background? Choose another or upload your own!"
                },
                "overlay": {
                    "title": "Add a preset layout",
                    "body": "An overlay sits on top of your background and helps you organize your content."
                }
            }
        },
        {
            "tabs": {
                "text": {
                    "title": "What's this JIG about?",
                    "body": "Add a title, images and a soundbite to your cover."
                },
                "image": {
                    "title": "Need some more images?",
                    "body": "Search our library with thousands of images perfect for your topic or upload your own."
                },
                "audio": {
                    "title": "Lookin good! Now add sound!",
                    "body": "Record a welcome message, instructions or upload audio you already have."
                }
            }
        }
    ]
}
```

- Enables the new theme system to set the Jiggling text using `MenuTabKind`
- When a step has no tabs, or tabs don't appear until some action has happened, a new `"default"` property is used to set the Jiggling text for the step.
  - Once a tab is rendered, the Jiggling text is set from that tab.