### PR TITLE
chore(be): Increase request/response size limit to 256KB

### DIFF
--- a/backend/core/src/config.rs
+++ b/backend/core/src/config.rs
@@ -37,8 +37,8 @@ pub const ANIMATION_BODY_SIZE_LIMIT: usize = 1024 * 1024 * 40;
 pub const AUDIO_BODY_SIZE_LIMIT: usize = 1024 * 1024 * 30;
 /// PDF file size limit. 10 MB
 pub const PDF_BODY_SIZE_LIMIT: usize = 1024 * 1024 * 10;
-/// JSON body size limit for both requests and responses. 16 KB
-pub const JSON_BODY_LIMIT: u64 = 1024 * 16;
+/// JSON body size limit for both requests and responses. 256 KB
+pub const JSON_BODY_LIMIT: u64 = 1024 * 256;
 /// Allowed CORS origins
 pub const CORS_ORIGINS: &[&str] = &[
     "https://jigzi.org",


### PR DESCRIPTION
Resolves #2766

- Increases the max payload size from 16KB to 256KB