### PR TITLE
fix(fe/module/drag-drop): Resolve regression where a single placement of a drag drop item caused the activity to end

### DIFF
--- a/frontend/apps/crates/entry/module/drag-drop/play/src/base/game/playing/actions.rs
+++ b/frontend/apps/crates/entry/module/drag-drop/play/src/base/game/playing/actions.rs
@@ -45,18 +45,29 @@ impl PlayState {
         let all_completed = state
             .items
             .iter()
-            .filter_map(|item| {
+            .enumerate()
+            .filter_map(|(idx, item)| {
                 match item {
                     PlayItem::Interactive(item) => {
-                        // Only return items which are interactive _and_ have a target trace so
+                        // Only return items which are interactive _and_ have target traces so
                         // that we can end the game correctly when there are items which aren't
                         // meant to be placed anywhere.
-                        item.target_index.borrow().as_ref().map(|_| item.clone())
+                        // Note: We only care that a sticker has a target trace, not which one it
+                        // is in. The `all()` call will ensure that all the items are completed
+                        // correctly. So we look for the first target trace that matches this
+                        // sticker.
+                        state
+                            .game
+                            .base
+                            .item_targets
+                            .iter()
+                            .find(|item_target| idx == item_target.sticker_idx)
+                            .map(|_| item.completed.get())
                     }
                     _ => None,
                 }
             })
-            .all(|item| item.completed.get());
+            .all(|completed| completed);
 
         all_completed
     }


### PR DESCRIPTION
Resolves #2733

The regression was caused by #2700 when the activity completed check was not updated to work with the new multiple target traces logic.

