### PR TITLE
fix(fe/module/drag-drop): Ensure drop targets are kept up to date on the client

### DIFF
--- a/frontend/apps/crates/entry/module/drag-drop/edit/src/base/main/drag/actions.rs
+++ b/frontend/apps/crates/entry/module/drag-drop/edit/src/base/main/drag/actions.rs
@@ -60,12 +60,8 @@ impl DragItem {
                         bounds_kind: StickerBoundsKind::Auto,
                     };
 
-                    let traces: Vec<&Trace> = self
-                        .base
-                        .target_areas
-                        .iter()
-                        .map(|area| &area.trace)
-                        .collect();
+                    let target_areas = self.base.target_areas.lock_ref();
+                    let traces: Vec<&Trace> = target_areas.iter().map(|area| &area.trace).collect();
 
                     if get_hit_index(hit_source, &traces).is_some() {
                         // The hit_index doesn't matter - We don't actually save the target trace,

--- a/frontend/apps/crates/entry/module/drag-drop/edit/src/base/state.rs
+++ b/frontend/apps/crates/entry/module/drag-drop/edit/src/base/state.rs
@@ -18,7 +18,7 @@ use dominator::clone;
 use futures_signals::{
     map_ref,
     signal::{Mutable, ReadOnlyMutable, Signal, SignalExt},
-    signal_vec::SignalVecExt,
+    signal_vec::{MutableVec, SignalVecExt},
 };
 use shared::domain::jig::{
     module::{
@@ -53,7 +53,7 @@ pub struct Base {
     pub traces: Rc<TracesEdit>,
     /// List of areas which a sticker can be dropped into so that we can confirm whether a sticker
     /// has actually been dropped into a trace area.
-    pub target_areas: Rc<Vec<TargetArea>>,
+    pub target_areas: Rc<MutableVec<TargetArea>>,
     pub text_editor: Rc<TextEditorState>,
     pub play_settings: Rc<PlaySettings>,
 
@@ -296,7 +296,9 @@ impl Base {
             backgrounds,
             stickers,
             traces,
-            target_areas: Rc::new(trace_data.iter().map(|(area, _)| area.clone()).collect()),
+            target_areas: Rc::new(MutableVec::new_with_values(
+                trace_data.iter().map(|(area, _)| area.clone()).collect(),
+            )),
             play_settings: Rc::new(PlaySettings::new(content.play_settings)),
             drag_item_selected_index: Mutable::new(None),
         });


### PR DESCRIPTION
Resolves #2686 

- Target area data in the Place tab were not being kept up to date with traces added in the Trace tab - This PR updates the logic so that they are synchronized correctly.