### PR TITLE
fix(fe/jig/play): Use configured JIG player direction settings from JIG

### DIFF
--- a/frontend/apps/crates/entry/jig/play/src/player/dom.rs
+++ b/frontend/apps/crates/entry/jig/play/src/player/dom.rs
@@ -23,7 +23,9 @@ pub fn render(state: Rc<State>) -> Dom {
     actions::load_jig(state.clone());
 
     html!("jig-play-landing", {
-        .property("rtl", state.player_options.direction.is_rtl())
+        .property_signal("rtl", state.jig.signal_cloned().map(|jig| {
+            jig.map(|jig| jig.jig_data.default_player_settings.direction.is_rtl())
+        }))
         .property_signal("paused", state.paused.signal())
         .property_signal("isLegacy", state.jig.signal_ref(|jig| {
             if let Some(jig) = jig {


### PR DESCRIPTION
Part of #2731

This is a stop-gap solution so that JIGs which have been configured for LTR/RTL play render correctly regardless of the setting of the `direction` query parameter.

- Once a JIG is loaded, set the direction based on the JIGs config.