### PR TITLE
fix(be/algolia): Remove multiple attributes for searchable attributes

### DIFF
--- a/backend/api/src/algolia/migration.rs
+++ b/backend/api/src/algolia/migration.rs
@@ -101,11 +101,9 @@ pub(crate) async fn course_index(
                 .single(Attribute("author_name".to_owned()))
                 .single(Attribute("translated_keywords".to_owned()))
                 .single(Attribute("description".to_owned()))
-                .multi(vec![
-                    Attribute("category_names".to_owned()),
-                    Attribute("translated_description".to_owned()),
-                    Attribute("resource_type_names".to_owned()),
-                ])
+                .single(Attribute("category_names".to_owned()))
+                .single(Attribute("translated_description".to_owned()))
+                .single(Attribute("resource_type_names".to_owned()))
                 .single(Attribute("language".to_owned()))
                 .single(Attribute("other_keywords".to_owned()))
                 .finish(),


### PR DESCRIPTION
- Removes the multi attributes config for searchable attributes.

Since last week, the multiple attributes config has caused errors when searching against algolia:

![image](https://user-images.githubusercontent.com/4161106/169026084-a2b82a19-13cb-403f-968f-e46b9033a293.png)

The error is weird, but adding each of those attributes individually as searchable instead of comma separated fixes it.