### PR TITLE
feat(module/drag-drop): Enable multiple targets for dragdrop activities

### DIFF
--- a/frontend/apps/crates/entry/module/drag-drop/edit/src/base/actions.rs
+++ b/frontend/apps/crates/entry/module/drag-drop/edit/src/base/actions.rs
@@ -4,11 +4,11 @@ use super::{
 };
 use components::module::_common::edit::prelude::*;
 use shared::domain::jig::module::body::{
-    Audio, Transform,
+    Audio,
     _groups::design::Trace as RawTrace,
     drag_drop::{
         Interactive as RawInteractive, ItemKind as RawItemKind, Mode, ModuleData as RawData, Step,
-        TargetArea,
+        TargetArea, TargetTransform,
     },
 };
 use std::rc::Rc;
@@ -68,7 +68,7 @@ impl Base {
     }
 
     pub fn on_trace_changed(&self, index: usize, raw_trace: RawTrace) {
-        let target_areas = self.target_areas.lock_mut().set_cloned(
+        self.target_areas.lock_mut().set_cloned(
             index,
             TargetArea {
                 trace: raw_trace.clone(),
@@ -139,23 +139,10 @@ impl Base {
         });
     }
 
-    pub fn set_drag_item_target_transform(&self, index: usize, transform: Transform) {
-        let list = &*self.stickers.list.lock_ref();
-        let item = &list[index];
-        let data = item.get_interactive_unchecked();
-
-        data.target_transform.set(Some(transform.clone()));
-
+    pub fn update_targets(&self, items: Vec<TargetTransform>) {
         self.history.push_modify(move |raw| {
             if let Some(content) = &mut raw.content {
-                match &mut content.items[index].kind {
-                    RawItemKind::Interactive(data) => {
-                        data.target_transform = Some(transform);
-                    }
-                    RawItemKind::Static => {
-                        panic!("saving offset on static item!?");
-                    }
-                }
+                content.item_targets = items;
             }
         });
     }

--- a/frontend/apps/crates/entry/module/drag-drop/edit/src/base/main/drag/actions.rs
+++ b/frontend/apps/crates/entry/module/drag-drop/edit/src/base/main/drag/actions.rs
@@ -1,8 +1,11 @@
+use crate::base::state::{Interactive, Item, ItemKind, StickerTarget};
+
 use super::state::*;
 use components::collision::stickers_traces::pixels::{
     get_hit_index, StickerBoundsKind, StickerHitSource,
 };
-use shared::domain::jig::module::body::_groups::design::Trace;
+use futures_signals::signal::Mutable;
+use shared::domain::jig::module::body::{_groups::design::Trace, drag_drop::TargetTransform};
 use std::{borrow::Cow, rc::Rc};
 use utils::{drag::*, prelude::*, resize::get_resize_info};
 
@@ -40,12 +43,9 @@ impl DragItem {
         }
     }
 
-    pub fn try_end_drag(&self, _x: i32, _y: i32, size: Option<(f64, f64)>) {
-        let target_transform = self
-            .item
-            .get_interactive_unchecked()
-            .target_transform
-            .get_cloned();
+    pub fn try_end_drag(&self, state: Rc<MainDrag>, idx: usize, size: Option<(f64, f64)>) {
+        let interactive_item = self.item.get_interactive_unchecked();
+        let target_transform = interactive_item.target_transform.get_cloned();
 
         if let Some(transform) = target_transform {
             if self.drag.lock_ref().is_some() {
@@ -63,18 +63,142 @@ impl DragItem {
                     let target_areas = self.base.target_areas.lock_ref();
                     let traces: Vec<&Trace> = target_areas.iter().map(|area| &area.trace).collect();
 
-                    if get_hit_index(hit_source, &traces).is_some() {
-                        // The hit_index doesn't matter - We don't actually save the target trace,
-                        // so we only care that the sticker has been placed inside a target.
-                        self.base
-                            .set_drag_item_target_transform(self.index, transform);
+                    if let Some(hit_idx) = get_hit_index(hit_source, &traces) {
+                        // Only allow the teacher to place a sticker in a target trace if the
+                        // sticker isn't already present in that trace.
+                        let sticker_exists = state
+                            .placed_items
+                            .lock_ref()
+                            .iter()
+                            .enumerate()
+                            .find(|(item_index, item)| {
+                                let same_trace = item.trace_idx.get() == Some(hit_idx);
+                                let same_sticker = item.index == self.index;
+                                // Only compare the indexes of the items if the item being dragged
+                                // is from the placed_items list.
+                                let same_drag_item = self.is_placed_item && *item_index == idx;
+
+                                if same_trace && same_drag_item {
+                                    // If the sticker is being moved around inside the same trace
+                                    // area, then we don't want to mark it as existing otherwise it
+                                    // will be removed from the trace area when the teacher cancels
+                                    // the drag.
+                                    false
+                                } else {
+                                    // Otherwise, if the sticker is being moved around in
+                                    // a different drag area, but the same sticker already exists
+                                    // in it, return true
+                                    same_trace && same_sticker
+                                }
+                            })
+                            .is_some();
+
+                        match (self.is_placed_item, sticker_exists) {
+                            (false, false) => {
+                                // A item is dragged from the initial list and placed inside
+                                // a trace area
+
+                                // We need to create a new Item so that it's signals are not cloned
+                                // and the transforms in one don't affect the transforms in the
+                                // other.
+                                let create_item = || Item {
+                                    sticker: self.item.sticker.clone(),
+                                    kind: Mutable::new(ItemKind::Interactive(Interactive {
+                                        audio: interactive_item.audio.clone(),
+                                        target_transform: Mutable::new(Some(transform.clone())),
+                                    })),
+                                };
+
+                                // Create a new DragItem with the current transform. This will get added to
+                                // the list of targets.
+                                let drag_item = DragItem {
+                                    item: create_item(),
+                                    index: self.index,
+                                    drag: Mutable::new(None),
+                                    base: self.base.clone(),
+                                    is_placed_item: true,
+                                    trace_idx: Mutable::new(Some(hit_idx)),
+                                };
+
+                                state.placed_items.lock_mut().push_cloned(drag_item);
+                                state
+                                    .base
+                                    .sticker_targets
+                                    .lock_mut()
+                                    .push_cloned(StickerTarget {
+                                        sticker_idx: self.index,
+                                        trace_idx: hit_idx,
+                                        item: create_item(),
+                                    })
+                            }
+                            (true, false) => {
+                                // An item is dragged from one trace area to another. Update the
+                                // trace index.
+                                //
+                                // This will also fire whenever a sticker is moved around inside
+                                // it's current trace area, but will not change anything thanks to
+                                // set_neq.
+                                self.trace_idx.set_neq(Some(hit_idx));
+                            }
+                            (true, true) => {
+                                // Moving an item from a trace into another trace where that item
+                                // exists. The item should be removed.
+                                //
+                                // We could reset it's position, but currently we use the
+                                // `target_transform` field everywhere for dragging and it would
+                                // require a much larger rewrite to implement.
+                                state.placed_items.lock_mut().remove(idx);
+                                state.base.sticker_targets.lock_mut().remove(idx);
+                            }
+                            _ => {
+                                // Do nothing
+                            }
+                        }
+
+                        // This item can be placed if it is not a placed item and does not exist in
+                        // the hit trace.
+                        if !self.is_placed_item && !sticker_exists {}
                     } else {
-                        // Reset to starting position
+                        if self.is_placed_item {
+                            state.placed_items.lock_mut().remove(idx);
+                            state.base.sticker_targets.lock_mut().remove(idx);
+                        }
+                    }
+
+                    // Save the target list. This will also update the transforms if a sticker has
+                    // been moved inside a target
+                    self.base.update_targets(
+                        state
+                            .placed_items
+                            .lock_ref()
+                            .iter()
+                            .filter(|item| {
+                                item.item
+                                    .get_interactive_unchecked()
+                                    .target_transform
+                                    .get_cloned()
+                                    .is_some()
+                                    && item.trace_idx.get().is_some()
+                            })
+                            .map(|item| TargetTransform {
+                                sticker_idx: item.index,
+                                transform: item
+                                    .item
+                                    .get_interactive_unchecked()
+                                    .target_transform
+                                    .get_cloned()
+                                    .unwrap_ji(),
+                                trace_idx: item.trace_idx.get().unwrap_ji(),
+                            })
+                            .collect(),
+                    );
+
+                    if !self.is_placed_item {
+                        // Reset the draggable item back to its initial position.
                         if let Some(sticker) = self.base.stickers.get(self.index) {
-                            self.base.set_drag_item_target_transform(
-                                self.index,
-                                sticker.transform().get_inner_clone(),
-                            );
+                            interactive_item
+                                .target_transform
+                                .set(Some(sticker.transform().get_inner_clone()));
                         }
                     }
                 }

--- a/frontend/apps/crates/entry/module/drag-drop/edit/src/base/main/drag/dom.rs
+++ b/frontend/apps/crates/entry/module/drag-drop/edit/src/base/main/drag/dom.rs
@@ -3,7 +3,7 @@ use components::stickers::dom::{
     mixin_sticker_button, render_sticker_raw, BaseRawRenderOptions, StickerRawRenderOptions,
 };
 use dominator::{clone, html, Dom};
-use futures_signals::signal::Mutable;
+use futures_signals::{signal::Mutable, signal_vec::SignalVecExt};
 use std::rc::Rc;
 use utils::prelude::*;
 
@@ -26,7 +26,8 @@ impl MainDrag {
             .children( {
                 state.items
                     .iter()
-                    .map(|item| {
+                    .enumerate()
+                    .map(|(idx, item)| {
 
                         let raw_sticker = &item.raw_sticker();
 
@@ -38,7 +39,7 @@ impl MainDrag {
 
                                 opts.set_transform_override(item.get_transform_override());
 
-                                opts.set_mixin(clone!(item => move |dom| {
+                                opts.set_mixin(clone!(state, item => move |dom| {
                                     dom
                                         .apply(mixin_sticker_button)
                                         .event(clone!(item => move |evt: events::PointerDown| {
@@ -47,11 +48,11 @@ impl MainDrag {
                                         .global_event(clone!(item => move |evt:events::PointerMove| {
                                             item.try_move_drag(evt.x() as i32, evt.y() as i32);
                                         }))
-                                        .global_event(clone!(item, size_signal => move |evt: events::PointerUp| {
-                                            item.try_end_drag(evt.x() as i32, evt.y() as i32, size_signal.get());
+                                        .global_event(clone!(state, item, size_signal => move |_evt: events::PointerUp| {
+                                            item.try_end_drag(state.clone(), idx, size_signal.get());
                                         }))
-                                        .global_event(clone!(item, size_signal => move |evt: events::PointerCancel| {
-                                            item.try_end_drag(evt.x() as i32, evt.y() as i32, size_signal.get());
+                                        .global_event(clone!(state, item, size_signal => move |_evt: events::PointerCancel| {
+                                            item.try_end_drag(state.clone(), idx, size_signal.get());
                                         }))
                                 }));
 
@@ -66,6 +67,46 @@ impl MainDrag {
                     })
                     .collect::<Vec<Dom>>()
             })
+            .children_signal_vec(state.placed_items.signal_vec_cloned()
+                .enumerate()
+                .map(move |(idx, item)| {
+                    let raw_sticker = &item.raw_sticker();
+
+                    let opts = {
+                        if item.get_is_interactive() {
+                            let mut opts = BaseRawRenderOptions::default();
+                            opts.set_size(Mutable::new(None));
+                            let size_signal = opts.size.clone().unwrap_or_else(|| Mutable::new(None));
+
+                            opts.set_transform_override(item.get_transform_override());
+
+                            opts.set_mixin(clone!(state, item => move |dom| {
+                                dom
+                                    .apply(mixin_sticker_button)
+                                    .event(clone!(item => move |evt: events::PointerDown| {
+                                        item.start_drag(evt.x() as i32, evt.y() as i32);
+                                    }))
+                                    .global_event(clone!(item => move |evt:events::PointerMove| {
+                                        item.try_move_drag(evt.x() as i32, evt.y() as i32);
+                                    }))
+                                    .global_event(clone!(state, idx, item, size_signal => move |_evt: events::PointerUp| {
+                                        item.try_end_drag(state.clone(), idx.get().unwrap_ji(), size_signal.get());
+                                    }))
+                                    .global_event(clone!(state, idx, item, size_signal => move |_evt: events::PointerCancel| {
+                                        item.try_end_drag(state.clone(), idx.get().unwrap_ji(), size_signal.get());
+                                    }))
+                            }));
+
+                            let opts = StickerRawRenderOptions::new(raw_sticker, Some(opts));
+                            Some(opts)
+                        } else {
+                            None
+                        }
+                    };
+
+                    render_sticker_raw(raw_sticker, theme_id, opts)
+                })
+            )
         })
     }
 }

--- a/frontend/apps/crates/entry/module/drag-drop/edit/src/base/main/drag/state.rs
+++ b/frontend/apps/crates/entry/module/drag-drop/edit/src/base/main/drag/state.rs
@@ -5,11 +5,12 @@ use std::rc::Rc;
 use utils::drag::Drag;
 
 use components::stickers::dom::TransformOverride;
-use futures_signals::signal::Mutable;
+use futures_signals::{signal::Mutable, signal_vec::MutableVec};
 
 pub struct MainDrag {
     pub base: Rc<Base>,
     pub items: Vec<DragItem>,
+    pub placed_items: MutableVec<DragItem>,
 }
 
 impl MainDrag {
@@ -21,23 +22,59 @@ impl MainDrag {
             .iter()
             .enumerate()
             .map(|(index, item)| DragItem {
-                item: item.clone(),
+                item: Item {
+                    // Recreate the full Item because we don't want any data in the
+                    // transform_target to initially affect the layout of the draggable items.
+                    sticker: item.sticker.clone(),
+                    kind: Mutable::new(match item.kind.get_cloned() {
+                        ItemKind::Static => ItemKind::Static,
+                        ItemKind::Interactive(data) => ItemKind::Interactive(Interactive {
+                            audio: data.audio.clone(),
+                            target_transform: Mutable::new(None),
+                        }),
+                    }),
+                },
                 index,
                 drag: Mutable::new(None),
                 base: base.clone(),
+                is_placed_item: false,
+                trace_idx: Mutable::new(None),
             })
             .collect();
 
-        Rc::new(Self { base, items })
+        let placed_items = base
+            .sticker_targets
+            .lock_ref()
+            .iter()
+            .map(|sticker_target| DragItem {
+                item: sticker_target.item.clone(),
+                index: sticker_target.sticker_idx,
+                drag: Mutable::new(None),
+                base: base.clone(),
+                is_placed_item: true,
+                trace_idx: Mutable::new(Some(sticker_target.trace_idx)),
+            })
+            .collect();
+
+        Rc::new(Self {
+            base,
+            items,
+            placed_items: MutableVec::new_with_values(placed_items),
+        })
     }
 }
 
 #[derive(Clone)]
 pub struct DragItem {
     pub item: Item,
+    /// Index of this item in the list of stickers
     pub index: usize,
     pub drag: Mutable<Option<Rc<Drag>>>,
     pub base: Rc<Base>,
+    /// Whether this is an item which has been placed in a trace
+    pub is_placed_item: bool,
+    /// Index of the trace where this item has been placed
+    pub trace_idx: Mutable<Option<usize>>,
 }
 
 impl DragItem {

--- a/frontend/apps/crates/entry/module/drag-drop/play/src/base/game/playing/dom.rs
+++ b/frontend/apps/crates/entry/module/drag-drop/play/src/base/game/playing/dom.rs
@@ -44,7 +44,8 @@ pub fn render(state: Rc<PlayState>) -> Dom {
         .children( {
             state.items
                 .iter()
-                .map(|item| {
+                .enumerate()
+                .map(|(index, item)| {
                     match item {
                         PlayItem::Static(sticker) => {
                             render_sticker_raw(sticker, theme_id, None)
@@ -74,12 +75,12 @@ pub fn render(state: Rc<PlayState>) -> Dom {
                                         }))
                                         .global_event(clone!(state, item => move |evt:events::PointerUp| {
                                             if item.try_end_drag(evt.x() as i32, evt.y() as i32) {
-                                                PlayState::evaluate(state.clone(), item.clone());
+                                                PlayState::evaluate(state.clone(), index, item.clone());
                                             }
                                         }))
                                         .global_event(clone!(state, item => move |evt:events::PointerCancel| {
                                             if item.try_end_drag(evt.x() as i32, evt.y() as i32) {
-                                                PlayState::evaluate(state.clone(), item.clone());
+                                                PlayState::evaluate(state.clone(), index, item.clone());
                                             }
                                         }))
                                     })

--- a/frontend/apps/crates/entry/module/drag-drop/play/src/base/state.rs
+++ b/frontend/apps/crates/entry/module/drag-drop/play/src/base/state.rs
@@ -4,7 +4,9 @@ use shared::domain::jig::{
         body::{
             Instructions,
             _groups::design::Backgrounds,
-            drag_drop::{Item, Mode, ModuleData as RawData, PlaySettings, Step, TargetArea},
+            drag_drop::{
+                Item, Mode, ModuleData as RawData, PlaySettings, Step, TargetArea, TargetTransform,
+            },
         },
         ModuleId,
     },
@@ -25,6 +27,7 @@ pub struct Base {
     pub settings: PlaySettings,
     pub backgrounds: Backgrounds,
     pub items: Vec<Item>,
+    pub item_targets: Vec<TargetTransform>,
     pub target_areas: Vec<TargetArea>,
     pub module_phase: Mutable<ModulePlayPhase>,
 }
@@ -52,6 +55,7 @@ impl Base {
             settings: content.play_settings,
             backgrounds: content.backgrounds,
             items: content.items,
+            item_targets: content.item_targets,
             target_areas: content.target_areas,
             module_phase: init_args.play_phase,
         })


### PR DESCRIPTION
Closes #2636 

- Implements multiple drag targets for editing and playing


https://user-images.githubusercontent.com/4161106/165936801-50c081b1-c5f7-4ae6-908b-ba43b809ff5d.mov



