### PR TITLE
feat(fe/module): Continue through tabs and steps

### DIFF
--- a/frontend/apps/crates/components/src/module/_common/edit/entry/base/actions.rs
+++ b/frontend/apps/crates/components/src/module/_common/edit/entry/base/actions.rs
@@ -17,7 +17,12 @@ where
 {
     pub fn try_next_step(&self) {
         if let Some(to) = self.step.get().next() {
-            self.try_change_step(to);
+            if self.base.can_continue_next().get() {
+                // If the module didn't handle the navigation, move on to the next step.
+                if !self.base.continue_next() {
+                    self.try_change_step(to);
+                }
+            }
         }
     }
     pub fn try_change_step(&self, to: Step) {

--- a/frontend/apps/crates/components/src/module/_common/edit/entry/base/dom/regular.rs
+++ b/frontend/apps/crates/components/src/module/_common/edit/entry/base/dom/regular.rs
@@ -209,7 +209,7 @@ where
         .child(Footer::render(state.footer.clone()))
         .child(html!("module-footer-continue-button", {
             .property("slot", "btn")
-            .property_signal("enabled", state.base.next_step_allowed_signal())
+            .property_signal("enabled", state.base.can_continue_next().signal_cloned())
             .event(clone!(state => move |_evt:events::Next| {
                 state.try_next_step();
             }))

--- a/frontend/apps/crates/components/src/module/_common/edit/entry/base/state.rs
+++ b/frontend/apps/crates/components/src/module/_common/edit/entry/base/state.rs
@@ -1,6 +1,6 @@
 use dominator::{clone, Dom};
 use dominator_helpers::futures::AsyncLoader;
-use futures_signals::signal::{Mutable, Signal, SignalExt};
+use futures_signals::signal::{Mutable, ReadOnlyMutable, Signal, SignalExt};
 use std::collections::HashSet;
 use std::{marker::PhantomData, rc::Rc};
 
@@ -211,19 +211,25 @@ pub trait DomRenderable {
     fn render(state: Rc<Self>) -> Dom;
 }
 
-pub trait BaseExt<Step: StepExt> {
-    // using these in practice will require
-    // #![feature(type_alias_impl_trait)]
-    // and the implementor will have
-    // type FooSignal = impl Signal<Item = Foo>
-    type NextStepAllowedSignal: Signal<Item = bool>;
+/// Convenience alias for commonly used custom continue functions
+pub type ContinueNextFn = Mutable<Option<Rc<dyn Fn() -> bool>>>;
 
+pub trait BaseExt<Step: StepExt> {
+    /// Whether the step in the modules sidebar can be changed
     fn allowed_step_change(&self, from: Step, to: Step) -> bool;
 
-    fn next_step_allowed_signal(&self) -> Self::NextStepAllowedSignal;
+    /// A signal used to determine whether the module navigation can proceed to the next tab/step
+    fn can_continue_next(&self) -> ReadOnlyMutable<bool>;
 
+    /// Custom module-level navigation
+    ///
+    /// Returns `false` if the module implementing this didn't handle the navigation.
+    fn continue_next(&self) -> bool;
+
+    /// Current JIG's ID
     fn get_jig_id(&self) -> JigId;
 
+    /// Current module's ID
     fn get_module_id(&self) -> ModuleId;
 }
 

--- a/frontend/apps/crates/components/src/module/_groups/cards/edit/sidebar/step_1/state.rs
+++ b/frontend/apps/crates/components/src/module/_groups/cards/edit/sidebar/step_1/state.rs
@@ -75,6 +75,20 @@ impl<RawData: RawDataExt, E: ExtraExt> Step1<RawData, E> {
 
         state
     }
+
+    pub fn next_kind(&self) -> Option<MenuTabKind> {
+        match self.tab_kind.get() {
+            Some(MenuTabKind::Text | MenuTabKind::DualList) => {
+                if matches!(self.base.mode, Mode::WordsAndImages) {
+                    Some(MenuTabKind::Image)
+                } else {
+                    Some(MenuTabKind::Audio)
+                }
+            }
+            Some(MenuTabKind::Image) => Some(MenuTabKind::Audio),
+            _ => None,
+        }
+    }
 }
 
 pub enum Tab {

--- a/frontend/apps/crates/components/src/module/_groups/cards/edit/sidebar/step_3/dom.rs
+++ b/frontend/apps/crates/components/src/module/_groups/cards/edit/sidebar/step_3/dom.rs
@@ -19,6 +19,19 @@ where
     SettingsState: 'static,
     RenderSettingsFn: Fn(Rc<SettingsState>) -> Dom + Clone + 'static,
 {
+    state.base.can_continue_next.set_neq(true);
+    state
+        .base
+        .continue_next_fn
+        .set(Some(Rc::new(clone!(state => move || {
+            if let Some(kind) = state.next_kind() {
+                state.tab.set(Tab::new(state.base.clone(), kind, state.get_settings.clone()));
+                true
+            } else {
+                false
+            }
+        }))));
+
     html!("menu-tabs", {
         .future(state.tab.signal_ref(|tab| tab.kind()).dedupe().for_each(clone!(state => move |kind| {
             state.tab_kind.set(Some(kind));

--- a/frontend/apps/crates/components/src/module/_groups/cards/edit/sidebar/step_3/state.rs
+++ b/frontend/apps/crates/components/src/module/_groups/cards/edit/sidebar/step_3/state.rs
@@ -50,6 +50,13 @@ where
             tab_kind,
         })
     }
+
+    pub fn next_kind(&self) -> Option<MenuTabKind> {
+        match self.tab_kind.get() {
+            Some(MenuTabKind::PlaySettings) => Some(MenuTabKind::Instructions),
+            _ => None,
+        }
+    }
 }
 
 pub enum Tab<SettingsState> {

--- a/frontend/apps/crates/components/src/module/_groups/cards/edit/state.rs
+++ b/frontend/apps/crates/components/src/module/_groups/cards/edit/state.rs
@@ -76,6 +76,8 @@ pub struct CardsBase<RawData: RawDataExt, E: ExtraExt> {
     pub pairs: MutableVec<(Card, Card)>,
     pub selected_pair: Mutable<Option<(usize, SelectedSide)>>,
     pub background: Mutable<Option<Background>>,
+    pub can_continue_next: Mutable<bool>,
+    pub continue_next_fn: ContinueNextFn,
     pub extra: E,
     pub debug: DebugSettings,
 }
@@ -131,6 +133,8 @@ impl<RawData: RawDataExt, E: ExtraExt> CardsBase<RawData, E> {
             .map(|pair| (pair.0.clone().into(), pair.1.clone().into()))
             .collect();
 
+        let pairs = MutableVec::new_with_values(pairs);
+
         let mode = content.mode;
         let instructions = Mutable::new(content.instructions);
 
@@ -145,9 +149,11 @@ impl<RawData: RawDataExt, E: ExtraExt> CardsBase<RawData, E> {
             instructions,
             mode,
             tooltips: Tooltips::new(),
-            pairs: MutableVec::new_with_values(pairs),
+            pairs,
             selected_pair: Mutable::new(None),
             background,
+            can_continue_next: Mutable::new(false),
+            continue_next_fn: Mutable::new(None),
             extra,
             module_kind,
             debug: debug.unwrap_or_default(),
@@ -196,24 +202,8 @@ impl<RawData: RawDataExt, E: ExtraExt> CardsBase<RawData, E> {
     pub fn theme_id_str_signal(&self) -> impl Signal<Item = &'static str> {
         self.theme_id.signal().map(|id| id.as_str_id())
     }
-}
 
-//the requirement for this indirection might be a compiler bug...
-//I couldn't reproduce it on playground
-//here was the latest attempt: https://play.rust-lang.org/?version=nightly&mode=debug&edition=2018&gist=75e158fa8d226b8fdc505ec8551ca259
-
-impl<RawData: RawDataExt, E: ExtraExt> BaseExt<Step> for CardsBase<RawData, E> {
-    type NextStepAllowedSignal = impl Signal<Item = bool>;
-
-    fn get_jig_id(&self) -> JigId {
-        self.jig_id
-    }
-
-    fn get_module_id(&self) -> ModuleId {
-        self.module_id
-    }
-
-    fn allowed_step_change(&self, _from: Step, _to: Step) -> bool {
+    pub fn is_valid(&self) -> bool {
         self.pairs
             .lock_ref()
             .iter()
@@ -222,9 +212,7 @@ impl<RawData: RawDataExt, E: ExtraExt> BaseExt<Step> for CardsBase<RawData, E> {
             >= 2
     }
 
-    fn next_step_allowed_signal(&self) -> Self::NextStepAllowedSignal {
-        let _mode = self.mode;
-
+    pub fn is_valid_signal(&self) -> impl Signal<Item = bool> {
         self.pairs
             .signal_vec_cloned()
             .map_signal(|(card_1, card_2)| {
@@ -237,6 +225,42 @@ impl<RawData: RawDataExt, E: ExtraExt> BaseExt<Step> for CardsBase<RawData, E> {
                 }
             })
             .to_signal_map(|xs| xs.iter().filter(|x| **x).count() >= 2)
+    }
+}
+
+//the requirement for this indirection might be a compiler bug...
+//I couldn't reproduce it on playground
+//here was the latest attempt: https://play.rust-lang.org/?version=nightly&mode=debug&edition=2018&gist=75e158fa8d226b8fdc505ec8551ca259
+
+impl<RawData: RawDataExt, E: ExtraExt> BaseExt<Step> for CardsBase<RawData, E> {
+    fn get_jig_id(&self) -> JigId {
+        self.jig_id
+    }
+
+    fn get_module_id(&self) -> ModuleId {
+        self.module_id
+    }
+
+    fn allowed_step_change(&self, _from: Step, _to: Step) -> bool {
+        self.is_valid()
+    }
+
+    fn can_continue_next(&self) -> ReadOnlyMutable<bool> {
+        self.can_continue_next.read_only()
+    }
+
+    fn continue_next(&self) -> bool {
+        if self.can_continue_next.get() {
+            match self.step.get() {
+                Step::One | Step::Three => match self.continue_next_fn.get_cloned() {
+                    Some(continue_next_fn) => continue_next_fn(),
+                    None => false,
+                },
+                _ => false,
+            }
+        } else {
+            false
+        }
     }
 }
 

--- a/frontend/apps/crates/entry/module/cover/edit/src/base/sidebar/step_2/dom.rs
+++ b/frontend/apps/crates/entry/module/cover/edit/src/base/sidebar/step_2/dom.rs
@@ -10,6 +10,19 @@ use futures_signals::signal::SignalExt;
 use std::rc::Rc;
 
 pub fn render(state: Rc<Step2>) -> Dom {
+    state
+        .sidebar
+        .base
+        .continue_next_fn
+        .set(Some(Rc::new(clone!(state => move || {
+            if let Some(kind) = state.next_kind() {
+                state.tab.set(Tab::new(state.sidebar.base.clone(), kind));
+                true
+            } else {
+                false
+            }
+        }))));
+
     html!("menu-tabs", {
         .future(state.tab.signal_ref(|tab| tab.kind()).dedupe().for_each(clone!(state => move |kind| {
             state.sidebar.tab_kind.set_neq(Some(kind));

--- a/frontend/apps/crates/entry/module/cover/edit/src/base/sidebar/step_2/state.rs
+++ b/frontend/apps/crates/entry/module/cover/edit/src/base/sidebar/step_2/state.rs
@@ -30,6 +30,14 @@ impl Step2 {
 
         Rc::new(Self { tab, sidebar })
     }
+
+    pub fn next_kind(&self) -> Option<MenuTabKind> {
+        match self.tab.get_cloned().kind() {
+            MenuTabKind::Text => Some(MenuTabKind::Image),
+            MenuTabKind::Image => Some(MenuTabKind::Audio),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Clone)]

--- a/frontend/apps/crates/entry/module/drag-drop/edit/src/base/sidebar/step_2/dom.rs
+++ b/frontend/apps/crates/entry/module/drag-drop/edit/src/base/sidebar/step_2/dom.rs
@@ -16,6 +16,19 @@ pub fn render_step_2(state: Rc<Step2>) -> Dom {
         .set_neq(Some(StickerPhase::Scene));
     state.sidebar.trace_phase.set_neq(None);
 
+    state
+        .sidebar
+        .base
+        .continue_next_fn
+        .set(Some(Rc::new(clone!(state => move || {
+            if let Some(kind) = state.next_kind() {
+                state.tab.set(Tab::new(state.sidebar.base.clone(), kind));
+                true
+            } else {
+                false
+            }
+        }))));
+
     html!("menu-tabs", {
         .future(state.tab.signal_ref(|tab| tab.kind()).dedupe().for_each(clone!(state => move |kind| {
             state.sidebar.tab_kind.set(Some(kind));

--- a/frontend/apps/crates/entry/module/drag-drop/edit/src/base/sidebar/step_2/state.rs
+++ b/frontend/apps/crates/entry/module/drag-drop/edit/src/base/sidebar/step_2/state.rs
@@ -22,6 +22,13 @@ impl Step2 {
         let tab = Mutable::new(Tab::new(sidebar.base.clone(), MenuTabKind::Text));
         Rc::new(Self { sidebar, tab })
     }
+
+    pub fn next_kind(&self) -> Option<MenuTabKind> {
+        match self.tab.get_cloned().kind() {
+            MenuTabKind::Text => Some(MenuTabKind::Image),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Clone)]

--- a/frontend/apps/crates/entry/module/drag-drop/edit/src/base/sidebar/step_3/dom.rs
+++ b/frontend/apps/crates/entry/module/drag-drop/edit/src/base/sidebar/step_3/dom.rs
@@ -12,6 +12,19 @@ use futures_signals::signal::{Signal, SignalExt};
 use std::rc::Rc;
 
 pub fn render_step_3(state: Rc<Step3>) -> Dom {
+    state
+        .sidebar
+        .base
+        .continue_next_fn
+        .set(Some(Rc::new(clone!(state => move || {
+            if let Some(kind) = state.next_kind() {
+                state.tab.set(Tab::new(state.sidebar.base.clone(), kind));
+                true
+            } else {
+                false
+            }
+        }))));
+
     html!("menu-tabs", {
         .future(state.tab.signal_cloned().for_each(clone!(state => move |tab| {
             let (sticker_phase, trace_phase) = match tab {

--- a/frontend/apps/crates/entry/module/drag-drop/edit/src/base/sidebar/step_3/state.rs
+++ b/frontend/apps/crates/entry/module/drag-drop/edit/src/base/sidebar/step_3/state.rs
@@ -21,6 +21,15 @@ impl Step3 {
 
         Rc::new(Self { sidebar, tab })
     }
+
+    pub fn next_kind(&self) -> Option<MenuTabKind> {
+        match self.tab.get_cloned().kind() {
+            MenuTabKind::Select => Some(MenuTabKind::Audio),
+            MenuTabKind::Audio => Some(MenuTabKind::Trace),
+            MenuTabKind::Trace => Some(MenuTabKind::Place),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Clone)]

--- a/frontend/apps/crates/entry/module/drag-drop/edit/src/base/sidebar/step_4/dom.rs
+++ b/frontend/apps/crates/entry/module/drag-drop/edit/src/base/sidebar/step_4/dom.rs
@@ -16,6 +16,19 @@ pub fn render_step_4(state: Rc<Step4>) -> Dom {
         .set_neq(Some(StickerPhase::Static));
     state.sidebar.trace_phase.set_neq(None);
 
+    state
+        .sidebar
+        .base
+        .continue_next_fn
+        .set(Some(Rc::new(clone!(state => move || {
+            if let Some(kind) = state.next_kind() {
+                state.tab.set(Tab::new(state.sidebar.base.clone(), kind));
+                true
+            } else {
+                false
+            }
+        }))));
+
     html!("menu-tabs", {
         .future(state.tab.signal_ref(|tab| tab.kind()).dedupe().for_each(clone!(state => move |kind| {
             state.sidebar.tab_kind.set_neq(Some(kind));

--- a/frontend/apps/crates/entry/module/drag-drop/edit/src/base/sidebar/step_4/state.rs
+++ b/frontend/apps/crates/entry/module/drag-drop/edit/src/base/sidebar/step_4/state.rs
@@ -29,6 +29,14 @@ impl Step4 {
 
         Rc::new(Self { sidebar, tab })
     }
+
+    pub fn next_kind(&self) -> Option<MenuTabKind> {
+        match self.tab.get_cloned().kind() {
+            MenuTabKind::PlaySettings => Some(MenuTabKind::Instructions),
+            MenuTabKind::Instructions => Some(MenuTabKind::Feedback),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Clone)]

--- a/frontend/apps/crates/entry/module/poster/edit/src/base/sidebar/step_2/dom.rs
+++ b/frontend/apps/crates/entry/module/poster/edit/src/base/sidebar/step_2/dom.rs
@@ -9,9 +9,22 @@ use futures_signals::signal::SignalExt;
 use std::rc::Rc;
 
 pub fn render(state: Rc<Step2>) -> Dom {
+    state
+        .sidebar
+        .base
+        .continue_next_fn
+        .set(Some(Rc::new(clone!(state => move || {
+            if let Some(kind) = state.next_kind() {
+                state.tab.set(Tab::new(state.sidebar.base.clone(), kind));
+                true
+            } else {
+                false
+            }
+        }))));
+
     html!("menu-tabs", {
         .future(state.tab.signal_ref(|tab| tab.kind()).dedupe().for_each(clone!(state => move |kind| {
-            state.sidebar.tab_kind.set(Some(kind));
+            state.sidebar.tab_kind.set_neq(Some(kind));
             async move {}
         })))
         .children(&mut [

--- a/frontend/apps/crates/entry/module/poster/edit/src/base/sidebar/step_2/state.rs
+++ b/frontend/apps/crates/entry/module/poster/edit/src/base/sidebar/step_2/state.rs
@@ -27,6 +27,13 @@ impl Step2 {
 
         Rc::new(Self { sidebar, tab })
     }
+
+    pub fn next_kind(&self) -> Option<MenuTabKind> {
+        match self.tab.get_cloned().kind() {
+            MenuTabKind::Text => Some(MenuTabKind::Image),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Clone)]

--- a/frontend/apps/crates/entry/module/resource-cover/edit/src/base/state.rs
+++ b/frontend/apps/crates/entry/module/resource-cover/edit/src/base/state.rs
@@ -30,6 +30,7 @@ pub struct Base {
     pub instructions: Mutable<Instructions>,
     pub jig_id: JigId,
     pub module_id: ModuleId,
+    pub continue_next_fn: ContinueNextFn,
     // ResourceCover-specific
     pub backgrounds: Rc<Backgrounds>,
     pub stickers: Rc<Stickers<Sticker>>,
@@ -125,6 +126,7 @@ impl Base {
             module_id,
             history,
             step: step.read_only(),
+            continue_next_fn: Mutable::new(None),
             theme_id,
             instructions,
             text_editor,
@@ -139,14 +141,19 @@ impl Base {
 }
 
 impl BaseExt<Step> for Base {
-    type NextStepAllowedSignal = impl Signal<Item = bool>;
-
     fn allowed_step_change(&self, _from: Step, _to: Step) -> bool {
         true
     }
 
-    fn next_step_allowed_signal(&self) -> Self::NextStepAllowedSignal {
-        signal::always(true)
+    fn can_continue_next(&self) -> ReadOnlyMutable<bool> {
+        Mutable::new(true).read_only()
+    }
+
+    fn continue_next(&self) -> bool {
+        // TODO Resource cover doesn't seem to be used(?), always returning false here means that
+        // when clicking Continue in a Resource Cover module, the sidebar will navigate to the next
+        // step.
+        false
     }
 
     fn get_jig_id(&self) -> JigId {

--- a/frontend/apps/crates/entry/module/tapping-board/edit/src/base/sidebar/step_2/dom.rs
+++ b/frontend/apps/crates/entry/module/tapping-board/edit/src/base/sidebar/step_2/dom.rs
@@ -12,6 +12,14 @@ pub fn render(state: Rc<Step2>) -> Dom {
     html!("menu-tabs", {
         .future(state.tab.signal_ref(|tab| tab.kind()).dedupe().for_each(clone!(state => move |kind| {
             state.sidebar.tab_kind.set(Some(kind));
+            state.sidebar.base.continue_next_fn.set(Some(Rc::new(clone!(state => move || {
+                if let Some(kind) = next_kind(&kind) {
+                        state.tab.set(Tab::new(state.sidebar.base.clone(), kind));
+                    true
+                } else {
+                    false
+                }
+            }))));
             async move {}
         })))
         .children(&mut [

--- a/frontend/apps/crates/entry/module/tapping-board/edit/src/base/sidebar/step_2/state.rs
+++ b/frontend/apps/crates/entry/module/tapping-board/edit/src/base/sidebar/step_2/state.rs
@@ -31,6 +31,13 @@ impl Step2 {
     }
 }
 
+pub fn next_kind(kind: &MenuTabKind) -> Option<MenuTabKind> {
+    match kind {
+        MenuTabKind::Text => Some(MenuTabKind::Image),
+        _ => None,
+    }
+}
+
 #[derive(Clone)]
 pub enum Tab {
     Text, // uses top-level state since it must be toggled from main too

--- a/frontend/apps/crates/entry/module/tapping-board/edit/src/base/sidebar/step_3/state.rs
+++ b/frontend/apps/crates/entry/module/tapping-board/edit/src/base/sidebar/step_3/state.rs
@@ -69,6 +69,13 @@ impl Step3 {
     }
 }
 
+pub fn next_kind(kind: &MenuTabKind) -> Option<MenuTabKind> {
+    match kind {
+        MenuTabKind::Audio => Some(MenuTabKind::Label),
+        _ => None,
+    }
+}
+
 #[derive(Clone)]
 pub enum Tab {
     Label(usize, Mutable<Option<String>>),

--- a/frontend/apps/crates/entry/module/tapping-board/edit/src/base/sidebar/step_4/dom.rs
+++ b/frontend/apps/crates/entry/module/tapping-board/edit/src/base/sidebar/step_4/dom.rs
@@ -11,6 +11,14 @@ pub fn render(state: Rc<Step4>) -> Dom {
     html!("menu-tabs", {
         .future(state.tab.signal_ref(|tab| tab.kind()).dedupe().for_each(clone!(state => move |kind| {
             state.sidebar.tab_kind.set(Some(kind));
+            state.sidebar.base.continue_next_fn.set(Some(Rc::new(clone!(state => move || {
+                if let Some(kind) = next_kind(&kind) {
+                        state.tab.set(Tab::new(state.sidebar.base.clone(), kind));
+                    true
+                } else {
+                    false
+                }
+            }))));
             async move {}
         })))
         .children(&mut [

--- a/frontend/apps/crates/entry/module/tapping-board/edit/src/base/sidebar/step_4/state.rs
+++ b/frontend/apps/crates/entry/module/tapping-board/edit/src/base/sidebar/step_4/state.rs
@@ -31,6 +31,13 @@ impl Step4 {
     }
 }
 
+pub fn next_kind(kind: &MenuTabKind) -> Option<MenuTabKind> {
+    match kind {
+        MenuTabKind::PlaySettings => Some(MenuTabKind::Instructions),
+        _ => None,
+    }
+}
+
 #[derive(Clone)]
 pub enum Tab {
     Settings(Rc<PlaySettingsState>),

--- a/frontend/apps/crates/entry/module/video/edit/src/base/sidebar/step_1/dom.rs
+++ b/frontend/apps/crates/entry/module/video/edit/src/base/sidebar/step_1/dom.rs
@@ -4,6 +4,9 @@ use dominator::Dom;
 use std::rc::Rc;
 
 pub fn render(state: Rc<Step1>) -> Dom {
+    state.sidebar.base.can_continue_next.set_neq(true);
+    state.sidebar.base.continue_next_fn.set(None);
+
     let theme_background =
         ThemeBackground::new(state.sidebar.base.clone(), state.sidebar.tab_kind.clone());
 

--- a/frontend/apps/crates/entry/module/video/edit/src/base/sidebar/step_2/dom.rs
+++ b/frontend/apps/crates/entry/module/video/edit/src/base/sidebar/step_2/dom.rs
@@ -5,45 +5,83 @@ use components::{
     text_editor::dom::render_controls as render_text_editor,
 };
 use dominator::{clone, html, Dom};
-use futures_signals::signal::SignalExt;
+use futures_signals::{map_ref, signal::SignalExt};
 use std::rc::Rc;
 
 pub fn render(state: Rc<Step2>) -> Dom {
-    html!("menu-tabs", {
-        .future(state.tab.signal_ref(|tab| tab.kind()).dedupe().for_each(clone!(state => move |kind| {
+    let is_empty = map_ref! {
+        let video = state.sidebar.base.video.signal_cloned()
+            => {
+            video.is_none()
+        }
+    };
+
+    let tab = map_ref! {
+        let tab = state.tab.signal_cloned(),
+        let video = state.sidebar.base.video.signal_cloned()
+            => {
+            (video.is_none(), tab.kind())
+        }
+    };
+
+    state
+        .sidebar
+        .base
+        .continue_next_fn
+        .set(Some(Rc::new(clone!(state => move || {
+            if let Some(kind) = state.next_kind() {
+                state.tab.set(Tab::new(state.sidebar.base.clone(), kind));
+                true
+            } else {
+                false
+            }
+        }))));
+
+    html!("empty-fragment", {
+        .future(tab.for_each(clone!(state => move |(is_empty, kind)| {
             state.sidebar.tab_kind.set(Some(kind));
+
+            state.sidebar.base.can_continue_next.set_neq(match kind {
+                MenuTabKind::Video => !is_empty,
+                _ => true,
+            });
+
             async move {}
         })))
-        .children(&mut [
-            render_tab(state.clone(), MenuTabKind::Video),
-            render_tab(state.clone(), MenuTabKind::Text),
-            render_tab(state.clone(), MenuTabKind::Image),
-            html!("module-sidebar-body", {
-                .property("slot", "body")
-                .child_signal(state.tab.signal_cloned().map(clone!(state => move |tab| {
-                    match tab {
-                        Tab::Video => {
-                            Some(video::render(Rc::clone(&state)))
-                        },
-                        Tab::Text => {
-                            Some(render_text_editor(state.sidebar.base.text_editor.clone()))
-                        },
-                        Tab::Image(state) => {
-                            Some(render_image_search(state, None))
-                        },
-                    }
-                })))
-            })
-        ])
+        .child_signal(is_empty.map(clone!(state => move |is_empty| {
+            Some(html!("menu-tabs", {
+                .children(&mut [
+                    render_tab(state.clone(), MenuTabKind::Video, true),
+                    render_tab(state.clone(), MenuTabKind::Text, !is_empty),
+                    render_tab(state.clone(), MenuTabKind::Image, !is_empty),
+                    html!("module-sidebar-body", {
+                        .property("slot", "body")
+                        .child_signal(state.tab.signal_cloned().map(clone!(state => move |tab| {
+                            match tab {
+                                Tab::Video => {
+                                    Some(video::render(Rc::clone(&state)))
+                                },
+                                Tab::Text => {
+                                    Some(render_text_editor(state.sidebar.base.text_editor.clone()))
+                                },
+                                Tab::Image(state) => {
+                                    Some(render_image_search(state, None))
+                                },
+                            }
+                        })))
+                    }),
+                ])
+            }))
+        })))
     })
 }
 
-fn render_tab(state: Rc<Step2>, tab_kind: MenuTabKind) -> Dom {
+fn render_tab(state: Rc<Step2>, tab_kind: MenuTabKind, enabled: bool) -> Dom {
     MenuTab::render(
         MenuTab::new(
             tab_kind,
             false,
-            true,
+            enabled,
             clone!(state => move || state.tab.signal_ref(clone!(tab_kind => move |curr| {
                 curr.kind() == tab_kind
             }))),

--- a/frontend/apps/crates/entry/module/video/edit/src/base/sidebar/step_2/state.rs
+++ b/frontend/apps/crates/entry/module/video/edit/src/base/sidebar/step_2/state.rs
@@ -28,6 +28,14 @@ impl Step2 {
 
         Rc::new(Self { sidebar, tab })
     }
+
+    pub fn next_kind(&self) -> Option<MenuTabKind> {
+        match self.tab.get_cloned().kind() {
+            MenuTabKind::Video => Some(MenuTabKind::Text),
+            MenuTabKind::Text => Some(MenuTabKind::Image),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Clone)]

--- a/frontend/apps/crates/entry/module/video/edit/src/base/sidebar/step_3/dom.rs
+++ b/frontend/apps/crates/entry/module/video/edit/src/base/sidebar/step_3/dom.rs
@@ -8,6 +8,20 @@ use futures_signals::signal::SignalExt;
 use std::rc::Rc;
 
 pub fn render(state: Rc<Step3>) -> Dom {
+    state.sidebar.base.can_continue_next.set_neq(true);
+    state
+        .sidebar
+        .base
+        .continue_next_fn
+        .set(Some(Rc::new(clone!(state => move || {
+            if let Some(kind) = state.next_kind() {
+                state.tab.set(Tab::new(state.sidebar.base.clone(), kind));
+                true
+            } else {
+                false
+            }
+        }))));
+
     html!("menu-tabs", {
         .future(state.tab.signal_ref(|tab| tab.kind()).dedupe().for_each(clone!(state => move |kind| {
             state.sidebar.tab_kind.set(Some(kind));

--- a/frontend/apps/crates/entry/module/video/edit/src/base/sidebar/step_3/state.rs
+++ b/frontend/apps/crates/entry/module/video/edit/src/base/sidebar/step_3/state.rs
@@ -30,6 +30,13 @@ impl Step3 {
 
         Rc::new(Self { sidebar, tab })
     }
+
+    pub fn next_kind(&self) -> Option<MenuTabKind> {
+        match self.tab.get_cloned().kind() {
+            MenuTabKind::PlaySettings => Some(MenuTabKind::Instructions),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
#2635 

- Updates all activities so that clicking continue will navigate the teacher to:
  - The next tab if the current step has tabs - including steps which have tabs conditionally shown (see Listen and Learn), if the tabs are rendered the teacher is navigated to the next tab.
  - The next tab if the teacher is on the last tab of the current step, or if the current step has no tabs - includes steps with conditional tabs, whereby if the tabs are not currently rendered, the teacher will be navigated to the next step.
- _Extra:_ Updates rules on video activity so that the teacher cannot continue past Step 2, Video tab if no video has been added.

### Card game activity

https://user-images.githubusercontent.com/4161106/162458044-f4d212b9-4be6-42b3-960e-acc9106a2d8b.mov

### Listen and learn activity

For _Step 3_, if no trace is selected, then clicking "Continue" will navigate to Step 4.

https://user-images.githubusercontent.com/4161106/162458232-7a874b43-f903-4475-8155-177840ac75ee.mov

### Talking Poster activity

https://user-images.githubusercontent.com/4161106/162681609-4640b679-0d72-4ff5-a656-c7a6ec300df0.mov

### Drag drop activity

https://user-images.githubusercontent.com/4161106/162689926-ea4598db-a987-4dc8-b23a-7ea2d1f82430.mov

### Video activity

https://user-images.githubusercontent.com/4161106/162696588-23df1f42-9ab5-49ae-bf47-493c268dd721.mov

### Cover activity

https://user-images.githubusercontent.com/4161106/162697470-dbb6f29c-52c5-4a98-88ea-00ff0f272117.mov


