### PR TITLE
feat(be/image): add image metrics functionality

### DIFF
--- a/backend/api/migrations/20220419233654_image_user_usage.sql
+++ b/backend/api/migrations/20220419233654_image_user_usage.sql
@@ -1,0 +1,29 @@
+create table image_usage (
+    image_id                uuid                                  not null
+         references image_metadata(id)
+         on delete cascade,
+
+    -- timestamp which 
+    reset_at              timestamp         default now()       not null
+);
+
+alter table image_metadata 
+
+
+create trigger update_path_like
+    after insert
+    on learning_path_like
+    for each row
+execute procedure update_imageh_like();
+
+create function update_image_usage() returns trigger
+    language plpgsql
+as
+$$
+begin
+    update learning_path
+    set liked_count = liked_count - 1
+    where id = OLD.learning_path_id;
+    return NULL;
+end;
+$$;      

--- a/backend/api/sqlx-data.json
+++ b/backend/api/sqlx-data.json
@@ -3871,6 +3871,126 @@
       ]
     }
   },
+  "6ea02d92ab71f14fa01d569cf9f6f71dbbbcef9a486d438c159fd7641175af7a": {
+    "query": "\nselect id,\n       name,\n       kind                                                                                     as \"kind!: ImageKind\",\n       description,\n       translated_description                                                                   as \"translated_description!: Json<HashMap<String, String>>\",\n       array((select affiliation_id from image_affiliation where image_id = image_metadata.id)) as \"affiliations!\",\n       array((select affiliation.display_name\n              from affiliation\n                       inner join image_affiliation on affiliation.id = image_affiliation.affiliation_id\n              where image_affiliation.image_id = image_metadata.id))                            as \"affiliation_names!\",\n       array((select style_id from image_style where image_id = image_metadata.id))             as \"styles!\",\n       array((select style.display_name\n              from style\n                       inner join image_style on style.id = image_style.style_id\n              where image_style.image_id = image_metadata.id))                                  as \"style_names!\",\n       array((select age_range_id from image_age_range where image_id = image_metadata.id))     as \"age_ranges!\",\n       array((select age_range.display_name\n              from age_range\n                       inner join image_age_range on age_range.id = image_age_range.age_range_id\n              where image_age_range.image_id = image_metadata.id))                              as \"age_range_names!\",\n       array((select category_id from image_category where image_id = image_metadata.id))       as \"categories!\",\n       array((select name\n              from category\n                       inner join image_category on category.id = image_category.category_id\n              where image_category.image_id = image_metadata.id))                               as \"category_names!\",\n       array((select index\n              from image_tag\n                       inner join image_tag_join on image_tag.index = image_tag_join.tag_index\n              where image_tag_join.image_id = image_metadata.id))                               as \"tags!\",\n       array((select display_name\n              from image_tag\n                       inner join image_tag_join on image_tag.index = image_tag_join.tag_index\n              where image_tag_join.image_id = image_metadata.id))                               as \"tag_names!\",\n       (publish_at < now() is true)                                                             as \"is_published!\",\n       is_premium,\n       user_usage                                                                               as \"user_usage!\"\nfrom image_metadata\n         join image_upload on id = image_id\nwhere (last_synced_at is null or\n       (updated_at is not null and last_synced_at < updated_at) or\n       (publish_at < now() is true and last_synced_at < publish_at))\n  and processed_at is not null\nlimit 100 for no key update skip locked;\n     ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 1,
+          "name": "name",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 2,
+          "name": "kind!: ImageKind",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 3,
+          "name": "description",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 4,
+          "name": "translated_description!: Json<HashMap<String, String>>",
+          "type_info": "Jsonb"
+        },
+        {
+          "ordinal": 5,
+          "name": "affiliations!",
+          "type_info": "UuidArray"
+        },
+        {
+          "ordinal": 6,
+          "name": "affiliation_names!",
+          "type_info": "TextArray"
+        },
+        {
+          "ordinal": 7,
+          "name": "styles!",
+          "type_info": "UuidArray"
+        },
+        {
+          "ordinal": 8,
+          "name": "style_names!",
+          "type_info": "TextArray"
+        },
+        {
+          "ordinal": 9,
+          "name": "age_ranges!",
+          "type_info": "UuidArray"
+        },
+        {
+          "ordinal": 10,
+          "name": "age_range_names!",
+          "type_info": "TextArray"
+        },
+        {
+          "ordinal": 11,
+          "name": "categories!",
+          "type_info": "UuidArray"
+        },
+        {
+          "ordinal": 12,
+          "name": "category_names!",
+          "type_info": "TextArray"
+        },
+        {
+          "ordinal": 13,
+          "name": "tags!",
+          "type_info": "Int2Array"
+        },
+        {
+          "ordinal": 14,
+          "name": "tag_names!",
+          "type_info": "TextArray"
+        },
+        {
+          "ordinal": 15,
+          "name": "is_published!",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 16,
+          "name": "is_premium",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 17,
+          "name": "user_usage!",
+          "type_info": "Int8"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        false,
+        true
+      ]
+    }
+  },
   "6f88dced30ef38b92e48c5b78cda75cfc877dff08195c25609ad0f19ddff49cc": {
     "query": "\ninsert into image_metadata (name, description, is_premium, publish_at, kind) values ($1, $2, $3, $4, $5)\nreturning id as \"id: ImageId\"\n        ",
     "describe": {
@@ -4828,120 +4948,6 @@
       ]
     }
   },
