### PR TITLE
fix(fe/jig/search): Disable search result jiggling for Safari

### DIFF
--- a/frontend/elements/src/entry/home/home/search-results/search-result.ts
+++ b/frontend/elements/src/entry/home/home/search-results/search-result.ts
@@ -25,13 +25,13 @@ export class _ extends LitElement {
                     36% {
                         transform: scaleX(-1) translateY(-78px);
                     }
-                    62% {
+                    52% {
                         transform: scaleX(-1) translateY(-55px);
                     }
-                    68% {
+                    70% {
                         transform: scaleX(-1) translateY(-64px);
                     }
-                    84% {
+                    90% {
                         transform: scaleX(-1) translateY(-58px);
                     }
                     100% {
@@ -289,6 +289,13 @@ export class _ extends LitElement {
                 :host(:hover) img-ui.jiggling {
                     animation: jump 1s ease-in-out;
                     transform: scaleX(-1) translateY(-60px);
+                }
+                @media not all and (min-resolution:.001dpcm) {
+                    @supports (-webkit-appearance:none) {
+                        img-ui.jiggling {
+                            display: none;
+                        }
+                    }
                 }
             `,
         ];


### PR DESCRIPTION
- Disables the Jiggling for Safari (temporarily), because I couldn't quickly figure out how to resolve:

https://user-images.githubusercontent.com/4161106/167589174-36262408-9e3a-40dc-aaf6-7cdf31b26d43.mov

- Updates the animation so its a little bit less jarring:

https://user-images.githubusercontent.com/4161106/167589338-75128c78-c156-4e79-bb73-fdad3bfa4ea6.mov

