### PR TITLE
feat(fe/jig/share): Add clearer notification for copying share data

### DIFF
--- a/frontend/apps/crates/components/src/share_jig/actions.rs
+++ b/frontend/apps/crates/components/src/share_jig/actions.rs
@@ -1,10 +1,14 @@
 use std::rc::Rc;
 
 use dominator::clone;
+use futures_signals::signal::Mutable;
+use gloo_timers::callback::Timeout;
 use shared::{api::endpoints::jig, domain::jig::JigPlayerSettings};
 use utils::prelude::*;
 
 use super::state::ShareJig;
+
+const COPIED_TIMEOUT: u32 = 3_000;
 
 impl ShareJig {
     pub(super) fn generate_student_code(self: &Rc<Self>) {
@@ -23,5 +27,16 @@ impl ShareJig {
                 },
             };
         }));
+    }
+
+    pub fn set_copied_mutable(copied: Mutable<bool>) {
+        copied.set(true);
+        let timeout = Timeout::new(
+            COPIED_TIMEOUT,
+            clone!(copied => move || {
+                copied.set(false);
+            }),
+        );
+        timeout.forget();
     }
 }

--- a/frontend/apps/crates/components/src/share_jig/state.rs
+++ b/frontend/apps/crates/components/src/share_jig/state.rs
@@ -15,6 +15,8 @@ pub struct ShareJig {
     pub jig_id: JigId,
     pub copied_embed: Mutable<bool>,
     pub link_copied: Mutable<bool>,
+    pub copied_student_url: Mutable<bool>,
+    pub copied_student_code: Mutable<bool>,
 }
 
 impl ShareJig {
@@ -26,6 +28,8 @@ impl ShareJig {
             active_popup: Mutable::new(None),
             copied_embed: Mutable::new(false),
             link_copied: Mutable::new(false),
+            copied_student_url: Mutable::new(false),
+            copied_student_code: Mutable::new(false),
         })
     }
 


### PR DESCRIPTION
Resolves #2735

- Adds copied notification for copying embedded code, student URL and student code:

https://user-images.githubusercontent.com/4161106/168264204-0d4ce940-fd6e-498b-b98e-7214c58b9147.mov

