### PR TITLE
feat(be/mail): set name for SENDER EMAIL

### DIFF
--- a/backend/api/src/service/mail.rs
+++ b/backend/api/src/service/mail.rs
@@ -7,6 +7,8 @@ use crate::error;
 
 use super::Service;
 
+const SENDER_NAME: &str = "Jigzi";
+
 pub struct Client {
     client: Sender,
 
@@ -23,7 +25,7 @@ impl Client {
     pub fn new(settings: EmailClientSettings) -> Self {
         Client {
             client: Sender::new(settings.api_key),
-            sender_email: Email::new(settings.sender_email),
+            sender_email: Email::new(settings.sender_email).set_name(SENDER_NAME),
             signup_verify_template: settings.signup_verify_template,
             password_reset_template: settings.password_reset_template,
             email_reset_template: settings.email_reset_template,


### PR DESCRIPTION
closes https://github.com/ji-devs/ji-cloud/issues/2592

references:
- Sendgrid https://docs.rs/sendgrid/0.17.4/sendgrid/v3/struct.Email.html#method.set_name