### PR TITLE
fix(fe/jig/play): Show module play button only once; Auto play audio

### DIFF
--- a/frontend/apps/crates/components/src/module/_common/play/entry/state.rs
+++ b/frontend/apps/crates/components/src/module/_common/play/entry/state.rs
@@ -37,6 +37,7 @@ where
     pub(super) raw_loader: AsyncLoader,
     pub(super) page_body_switcher: AsyncLoader,
     pub(super) dom_body_handle: Mutable<Option<DomHandle>>,
+    pub(super) audio_ready: Mutable<bool>,
     phantom: PhantomData<(Mode, Step)>,
 }
 
@@ -87,6 +88,7 @@ where
             raw_loader: AsyncLoader::new(),
             page_body_switcher: AsyncLoader::new(),
             dom_body_handle: Mutable::new(None),
+            audio_ready: Mutable::new(false),
             phantom: PhantomData,
         });
 

--- a/frontend/apps/crates/entry/jig/play/src/player/dom.rs
+++ b/frontend/apps/crates/entry/jig/play/src/player/dom.rs
@@ -89,7 +89,7 @@ pub fn render(state: Rc<State>) -> Dom {
                 None
             }
         }))
-        .child_signal(active_module_valid_signal(Rc::clone(&state)).map(clone!(state => move |valid| {
+        .child_signal(active_module_valid_signal(Rc::clone(&state)).dedupe().map(clone!(state => move |valid| {
             if valid {
                 Some(html!("iframe" => HtmlIFrameElement, {
                     .property("allow", "autoplay; fullscreen")

--- a/frontend/apps/crates/entry/jig/play/src/player/state.rs
+++ b/frontend/apps/crates/entry/jig/play/src/player/state.rs
@@ -23,6 +23,9 @@ pub struct State {
     pub timer: Mutable<Option<Timer>>,
     pub points: Mutable<u32>,
     pub iframe: Rc<RefCell<Option<HtmlIFrameElement>>>,
+    /// Indicates that the JIG has been started. This can be true when paused is true and when done
+    /// is true.
+    pub started: Mutable<bool>,
     pub paused: Mutable<bool>,
     pub done: Mutable<bool>,
     pub player_options: JigPlayerOptions,
@@ -48,6 +51,7 @@ impl State {
             timer: Mutable::new(None),
             points: Mutable::new(0),
             iframe: Rc::new(RefCell::new(None)),
+            started: Mutable::new(false),
             paused: Mutable::new(false),
             done: Mutable::new(false),
             player_options,

--- a/frontend/apps/crates/utils/src/iframe.rs
+++ b/frontend/apps/crates/utils/src/iframe.rs
@@ -171,10 +171,13 @@ pub enum JigToModulePlayerMessage {
     TimerDone,
     Play,
     Pause,
+    /// Ready(None) when we're still waiting for the iframe message
+    AudioReady,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum ModuleToJigPlayerMessage {
+    Ready,
     AddPoints(u32),
     Start(Option<u32>),
     Stop,


### PR DESCRIPTION

- Updates the JIG player so that the play button is only show once when the first module is loaded. 
- Subsequent modules will start automatically.
- Removes the check for context_available because it doesn't wait for the ready state change, and safari doesn't seem to ever fire it...
- Uses iframe message to tell each module whether it needs to render the play button or not - once the first play button is clicked, subsequent modules will be told not to render.

### Problems

- This only works on Chrome/FF. Safari won't play the audio of subsequent modules automatically.