### PR TITLE
feat(fe/jig/edit): Add back draft indicator for JIG edit gallery

### DIFF
--- a/frontend/apps/crates/entry/jig/edit/src/gallery/dom.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/gallery/dom.rs
@@ -144,8 +144,7 @@ impl JigGallery {
                             .apply(|dom| {
                                 match jig.published_at {
                                     None => {
-                                        // dom.property("draft", true)
-                                        dom
+                                        dom.property("draft", true)
                                     },
                                     Some(published_at) => {
                                         dom.property("publishedAt", published_at_string(published_at, true))


### PR DESCRIPTION
Part of #2699 

![Screenshot 2022-05-10 at 11 36 49](https://user-images.githubusercontent.com/4161106/167599613-48ba4b13-3ed0-4000-b5c5-5012b955ed81.png)
