### PR TITLE
feat(shared/drag-drop): Change data type for dragdrop target list to include target trace index

### DIFF
--- a/shared/rust/src/domain/jig/module/body/drag_drop.rs
+++ b/shared/rust/src/domain/jig/module/body/drag_drop.rs
@@ -166,8 +166,10 @@ pub struct Item {
 pub struct TargetTransform {
     /// Index of the sticker in the list of stickers
     pub sticker_idx: usize,
-    /// Target transform for this sticker
+    /// Target transform for this sticker for rendering during edit
     pub transform: Transform,
+    /// Index of the trace in which this item can be placed
+    pub trace_idx: usize,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]


### PR DESCRIPTION
Part of #2636 

- Improves data structure for easier trace placement detection when playing games
  - Also helps for working out whether an item has already been placed in a specific trace when editing