### PR TITLE
fix(fe/module/drag-drop): Ensure game is ended when all items with targets are placed correctly

### DIFF
--- a/frontend/apps/crates/entry/module/drag-drop/play/src/base/game/playing/state.rs
+++ b/frontend/apps/crates/entry/module/drag-drop/play/src/base/game/playing/state.rs
@@ -51,11 +51,10 @@ impl PlayState {
         signal_vec::always(
             self.items
                 .iter()
-                .filter(|item| match item {
-                    PlayItem::Interactive(_) => true,
-                    _ => false,
+                .filter_map(|item| match item {
+                    PlayItem::Interactive(item) => Some(item.clone()),
+                    _ => None,
                 })
-                .map(|item| item.get_interactive_unchecked())
                 .collect::<Vec<Rc<InteractiveItem>>>(),
         )
         .filter_signal_cloned(|data| data.size.signal_cloned().map(|size| size.is_none()))
@@ -67,22 +66,6 @@ impl PlayState {
 pub enum PlayItem {
     Static(Sticker),
     Interactive(Rc<InteractiveItem>),
-}
-
-impl PlayItem {
-    pub fn get_interactive_unchecked(&self) -> Rc<InteractiveItem> {
-        match self {
-            Self::Interactive(data) => data.clone(),
-            _ => panic!("not interctive!"),
-        }
-    }
-
-    pub fn is_interactive(&self) -> bool {
-        match self {
-            Self::Interactive(_) => true,
-            _ => false,
-        }
-    }
 }
 
 pub struct InteractiveItem {


### PR DESCRIPTION
- When interactive items are configured _without_ targets, ensure that the game shows/plays feedback and ends correctly.
- Minor refactoring.