### PR TITLE
feat(fe/jig/search): Update JIG card back-side colours

### DIFF
--- a/frontend/apps/crates/entry/home/src/home/search_results/search_results_section/dom.rs
+++ b/frontend/apps/crates/entry/home/src/home/search_results/search_results_section/dom.rs
@@ -90,11 +90,13 @@ impl SearchResultsSection {
                 Some("image")
             ))
             .apply_if(!jig.jig_data.categories.is_empty(), clone!(state => move |dom| {
+                log::info!("matches {}", matches!(state.focus, JigFocus::Modules));
                 dom.child(html!("home-search-result-details", {
                     .property("slot", "categories")
                     .child(html!("div", {
                         .children(jig.jig_data.categories.iter().map(|category_id| {
                             html!("home-search-result-category", {
+                                .property("filled", matches!(state.focus, JigFocus::Modules))
                                 .property_signal("label", {
                                     state.search_options.category_label_lookup.signal_cloned().map(clone!(category_id => move |category_label_lookup| {
                                         match category_label_lookup.get(&category_id) {
@@ -131,7 +133,7 @@ impl SearchResultsSection {
                     JigFocus::Modules => {
                         dom.child(html!("button-rect", {
                             .property("slot", "play-button")
-                            .property("color", "blue")
+                            .property("color", "red")
                             .property("bold", true)
                             .text("Play")
                             .event({

--- a/frontend/elements/src/core/buttons/rectangle.ts
+++ b/frontend/elements/src/core/buttons/rectangle.ts
@@ -51,7 +51,7 @@ export class _ extends LitElement {
                     --color: var(--light-gray-4);
                 }
                 :host([color="red"]) {
-                    --color: #fd6b71;
+                    --color: var(--main-red);
                 }
                 :host([color="red"]:hover) {
                     --color: #ed6065;

--- a/frontend/elements/src/core/images/composed/module-screenshot.ts
+++ b/frontend/elements/src/core/images/composed/module-screenshot.ts
@@ -8,7 +8,6 @@ export class _ extends LitElement {
         return [
             css`
                 :host {
-                    border: solid var(--light-blue-3) 1px;
                     box-sizing: border-box;
                     overflow: hidden;
                     display: inline-block;

--- a/frontend/elements/src/entry/home/home/search-results/search-result-category.ts
+++ b/frontend/elements/src/entry/home/home/search-results/search-result-category.ts
@@ -8,11 +8,17 @@ export class _ extends LitElement {
                 :host {
                     display: inline-block;
                     box-sizing: border-box;
-                    border: solid 1px #ffffff;
-                    padding: 3px 12px;
+                    padding: 2px 12px;
                     font-size: 14px;
-                    border-radius: 20px;
-                    color: #ffffff;
+                    border-radius: 16px;
+                    border: solid 1px var(--white);
+                    color: var(--white);
+                }
+
+                :host([filled]) {
+                    border: solid 1px var(--light-orange-3);
+                    background-color: var(--white);
+                    color: var(--dark-gray-5);
                 }
             `,
         ];
@@ -20,6 +26,9 @@ export class _ extends LitElement {
 
     @property()
     label: string = "";
+
+    @property({ type: Boolean, reflect: true })
+    filled: boolean = false;
 
     render() {
         return html` ${this.label} `;

--- a/frontend/elements/src/entry/home/home/search-results/search-result.ts
+++ b/frontend/elements/src/entry/home/home/search-results/search-result.ts
@@ -118,13 +118,14 @@ export class _ extends LitElement {
                     grid-column: 1;
                     grid-row: 1;
                     height: 100%;
-                    color: #ffffff;
+                    color: var(--white);
                     display: grid;
                     grid-template-rows: 1fr auto;
                     transform: rotateY(180deg);
                 }
                 :host([kind=jig]) .hover {
-                    background-color: var(--dark-blue-2);
+                    background-color: var(--light-orange-1);
+                    color: var(--dark-gray-5);
                 }
                 :host([kind=resource]) .hover {
                     background-color: #00844c;
@@ -137,7 +138,7 @@ export class _ extends LitElement {
                     scrollbar-width: thin;
                 }
                 :host([kind=jig]) .hover {
-                    scrollbar-color: var(--light-blue-5) transparent;
+                    scrollbar-color: var(--light-gray-2) transparent;
                 }
                 :host([kind=resource]) .hover {
                     scrollbar-color: #3f9c6f transparent;
@@ -163,8 +164,11 @@ export class _ extends LitElement {
                     font-size: 16px;
                     font-weight: 600;
                 }
+                :host([kind=jig]) .hover .title {
+                    color: var(--dark-blue-4);
+                }
                 :host([kind=jig]) .hover home-search-result-details:not(:last-child) {
-                    border-bottom: solid 1px #3c7df0;
+                    border-bottom: solid 1px var(--light-orange-3);
                 }
                 :host([kind=resource]) .hover home-search-result-details:not(:last-child) {
                     border-bottom: solid 1px #3f9c6f;
@@ -174,7 +178,7 @@ export class _ extends LitElement {
                     --closed-height: 36px;
                 }
                 :host([kind=jig]) ::slotted(home-search-result-details) {
-                    border-bottom: solid 1px #3c7df0;
+                    border-bottom: solid 1px var(--light-orange-3);
                 }
                 :host([kind=resource]) ::slotted(home-search-result-details) {
                     border-bottom: solid 1px #3f9c6f;
@@ -186,7 +190,7 @@ export class _ extends LitElement {
                     padding: 10px 0;
                 }
                 .hover ::slotted(a[slot=additional-resources]) {
-                    color: #ffffff;
+                    color: var(--dark-gray-5);
                     text-decoration: none;
                     font-size: 14px;
                     display: flex;
@@ -199,7 +203,7 @@ export class _ extends LitElement {
                 }
                 .hover .published-at {
                     font-size: 14px;
-                    font-weight: 500;
+                    font-weight: 250;
                     margin: 4px 0;
                     display: flex;
                     align-items: center;
@@ -221,7 +225,11 @@ export class _ extends LitElement {
                     display: flex;
                     justify-content: space-between;
                     flex-wrap: wrap;
-                    margin: 6px 0;
+                    padding: 10px 0;
+                    border-bottom: solid 1px #3f9c6f;
+                }
+                :host([kind=jig]) .hover .author-section {
+                    border-bottom: solid 1px var(--light-orange-3);
                 }
                 .hover .author-section .left-side {
                     display: flex;
@@ -346,12 +354,6 @@ export class _ extends LitElement {
                 <div class="hover">
                     <div class="scrollable-content">
                         <h3 class="title">${this.title}</h3>
-                        <p class="published-at">
-                            <img-ui
-                                path="entry/home/search-results/time.svg"
-                            ></img-ui>
-                            ${this.publishedAt}
-                        </p>
                         <div class="collapsibles">
                             <slot name="categories"></slot>
                             <home-search-result-details>
@@ -388,6 +390,14 @@ export class _ extends LitElement {
                                         icon="fa-light fa-chevron-right"
                                     ></fa-icon>
                                 </a> -->
+                            </div>
+                            <div class="published-at">
+                                ${this.kind === "jig"
+                                    ? html`<img-ui path="entry/home/search-results/clock.svg"></img-ui>`
+                                    : html`<img-ui path="entry/home/search-results/time.svg"></img-ui>`
+                                }
+
+                                ${this.publishedAt}
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
- Updates the back of the JIG cards in search results to more closely match styling here https://app.zeplin.io/project/5fd249c98c6a325399642201/screen/61c4d81c1476c4635dedcc71

![Screenshot 2022-05-06 at 11 01 42](https://user-images.githubusercontent.com/4161106/167101342-4cd66e2f-ed25-45af-a065-5f47c62c23fa.png)
![Screenshot 2022-05-06 at 11 01 51](https://user-images.githubusercontent.com/4161106/167101351-69458b49-c88f-40e9-8dd2-0a58d4c22c31.png)
