### PR TITLE
fix(fe/jig/search): Improve icon/label spacing on the back of JIG search result cards

### DIFF
--- a/frontend/apps/crates/entry/home/src/home/search_results/search_results_section/dom.rs
+++ b/frontend/apps/crates/entry/home/src/home/search_results/search_results_section/dom.rs
@@ -146,6 +146,7 @@ impl SearchResultsSection {
                                     .property("labelColor", "dark-blue")
                                     .property("iconPath", "search/cards/share-backside.svg")
                                     .property("iconHoverPath", "search/cards/share-backside-hover.svg")
+                                    .property("gapOverride", "0px")
                                     .property("label", "Share")
                                 }),
                                 Some("actions"),
@@ -156,6 +157,7 @@ impl SearchResultsSection {
                                     .property("labelColor", "dark-blue")
                                     .property("iconPath", "search/cards/edit-backside.svg")
                                     .property("iconHoverPath", "search/cards/edit-backside-hover.svg")
+                                    .property("gapOverride", "0px")
                                     .property("label", "Edit")
                                     .property("href", {
                                         String::from(Route::Jig(JigRoute::Edit(

--- a/frontend/elements/src/core/buttons/icon-label.ts
+++ b/frontend/elements/src/core/buttons/icon-label.ts
@@ -9,10 +9,13 @@ export class _ extends LitElement {
     static get styles() {
         return [
             css`
+                :host {
+                    --gap-override: 4px;
+                }
                 :host, a {
                     display: inline-flex;
                     align-items: center;
-                    gap: 2px;
+                    gap: var(--gap-override);
                     cursor: pointer;
                 }
 
@@ -75,6 +78,9 @@ export class _ extends LitElement {
     @property({ reflect: true })
     labelColor: LabelColor = "blue";
 
+    @property({ type: String })
+    gapOverride?: string;
+
     connectedCallback() {
         super.connectedCallback();
         this.addEventListener("mouseenter", this.onMouseEnter);
@@ -85,6 +91,12 @@ export class _ extends LitElement {
         super.disconnectedCallback();
         this.removeEventListener("mouseenter", this.onMouseEnter);
         this.removeEventListener("mouseleave", this.onMouseLeave);
+    }
+
+    updated() {
+        if (this.gapOverride) {
+            this.style.setProperty("--gap-override", this.gapOverride);
+        }
     }
 
     onMouseEnter() {

--- a/frontend/elements/src/entry/home/home/search-results/search-result.ts
+++ b/frontend/elements/src/entry/home/home/search-results/search-result.ts
@@ -272,7 +272,7 @@ export class _ extends LitElement {
                 .hover .extra-actions {
                     margin-right: auto;
                     display: flex;
-                    gap: 8px;
+                    gap: 16px;
                     align-items: center;
                 }
                 .hover .primary-action {


### PR DESCRIPTION
- Updates spacing for icons and labels on the backs of JIG search result cards

![image](https://user-images.githubusercontent.com/4161106/167819875-8c5d4df3-2be0-4d63-bfc1-76ceaeccf906.png)