-  "8e275e9f53e8192c7299a6bed97b2313030df3f9caa7f7824b48da4a86d0fed2": {
-    "query": "\nselect id,\n       name,\n       kind                                                                                     as \"kind!: ImageKind\",\n       description,\n       translated_description                                                                   as \"translated_description!: Json<HashMap<String, String>>\",\n       array((select affiliation_id from image_affiliation where image_id = image_metadata.id)) as \"affiliations!\",\n       array((select affiliation.display_name\n              from affiliation\n                       inner join image_affiliation on affiliation.id = image_affiliation.affiliation_id\n              where image_affiliation.image_id = image_metadata.id))                            as \"affiliation_names!\",\n       array((select style_id from image_style where image_id = image_metadata.id))             as \"styles!\",\n       array((select style.display_name\n              from style\n                       inner join image_style on style.id = image_style.style_id\n              where image_style.image_id = image_metadata.id))                                  as \"style_names!\",\n       array((select age_range_id from image_age_range where image_id = image_metadata.id))     as \"age_ranges!\",\n       array((select age_range.display_name\n              from age_range\n                       inner join image_age_range on age_range.id = image_age_range.age_range_id\n              where image_age_range.image_id = image_metadata.id))                              as \"age_range_names!\",\n       array((select category_id from image_category where image_id = image_metadata.id))       as \"categories!\",\n       array((select name\n              from category\n                       inner join image_category on category.id = image_category.category_id\n              where image_category.image_id = image_metadata.id))                               as \"category_names!\",\n       array((select index\n              from image_tag\n                       inner join image_tag_join on image_tag.index = image_tag_join.tag_index\n              where image_tag_join.image_id = image_metadata.id))                               as \"tags!\",\n       array((select display_name\n              from image_tag\n                       inner join image_tag_join on image_tag.index = image_tag_join.tag_index\n              where image_tag_join.image_id = image_metadata.id))                               as \"tag_names!\",\n       (publish_at < now() is true)                                                             as \"is_published!\",\n       is_premium\nfrom image_metadata\n         join image_upload on id = image_id\nwhere (last_synced_at is null or\n       (updated_at is not null and last_synced_at < updated_at) or\n       (publish_at < now() is true and last_synced_at < publish_at))\n  and processed_at is not null\nlimit 100 for no key update skip locked;\n     ",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 1,
-          "name": "name",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 2,
-          "name": "kind!: ImageKind",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 3,
-          "name": "description",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 4,
-          "name": "translated_description!: Json<HashMap<String, String>>",
-          "type_info": "Jsonb"
-        },
-        {
-          "ordinal": 5,
-          "name": "affiliations!",
-          "type_info": "UuidArray"
-        },
-        {
-          "ordinal": 6,
-          "name": "affiliation_names!",
-          "type_info": "TextArray"
-        },
-        {
-          "ordinal": 7,
-          "name": "styles!",
-          "type_info": "UuidArray"
-        },
-        {
-          "ordinal": 8,
-          "name": "style_names!",
-          "type_info": "TextArray"
-        },
-        {
-          "ordinal": 9,
-          "name": "age_ranges!",
-          "type_info": "UuidArray"
-        },
-        {
-          "ordinal": 10,
-          "name": "age_range_names!",
-          "type_info": "TextArray"
-        },
-        {
-          "ordinal": 11,
-          "name": "categories!",
-          "type_info": "UuidArray"
-        },
-        {
-          "ordinal": 12,
-          "name": "category_names!",
-          "type_info": "TextArray"
-        },
-        {
-          "ordinal": 13,
-          "name": "tags!",
-          "type_info": "Int2Array"
-        },
-        {
-          "ordinal": 14,
-          "name": "tag_names!",
-          "type_info": "TextArray"
-        },
-        {
-          "ordinal": 15,
-          "name": "is_published!",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 16,
-          "name": "is_premium",
-          "type_info": "Bool"
-        }
-      ],
-      "parameters": {
-        "Left": []
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        false
-      ]
-    }
-  },
   "8e91b63b58e15b8c898573ffd729ea87968e8d2efa24ee4d855ac357c193087b": {
     "query": "insert into web_media_library_url (media_id, media_url) values ($1, $2) on conflict (media_id, media_url) do nothing",
     "describe": {
@@ -5596,6 +5602,16 @@
       ]
     }
   },
