### PR TITLE
fix(be/api): Add is_complete check when create a new JIG module

### DIFF
--- a/backend/api/sqlx-data.json
+++ b/backend/api/sqlx-data.json
@@ -2329,34 +2329,6 @@
     },
     "query": "insert into session (token, user_id, impersonator_id, expires_at, scope_mask) values ($1, $2, $3, $4, $5)"
   },
-  "4485adb8cd789a26f1d0930478a2870c60300ec8612b076a059358c2baaa69a6": {
-    "describe": {
-      "columns": [
-        {
-          "name": "id",
-          "ordinal": 0,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "index",
-          "ordinal": 1,
-          "type_info": "Int2"
-        }
-      ],
-      "nullable": [
-        false,
-        false
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Int2",
-          "Jsonb"
-        ]
-      }
-    },
-    "query": "\ninsert into jig_data_module (jig_data_id, kind, contents, index)\nvalues ($1, $2, $3, (select count(*) from jig_data_module where jig_data_id = $1))\nreturning id, \"index\"\n"
-  },
   "477cc11eb6ff88e4c8c0779c11ab3480de42748968c29564bc0e70db1f18a9bc": {
     "describe": {
       "columns": [],
@@ -5468,6 +5440,35 @@
       }
     },
     "query": "delete from session where token = $1 and (scope_mask & $2) = $2 returning user_id"
+  },
+  "a665288fc26ec7d8d82a6d2859310b10a0a1057effe65e67503e2e2f06d6a1c2": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "index",
+          "ordinal": 1,
+          "type_info": "Int2"
+        }
+      ],
+      "nullable": [
+        false,
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Int2",
+          "Jsonb",
+          "Bool"
+        ]
+      }
+    },
+    "query": "\ninsert into jig_data_module (jig_data_id, kind, contents, index, is_complete)\nvalues ($1, $2, $3, (select count(*) from jig_data_module where jig_data_id = $1), $4)\nreturning id, \"index\"\n"
   },
   "a7597f668f530133865fe74a396da14ff51dcb53fc0537df95964ae98649ce1d": {
     "describe": {

--- a/backend/api/src/db/jig.rs
+++ b/backend/api/src/db/jig.rs
@@ -1113,7 +1113,6 @@ pub async fn clone_data(
     from_data_id: &Uuid,
     draft_or_live: DraftOrLive,
 ) -> Result<Uuid, error::CloneDraft> {
-    println!("here in clone");
     let new_id = sqlx::query!(
         //language=SQL
         r#"

--- a/backend/api/src/db/jig/module.rs
+++ b/backend/api/src/db/jig/module.rs
@@ -55,6 +55,7 @@ pub async fn create(
     pool: &PgPool,
     parent: JigId,
     body: ModuleBody,
+    is_complete: bool,
 ) -> anyhow::Result<(ModuleId, u16)> {
     let (kind, body) = map_module_contents(&body)?;
 
@@ -74,13 +75,14 @@ select draft_id from jig where jig.id = $1
     let res = sqlx::query!(
         //language=SQL
         r#"
-insert into jig_data_module (jig_data_id, kind, contents, index)
-values ($1, $2, $3, (select count(*) from jig_data_module where jig_data_id = $1))
+insert into jig_data_module (jig_data_id, kind, contents, index, is_complete)
+values ($1, $2, $3, (select count(*) from jig_data_module where jig_data_id = $1), $4)
 returning id, "index"
 "#,
         draft_id,
         kind as i16,
         body,
+        is_complete,
     )
     .fetch_one(&mut txn)
     .await

--- a/backend/api/src/http/endpoints/jig/module.rs
+++ b/backend/api/src/http/endpoints/jig/module.rs
@@ -31,7 +31,8 @@ async fn create(
 
     let req = req.into_inner();
 
-    let (id, _index) = db::jig::module::create(&*db, parent_id, req.body).await?;
+    let is_complete = req.body.is_complete();
+    let (id, _index) = db::jig::module::create(&*db, parent_id, req.body, is_complete).await?;
 
     Ok(HttpResponse::Created().json(CreateResponse { id }))
 }

--- a/shared/rust/src/domain/jig/module/body.rs
+++ b/shared/rust/src/domain/jig/module/body.rs
@@ -118,6 +118,23 @@ impl Body {
             Self::Legacy(data) => data.convert_to_body(kind),
         }
     }
+
+    /// Helper to check whether the inner data is complete
+    pub fn is_complete(&self) -> bool {
+        match self {
+            Self::MemoryGame(data) => data.is_complete(),
+            Self::Matching(data) => data.is_complete(),
+            Self::Flashcards(data) => data.is_complete(),
+            Self::CardQuiz(data) => data.is_complete(),
+            Self::Poster(data) => data.is_complete(),
+            Self::Video(data) => data.is_complete(),
+            Self::TappingBoard(data) => data.is_complete(),
+            Self::DragDrop(data) => data.is_complete(),
+            Self::Cover(data) => data.is_complete(),
+            Self::ResourceCover(data) => data.is_complete(),
+            Self::Legacy(data) => data.is_complete(),
+        }
+    }
 }
 
 /// Extension trait for interop


### PR DESCRIPTION
Resolves #2743

- Checks whether the new modules data is complete and marks the `is_complete` column in the data table.