### PR TITLE
feat(fe/module/drag-drop): Reset dragged item position when outside of target area

### DIFF
--- a/frontend/apps/crates/components/src/collision/stickers_traces/pixels.rs
+++ b/frontend/apps/crates/components/src/collision/stickers_traces/pixels.rs
@@ -73,7 +73,7 @@ pub enum StickerBoundsKind {
     Auto,
 }
 
-pub async fn get_hit_index<'a, V: AsRef<Trace>>(
+pub fn get_hit_index<'a, V: AsRef<Trace>>(
     source: StickerHitSource<'a>,
     traces: &[V],
 ) -> Option<usize> {

--- a/frontend/apps/crates/entry/module/drag-drop/edit/src/base/main/drag/actions.rs
+++ b/frontend/apps/crates/entry/module/drag-drop/edit/src/base/main/drag/actions.rs
@@ -1,5 +1,9 @@
 use super::state::*;
-use std::rc::Rc;
+use components::collision::stickers_traces::pixels::{
+    get_hit_index, StickerBoundsKind, StickerHitSource,
+};
+use shared::domain::jig::module::body::_groups::design::Trace;
+use std::{borrow::Cow, rc::Rc};
 use utils::{drag::*, prelude::*, resize::get_resize_info};
 
 impl DragItem {
@@ -36,18 +40,48 @@ impl DragItem {
         }
     }
 
-    pub fn try_end_drag(&self, _x: i32, _y: i32) {
-        if self.drag.lock_ref().is_some() {
-            let _drag = self.drag.lock_mut().take().unwrap_ji();
+    pub fn try_end_drag(&self, _x: i32, _y: i32, size: Option<(f64, f64)>) {
+        let target_transform = self
+            .item
+            .get_interactive_unchecked()
+            .target_transform
+            .get_cloned();
 
-            if let Some(transform) = self
-                .item
-                .get_interactive_unchecked()
-                .target_transform
-                .get_cloned()
-            {
-                self.base
-                    .set_drag_item_target_transform(self.index, transform);
+        if let Some(transform) = target_transform {
+            if self.drag.lock_ref().is_some() {
+                let _drag = self.drag.lock_mut().take().unwrap_ji();
+
+                if let Some(size) = size {
+                    let raw_sticker = self.item.sticker.to_raw();
+                    let hit_source = StickerHitSource {
+                        sticker: Cow::Borrowed(&raw_sticker),
+                        size,
+                        transform_override: Some(Cow::Borrowed(&transform)),
+                        bounds_kind: StickerBoundsKind::Auto,
+                    };
+
+                    let traces: Vec<&Trace> = self
+                        .base
+                        .target_areas
+                        .iter()
+                        .map(|area| &area.trace)
+                        .collect();
+
+                    if get_hit_index(hit_source, &traces).is_some() {
+                        // The hit_index doesn't matter - We don't actually save the target trace,
+                        // so we only care that the sticker has been placed inside a target.
+                        self.base
+                            .set_drag_item_target_transform(self.index, transform);
+                    } else {
+                        // Reset to starting position
+                        if let Some(sticker) = self.base.stickers.get(self.index) {
+                            self.base.set_drag_item_target_transform(
+                                self.index,
+                                sticker.transform().get_inner_clone(),
+                            );
+                        }
+                    }
+                }
             }
         }
     }

--- a/frontend/apps/crates/entry/module/drag-drop/edit/src/base/main/drag/dom.rs
+++ b/frontend/apps/crates/entry/module/drag-drop/edit/src/base/main/drag/dom.rs
@@ -3,6 +3,7 @@ use components::stickers::dom::{
     mixin_sticker_button, render_sticker_raw, BaseRawRenderOptions, StickerRawRenderOptions,
 };
 use dominator::{clone, html, Dom};
+use futures_signals::signal::Mutable;
 use std::rc::Rc;
 use utils::prelude::*;
 
@@ -11,6 +12,17 @@ impl MainDrag {
         let theme_id = state.base.theme_id.get();
 
         html!("empty-fragment", {
+            .child(html!("empty-fragment", {
+                .style("opacity", "50%")
+                .children( {
+                    state.items
+                        .iter()
+                        .map(|item| {
+                            render_sticker_raw(&item.raw_sticker(), theme_id, None)
+                        })
+                        .collect::<Vec<Dom>>()
+                })
+            }))
             .children( {
                 state.items
                     .iter()
@@ -21,21 +33,25 @@ impl MainDrag {
                         let opts = {
                             if item.get_is_interactive() {
                                 let mut opts = BaseRawRenderOptions::default();
+                                opts.set_size(Mutable::new(None));
+                                let size_signal = opts.size.clone().unwrap_or_else(|| Mutable::new(None));
 
                                 opts.set_transform_override(item.get_transform_override());
 
                                 opts.set_mixin(clone!(item => move |dom| {
                                     dom
                                         .apply(mixin_sticker_button)
-                                        .event(clone!(item => move |evt:events::MouseDown| {
+                                        .event(clone!(item => move |evt: events::PointerDown| {
                                             item.start_drag(evt.x() as i32, evt.y() as i32);
                                         }))
-                                        .global_event(clone!(item => move |evt:events::MouseUp| {
-                                            item.try_end_drag(evt.x() as i32, evt.y() as i32);
-
-                                        }))
-                                        .global_event(clone!(item => move |evt:events::MouseMove| {
+                                        .global_event(clone!(item => move |evt:events::PointerMove| {
                                             item.try_move_drag(evt.x() as i32, evt.y() as i32);
+                                        }))
+                                        .global_event(clone!(item, size_signal => move |evt: events::PointerUp| {
+                                            item.try_end_drag(evt.x() as i32, evt.y() as i32, size_signal.get());
+                                        }))
+                                        .global_event(clone!(item, size_signal => move |evt: events::PointerCancel| {
+                                            item.try_end_drag(evt.x() as i32, evt.y() as i32, size_signal.get());
                                         }))
                                 }));
 

--- a/frontend/apps/crates/entry/module/drag-drop/play/src/base/game/playing/actions.rs
+++ b/frontend/apps/crates/entry/module/drag-drop/play/src/base/game/playing/actions.rs
@@ -16,7 +16,7 @@ use components::module::_common::play::prelude::*;
 use shared::domain::jig::module::body::drag_drop::Next;
 
 impl PlayState {
-    pub async fn set_targets(&self) {
+    pub fn set_targets(&self) {
         let items = self.items.iter().filter_map(|item| match item {
             PlayItem::Interactive(item) => Some(item.clone()),
             _ => None,
@@ -35,7 +35,7 @@ impl PlayState {
                 .get_hit_source(Some(SourceTransformOverride::Target))
                 .unwrap_ji();
 
-            if let Some(index) = get_hit_index(hit_source, &traces).await {
+            if let Some(index) = get_hit_index(hit_source, &traces) {
                 *item.target_index.borrow_mut() = Some(index);
             }
         }
@@ -79,7 +79,7 @@ impl PlayState {
                         .map(|area| &area.trace)
                         .collect();
 
-                    if let Some(index) = get_hit_index(hit_source, &traces).await {
+                    if let Some(index) = get_hit_index(hit_source, &traces) {
                         if DEBUGGING_EVALUATION_RESULT
                             && (!DEBUGGING_EVALUATION_RESULT_ONLY_MATCH || index == target_index)
                         {

--- a/frontend/apps/crates/entry/module/drag-drop/play/src/base/game/playing/dom.rs
+++ b/frontend/apps/crates/entry/module/drag-drop/play/src/base/game/playing/dom.rs
@@ -25,7 +25,7 @@ pub fn render(state: Rc<PlayState>) -> Dom {
         .future(state.all_interactive_items_have_sizes().for_each(clone!(state, targets_ready => move |x| {
             clone!(state, targets_ready => async move {
                 if x {
-                    state.set_targets().await;
+                    state.set_targets();
                     targets_ready.set_neq(true);
                 }
             })


### PR DESCRIPTION
Part of #2636 

This is initial work to begin enabling multiple drop targets for a sticker. 

- When editing a drag-drop activity:
	- Adds logic to check whether a sticker has been placed within a target trace;
		- When not within a trace, resets the stickers position, otherwise saves the new position.
	- Creates a set of semi-transparent stickers that are visible whenever a sticker is being dragged or dropped on a target area;

Misc. updates

- Removes some unnecessary `async` declarations;
- Changes mouse events to pointer events so that dragging would work on touch devices.


https://user-images.githubusercontent.com/4161106/163121226-307e65a3-29a2-44fa-8da1-52b9940b9321.mov

