### PR TITLE
chore: Lock rust nightly version to nightly-2022-03-22

### DIFF
--- a/frontend/apps/crates/entry/home/Cargo.toml
+++ b/frontend/apps/crates/entry/home/Cargo.toml
@@ -28,7 +28,7 @@ web-sys = { version = "0.3.55", features = [
     'Response',
     'RequestMode',
     'Headers',
-    'Document', 
+    'Document',
     'DocumentFragment',
     'HtmlTemplateElement',
     'Window',

--- a/frontend/apps/rust-toolchain.toml
+++ b/frontend/apps/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2022-03-22"


### PR DESCRIPTION
Rust nightly 2022-03-23 has a change which has caused ring to stop building: https://github.com/rust-lang/rust/issues/95267

This PR locks the nightly version to nightly-2022-03-22.