### PR TITLE
feat(shared/drag-drop): Add new item_targets field to drag-drop Content

### DIFF
--- a/shared/rust/src/domain/jig/module/body/drag_drop.rs
+++ b/shared/rust/src/domain/jig/module/body/drag_drop.rs
@@ -118,6 +118,13 @@ pub struct Content {
     /// Items (wrapper around Sticker and metadata)
     pub items: Vec<Item>,
 
+    /// List of targets for items
+    ///
+    /// Each item can possibly have multiple targets
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub item_targets: Vec<Item>,
+
     /// The editor state
     pub editor_state: EditorState,
 


### PR DESCRIPTION
Part of #2636 

- Updates the shared data for dragdrop so that I can work on persisting target data without running a backend locally.