### PR TITLE
fix(fe/module/drag-drop): Remove start drag sound effect

### DIFF
--- a/frontend/apps/crates/entry/module/drag-drop/play/src/base/game/playing/actions.rs
+++ b/frontend/apps/crates/entry/module/drag-drop/play/src/base/game/playing/actions.rs
@@ -124,22 +124,13 @@ impl PlayState {
 }
 
 pub enum AudioEffect {
-    Drag,
     Correct,
     Wrong,
 }
 
 impl AudioEffect {
-    pub fn is_loop(&self) -> bool {
-        match self {
-            AudioEffect::Drag => true,
-            _ => false,
-        }
-    }
-
     pub fn as_path(&self) -> AudioPath<'_> {
         let filename = match self {
-            AudioEffect::Drag => "drag-loop",
             AudioEffect::Correct => "correct",
             AudioEffect::Wrong => "wrong",
         };
@@ -157,7 +148,7 @@ impl InteractiveItem {
     }
     pub fn play_audio_effect(&self, effect: AudioEffect) {
         *self.audio_effect_handle.borrow_mut() =
-            Some(AUDIO_MIXER.with(|mixer| mixer.play(effect.as_path(), effect.is_loop())));
+            Some(AUDIO_MIXER.with(|mixer| mixer.play(effect.as_path(), false)));
     }
 
     pub fn stop_all_audio(&self) {
@@ -168,7 +159,6 @@ impl InteractiveItem {
     pub fn start_drag(&self, x: i32, y: i32) {
         if !self.completed.get() {
             self.try_play_user_audio();
-            self.play_audio_effect(AudioEffect::Drag);
 
             self.drag
                 .set(Some(Rc::new(Drag::new(x, y, 0.0, 0.0, true))));

--- a/frontend/apps/crates/entry/user/src/profile/actions.rs
+++ b/frontend/apps/crates/entry/user/src/profile/actions.rs
@@ -8,14 +8,15 @@ use shared::{
     api::endpoints::{self, meta, user, ApiEndpoint},
     domain::{
         image::{user::UserImageCreateRequest, ImageId, ImageKind},
-        meta::MetadataResponse, user::ResetPasswordRequest,
+        meta::MetadataResponse,
+        user::ResetPasswordRequest,
     },
     error::EmptyError,
     media::MediaLibrary,
 };
 use wasm_bindgen_futures::spawn_local;
 
-use super::state::{State, ResetPasswordStatus};
+use super::state::{ResetPasswordStatus, State};
 use utils::{fetch::api_with_auth, prelude::*, unwrap::UnwrapJiExt};
 use web_sys::File;
 
@@ -23,7 +24,9 @@ impl State {
     pub fn send_reset_password(self: &Rc<Self>) {
         let state = self;
 
-        state.reset_password_status.set(ResetPasswordStatus::Loading);
+        state
+            .reset_password_status
+            .set(ResetPasswordStatus::Loading);
 
         spawn_local(clone!(state => async move {
             let req = ResetPasswordRequest {

--- a/frontend/apps/crates/entry/user/src/profile/dom/mod.rs
+++ b/frontend/apps/crates/entry/user/src/profile/dom/mod.rs
@@ -16,7 +16,10 @@ use wasm_bindgen::JsValue;
 use web_sys::{HtmlElement, HtmlInputElement};
 
 use crate::{
-    profile::{dom::options_popup::PopupCallbacks, state::{ActivePopup, ResetPasswordStatus}},
+    profile::{
+        dom::options_popup::PopupCallbacks,
+        state::{ActivePopup, ResetPasswordStatus},
+    },
     strings::register::step_2::{STR_LOCATION_PLACEHOLDER, STR_PERSONA_OPTIONS},
 };
 

--- a/frontend/apps/crates/entry/user/src/profile/state.rs
+++ b/frontend/apps/crates/entry/user/src/profile/state.rs
@@ -31,7 +31,7 @@ impl State {
 pub enum ResetPasswordStatus {
     Ready,
     Loading,
-    Sent
+    Sent,
 }
 
 impl Default for ResetPasswordStatus {


### PR DESCRIPTION
- Removes default sound effect when player starts dragging an item (requested by @corinnewo);
	- Custom audio on the item still plays, however.
- Ran `cargo fmt`