+  "ab3f65700794b2255239083c9b4a2f553f0cd5764404fd40325b6bdff3724243": {
+    "query": "\n        update image_usage \n        set usage_reset_at = now()\n        where usage_reset_at < now() - interval '14 days'\n            ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": []
+    }
+  },
   "ab605fef6d23ea4a74e80999574296f7b4fce2ed0029455be3d6541ee379d329": {
     "query": "\ninsert into jig_data\n(display_name, created_at, updated_at, language, last_synced_at, description, theme, audio_background,\n audio_feedback_negative, audio_feedback_positive, direction, display_score, drag_assist, track_assessments, privacy_level, other_keywords, translated_keywords, translated_description)\nselect display_name,\n       created_at,\n       updated_at,\n       language,\n       last_synced_at,\n       description,\n       theme,\n       audio_background,\n       audio_feedback_negative,\n       audio_feedback_positive,\n       direction,\n       display_score,\n       drag_assist,\n       track_assessments,\n       privacy_level,\n       other_keywords,\n       translated_keywords,\n       translated_description::jsonb\nfrom jig_data\nwhere id = $1\nreturning id\n        ",
     "describe": {
@@ -6101,6 +6117,18 @@
       "nullable": [
         false
       ]
+    }
+  },
+  "c8af80ae8c251038a446a026c9fed161019cbd34726bd868c1915105deaa8b0f": {
+    "query": "\nupdate image_metadata \nset user_usage = user_usage + 1\nwhere id = $1\n",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      },
+      "nullable": []
     }
   },
   "c8b56c12795686a4ecf068a13f44acab1b3382515c4b21024d95cb867e76fed1": {

--- a/backend/api/src/db/image.rs
+++ b/backend/api/src/db/image.rs
@@ -259,6 +259,21 @@ order by id
     .fetch(db)
 }
 
+pub async fn add_usage(db: &PgPool, id: ImageId) -> sqlx::Result<()> {
+    sqlx::query!(
+        r#"
+update image_metadata 
+set user_usage = user_usage + 1
+where id = $1
+"#,
+        id.0,
+    )
+    .execute(db)
+    .await?;
+
+    Ok(())
+}
+
 pub async fn delete(db: &PgPool, image: ImageId) -> sqlx::Result<()> {
     let mut conn = db.begin().await?;
 

--- a/backend/api/src/image_search.rs
+++ b/backend/api/src/image_search.rs
@@ -9,15 +9,11 @@ const QUERY_TYPE: &str = "imageType";
 struct Image {
     thumbnail_url: url::Url,
     content_url: url::Url,
-    name: String,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ImagesResponse {
-    read_link: String,
-    current_offset: i64,
-    next_offset: i64,
     value: Vec<Image>,
 }
 

--- a/backend/api/src/jwk.rs
+++ b/backend/api/src/jwk.rs
@@ -146,13 +146,6 @@ pub struct IdentityClaims {
     pub expire_at: u64,
 }
 
-#[derive(Debug, Deserialize)]
-struct FirebaseClaims {
-    pub sub: String,
-    pub iat: u64,
-    pub auth_time: u64,
-}
-
 #[derive(Debug)]
 pub struct JwkVerifier {
     // use a vec instead of a hashmap because there are typically

--- a/shared/rust/src/api/endpoints/image.rs
+++ b/shared/rust/src/api/endpoints/image.rs
@@ -143,3 +143,13 @@ impl ApiEndpoint for Delete {
     const PATH: &'static str = "/v1/image/{id}";
     const METHOD: Method = Method::Delete;
 }
+
+/// Update usage of an Image for metric purposes
+pub struct PutImageUsage;
+impl ApiEndpoint for PutImageUsage {
+    type Req = ();
+    type Res = ();
+    type Err = EmptyError;
+    const PATH: &'static str = "/v1/image/{id}/usage";
+    const METHOD: Method = Method::Put;
+}


### PR DESCRIPTION
https://github.com/ji-devs/ji-cloud/issues/1895

## Endpoints 
- `PUT v1/image/{image_id}/usage` 
> - increments the `user_usage` value in `image_metadata` table

## Migrations
- `image_user_usage` 
> - Added `image_usage` table - stores the new timestamp when 2 weeks has passed for each `image_id`
> - Added field `user_usage` to `image_metadata` table - keeps track of the amount of uses for each image
> - Added trigger and function that resets the usage amount to 0 after two weeks has passed.
> - Added trigger and function that adds a new `image_id` to `image_usage` table from `image_metadata`
