### PR TITLE
feat: dont stretch overlay image

### DIFF
--- a/frontend/apps/crates/components/src/backgrounds/dom.rs
+++ b/frontend/apps/crates/components/src/backgrounds/dom.rs
@@ -143,7 +143,7 @@ fn render_bg(bg: &Background) -> Option<Dom> {
             .style("position", "absolute")
             .style("top", "0")
             .style("left", "0")
-            .style("display", "block")
+            .style("object-fit", "contain")
             .style("width", "100%")
             .style("height", "100%")
             .property("id", image.id.0.to_string())


### PR DESCRIPTION
closes #1964 

# Before

![image](https://user-images.githubusercontent.com/13839150/160385468-aef3e29a-dfde-4d53-a2c6-5768631a9e4e.png)

------------------------------------------------------

# After

![image](https://user-images.githubusercontent.com/13839150/160376105-49414de7-f163-4f56-bd30-319784c1b54d.png)
![image](https://user-images.githubusercontent.com/13839150/160376162-8ff25971-6428-49ee-9a70-2ce01b0286f7.png)

## Something to note is that the image isn't getting centered if it isn't formatted to fit the box
![image](https://user-images.githubusercontent.com/13839150/160376289-a2a4902d-7a78-4534-b53c-07e4a77691b5.png)
