### PR TITLE
fix(be/pages): Fix routes for asset galleries

### DIFF
--- a/backend/pages/src/server/routes.rs
+++ b/backend/pages/src/server/routes.rs
@@ -12,6 +12,10 @@ pub fn configure(config: &mut ServiceConfig) {
         .route("/admin/{path:.*}", web::get().to(spa::admin_template))
         .route("/admin", web::get().to(spa::admin_template))
         .route(
+            "/asset/edit/{gallery_kind}",
+            web::get().to(spa::gallery_template),
+        )
+        .route(
             "/asset/{page_kind}/{asset_kind}/{jig_id}",
             web::get().to(spa::jig_template),
         )

--- a/backend/pages/src/templates/spa.rs
+++ b/backend/pages/src/templates/spa.rs
@@ -112,6 +112,13 @@ pub async fn admin_template(settings: Data<RuntimeSettings>) -> actix_web::Resul
     spa_template(&settings, SpaPage::Admin)
 }
 
+pub async fn gallery_template(
+    settings: Data<RuntimeSettings>,
+    _path: Path<String>,
+) -> actix_web::Result<HttpResponse> {
+    spa_template(&settings, SpaPage::Jig(ModuleJigPageKind::Edit))
+}
+
 pub async fn jig_template(
     settings: Data<RuntimeSettings>,
     path: Path<(ModuleJigPageKind, String, String)>,


### PR DESCRIPTION
- #2773 fixed routing for playing jigs, but broke it for loading galleries