### PR TITLE
refactor(be): Removed jig cover

### DIFF
--- a/backend/api/src/db/jig.rs
+++ b/backend/api/src/db/jig.rs
@@ -221,16 +221,9 @@ select cte.jig_id                                          as "jig_id: JigId",
        curated,
        array(select row (unnest(audio_feedback_positive))) as "audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>",
        array(select row (unnest(audio_feedback_negative))) as "audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>",
-       (
-                select row(jig_data_module.id, kind, is_complete) 
-                from jig_data_module                
-                where jig_data_id = cte.draft_or_live_id and "index" = 0 
-                order by "index"
-       )                                                   as "cover?: (ModuleId, ModuleKind, bool)",
        array(
                select row (jig_data_module.id, kind, is_complete)
                from jig_data_module
-               where jig_data_id = cte.draft_or_live_id and "index" <> 0
                order by "index"
        )                                               as "modules!: Vec<(ModuleId, ModuleKind, bool)>",
        array(select row (category_id)
@@ -268,11 +261,6 @@ from jig_data
             draft_or_live,
             display_name: row.display_name,
             language: row.language,
-            cover: row.cover.map(|(id, kind, is_complete)| LiteModule {
-                id,
-                kind,
-                is_complete,
-            }),
             modules: row
                 .modules
                 .into_iter()
@@ -401,16 +389,9 @@ select id,
        audio_background                                                              as "audio_background!: Option<AudioBackground>",
        array(select row (unnest(audio_feedback_positive)))                           as "audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>",
        array(select row (unnest(audio_feedback_negative)))                           as "audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>",
-       (
-                select row(jig_data_module.id, kind, is_complete) 
-                from jig_data_module                
-                where jig_data_id = jig_data.id and "index" = 0
-                order by "index"
-        )                                                   as "cover?: (ModuleId, ModuleKind, bool)",
        array(
                select row (jig_data_module.id, kind, is_complete)
                from jig_data_module
-               where jig_data_id = jig_data.id and "index" <> 0
                order by "index"
            )                                               as "modules!: Vec<(ModuleId, ModuleKind, bool)>",
        array(select row (category_id)
@@ -457,13 +438,6 @@ from jig_data
                 draft_or_live,
                 display_name: jig_data_row.display_name,
                 language: jig_data_row.language,
-                cover: jig_data_row
-                    .cover
-                    .map(|(id, kind, is_complete)| LiteModule {
-                        id,
-                        kind,
-                        is_complete,
-                    }),
                 modules: jig_data_row
                     .modules
                     .into_iter()
@@ -611,16 +585,9 @@ select jig.id                                              as "jig_id: JigId",
    draft_or_live                                                                 as "draft_or_live!: DraftOrLive",
    array(select row (unnest(audio_feedback_positive)))                           as "audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>",
    array(select row (unnest(audio_feedback_negative)))                           as "audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>",
-   (
-            select row(jig_data_module.id, kind, is_complete) 
-            from jig_data_module                
-            where jig_data_id = jig_data.id and "index" = 0
-            order by "index"
-   )                                                   as "cover?: (ModuleId, ModuleKind, bool)",
    array(
            select row (jig_data_module.id, kind, is_complete)
            from jig_data_module
-           where jig_data_id = jig_data.id and "index" <> 0
            order by "index"
     )                                               as "modules!: Vec<(ModuleId, ModuleKind, bool)>",
    array(select row (category_id)
@@ -686,13 +653,6 @@ limit $7
                 draft_or_live: jig_data_row.draft_or_live,
                 display_name: jig_data_row.display_name,
                 language: jig_data_row.language,
-                cover: jig_data_row
-                    .cover
-                    .map(|(id, kind, is_complete)| LiteModule {
-                        id,
-                        kind,
-                        is_complete,
-                    }),
                 modules: jig_data_row
                     .modules
                     .into_iter()

--- a/shared/rust/src/domain/asset.rs
+++ b/shared/rust/src/domain/asset.rs
@@ -195,8 +195,8 @@ impl Asset {
     /// get cover
     pub fn cover(&self) -> Option<&LiteModule> {
         match self {
-            Self::Jig(jig) => jig.jig_data.modules.first(),
-            Self::Course(_) => todo!(),
+            Self::Jig(jig) => jig.jig_data.modules.get(0),
+            Self::Course(course) => course.course_data.cover.as_ref(),
         }
     }
 

--- a/shared/rust/src/domain/jig.rs
+++ b/shared/rust/src/domain/jig.rs
@@ -85,9 +85,6 @@ pub struct JigData {
     /// The JIG's name.
     pub display_name: String,
 
-    /// The JIG's cover module.
-    pub cover: Option<LiteModule>,
-
     /// The JIG's remaining modules.
     ///
     /// NOTE: the first module will always exist and will always be of type cover


### PR DESCRIPTION
Changing the logic in the frontend from a single list of modules to a cover and a list of modules is going to require a huge rewrite.

Would this commit be enough to get modules back to the way it was working earlier?

Don't merge yet