### PR TITLE
fix(be/pages): Update jig route to asset

### DIFF
--- a/backend/pages/src/server/routes.rs
+++ b/backend/pages/src/server/routes.rs
@@ -12,11 +12,11 @@ pub fn configure(config: &mut ServiceConfig) {
         .route("/admin/{path:.*}", web::get().to(spa::admin_template))
         .route("/admin", web::get().to(spa::admin_template))
         .route(
-            "/jig/{page_kind}/{jig_id}",
+            "/asset/{page_kind}/{jig_id}",
             web::get().to(spa::jig_template),
         )
         .route(
-            "/jig/{page_kind}/{jig_id}/{module_id}",
+            "/asset/{page_kind}/{jig_id}/{module_id}",
             web::get().to(spa::jig_template_with_module),
         )
         .route("/legacy/play/{jig_id}", web::get().to(spa::legacy_template))


### PR DESCRIPTION
- Updates the SPA route for jigs from `/jig/**` to `/asset/**`