### PR TITLE
feat(fe/module/drag-drop): Add default text when creating a new drag-drop module

### DIFF
--- a/shared/rust/src/domain/jig/module/body/drag_drop.rs
+++ b/shared/rust/src/domain/jig/module/body/drag_drop.rs
@@ -12,6 +12,8 @@ use std::convert::TryFrom;
 mod play_settings;
 pub use play_settings::*;
 
+use super::_groups::design::Text;
+
 /// The body for [`DragDrop`](crate::domain::jig::module::ModuleKind::DragDrop) modules.
 #[derive(Default, Clone, Serialize, Deserialize, Debug)]
 pub struct ModuleData {
@@ -37,6 +39,10 @@ impl BodyExt<Mode, Step> for ModuleData {
             content: Some(Content {
                 mode,
                 theme,
+                items: vec![Item {
+                    sticker: Sticker::Text(Text::default()),
+                    kind: ItemKind::Static,
+                }],
                 ..Default::default()
             }),
         }


### PR DESCRIPTION
- Adds default text when creating a new drag-drop activity for a JIG