### PR TITLE
fix(be): Resolve broken editor state for dragdrop module

### DIFF
--- a/backend/api/migrations/20220404095051_fix-dragdrop-editor-state.sql
+++ b/backend/api/migrations/20220404095051_fix-dragdrop-editor-state.sql
@@ -1,0 +1,4 @@
+update jig_data_module
+set contents = jsonb_set(contents, '{"content", "editor_state"}', '{"step": "Five", "steps_completed": ["Four", "Three", "Two", "One"]}'::jsonb)
+where kind = 10
+    and contents->'content'->'editor_state'->>'step' = 'Five';


### PR DESCRIPTION
- Fixes the editor_state data for drag drop modules (Caused by the migration added in #2619)