### PR TITLE
feat(fe/jig/search): Add play icon to play button; Include extra action hover effect

### DIFF
--- a/frontend/apps/crates/entry/home/src/home/search_results/search_results_section/dom.rs
+++ b/frontend/apps/crates/entry/home/src/home/search_results/search_results_section/dom.rs
@@ -143,6 +143,7 @@ impl SearchResultsSection {
                             .child(share_jig.render(
                                 html!("button-icon-label", {
                                     .property("slot", "actions")
+                                    .property("labelColor", "dark-blue")
                                     .property("iconPath", "search/cards/share-backside.svg")
                                     .property("iconHoverPath", "search/cards/share-backside-hover.svg")
                                     .property("label", "Share")
@@ -152,6 +153,7 @@ impl SearchResultsSection {
                             .apply_if(jig.author_id == user_id, move |dom| {
                                 dom.child(html!("button-icon-label", {
                                     .property("slot", "actions")
+                                    .property("labelColor", "dark-blue")
                                     .property("iconPath", "search/cards/edit-backside.svg")
                                     .property("iconHoverPath", "search/cards/edit-backside-hover.svg")
                                     .property("label", "Edit")
@@ -164,10 +166,12 @@ impl SearchResultsSection {
                                     })
                                 }))
                             })
-                            .child(html!("button-rect", {
+                            .child(html!("button-rect-icon", {
                                 .property("slot", "play-button")
                                 .property("color", "red")
                                 .property("bold", true)
+                                .property("size", "small")
+                                .property("iconBeforePath", "search/cards/play.svg")
                                 .text("Play")
                                 .event({
                                     let jig_id = jig.id;

--- a/frontend/elements/src/_bundles/home/imports.ts
+++ b/frontend/elements/src/_bundles/home/imports.ts
@@ -1,6 +1,7 @@
 import "@elements/_bundles/_sub-bundles/page/header";
 import "@elements/_bundles/_sub-bundles/all";
 import "@elements/core/buttons/icon-label";
+import "@elements/core/buttons/rectangle-icon";
 import "@elements/core/images/ui";
 import "@elements/core/images/ji";
 import "@elements/core/inputs/composed/select/select";

--- a/frontend/elements/src/core/buttons/icon-label.ts
+++ b/frontend/elements/src/core/buttons/icon-label.ts
@@ -2,7 +2,7 @@ import { LitElement, html, css, customElement, property } from "lit-element";
 import { IconKind, IconSize } from "./icon";
 import "./icon";
 
-export type LabelColor = "blue";
+export type LabelColor = "blue" | "dark-blue";
 
 @customElement("button-icon-label")
 export class _ extends LitElement {
@@ -12,7 +12,7 @@ export class _ extends LitElement {
                 :host, a {
                     display: inline-flex;
                     align-items: center;
-                    gap: 8px;
+                    gap: 2px;
                     cursor: pointer;
                 }
 
@@ -22,6 +22,13 @@ export class _ extends LitElement {
 
                 :host([labelColor="blue"]) .label {
                     color: var(--main-blue);
+                }
+
+                :host([labelColor="dark-blue"]) .label {
+                    color: var(--dark-blue-1);
+                }
+                :host(:hover[labelColor="dark-blue"]) .label {
+                    color: var(--dark-blue-2);
                 }
 
                 .label {

--- a/frontend/elements/src/core/buttons/rectangle-icon.ts
+++ b/frontend/elements/src/core/buttons/rectangle-icon.ts
@@ -47,8 +47,15 @@ export class _ extends LitElement {
 
     @property()
     iconBefore?: IconBefore;
+
+    @property({ type: String })
+    iconBeforePath?: string;
+
     @property()
     iconAfter?: IconAfter;
+
+    @property({ type: String })
+    iconAfterPath?: string;
 
     connectedCallback() {
         super.connectedCallback();
@@ -64,25 +71,31 @@ export class _ extends LitElement {
 
     render() {
         const { iconBefore, iconAfter, color, disabled } = this;
+        let { iconBeforePath, iconAfterPath } = this;
 
-        const iconBeforePath =
-            iconBefore === "magnifier"
-                ? "core/buttons/rect/magnifier.svg"
-                : iconBefore === "share"
-                ? `core/buttons/rect/share-${color}.svg`
-                : iconBefore === "create"
-                ? `core/buttons/rect/plus-${color}.svg`
-                : iconBefore === "play"
-                ? `core/buttons/rect/play-${color}.svg`
-                : iconBefore === "plus"
-                ? getPlus(color)
-                : nothing;
-        const iconAfterPath =
-            iconAfter === "arrow"
-                ? getArrow(disabled)
-                : iconAfter === "done"
-                ? "core/buttons/rect/done-check.svg"
-                : "";
+        if (!iconBeforePath) {
+            iconBeforePath =
+                iconBefore === "magnifier"
+                    ? "core/buttons/rect/magnifier.svg"
+                    : iconBefore === "share"
+                    ? `core/buttons/rect/share-${color}.svg`
+                    : iconBefore === "create"
+                    ? `core/buttons/rect/plus-${color}.svg`
+                    : iconBefore === "play"
+                    ? `core/buttons/rect/play-${color}.svg`
+                    : iconBefore === "plus"
+                    ? getPlus(color)
+                    : undefined
+        }
+
+        if (!iconAfterPath) {
+            iconAfterPath =
+                iconAfter === "arrow"
+                    ? getArrow(disabled)
+                    : iconAfter === "done"
+                    ? "core/buttons/rect/done-check.svg"
+                    : undefined;
+        }
 
         return html`
             <button-rect
@@ -97,10 +110,10 @@ export class _ extends LitElement {
                 target="${ifDefined(this.target)}"
             >
                 <div class="content">
-                    ${iconBefore &&
+                    ${iconBeforePath &&
                     html`<img-ui path="${iconBeforePath}"></img-ui>`}
                     <slot></slot>
-                    ${iconAfter &&
+                    ${iconAfterPath &&
                     html`<img-ui path="${iconAfterPath}"></img-ui>`}
                 </div>
             </button-rect>
@@ -108,7 +121,7 @@ export class _ extends LitElement {
     }
 }
 function getPlus(color: Color) {
-    return color === "blue" ? "core/inputs/plus-white.svg" : nothing;
+    return color === "blue" ? "core/inputs/plus-white.svg" : undefined;
 }
 
 function getArrow(disabled: boolean) {

--- a/frontend/elements/src/entry/home/home/search-results/search-result.ts
+++ b/frontend/elements/src/entry/home/home/search-results/search-result.ts
@@ -290,6 +290,7 @@ export class _ extends LitElement {
                     animation: jump 1s ease-in-out;
                     transform: scaleX(-1) translateY(-60px);
                 }
+
                 @media not all and (min-resolution:.001dpcm) {
                     @supports (-webkit-appearance:none) {
                         img-ui.jiggling {


### PR DESCRIPTION
Closes #2651

- Adds yellow play icon to the JIG search result cards;
- Updates the `button-rect-icon` element to allow users to pass in any before/after icon;
- Updates `button-icon-label` components to include `"dark-blue"` colour and adds a hover effect for that colour.


https://user-images.githubusercontent.com/4161106/167596185-3648543b-7b61-4f06-b2fa-208d5166ed62.mov

