### PR TITLE
fix(fe/components/traces): Ensure trace drawing is cancelled correctly

### DIFF
--- a/frontend/apps/crates/components/src/traces/edit/draw/actions.rs
+++ b/frontend/apps/crates/components/src/traces/edit/draw/actions.rs
@@ -32,6 +32,13 @@ impl Draw {
                 } else {
                     self.cancel();
                 }
+            } else {
+                // This branch is (I think) when bounds is 0x0 and `calc_bounds` returns None.
+                // There are a few other cases where a teacher is able to draw a short straight line
+                // down and releasing the mouse wouldn't clear the line. Canceling at this point
+                // clears the line correctly and also prevents a weird state when the teacher
+                // simply taps on the screen.
+                self.cancel();
             }
         }
     }


### PR DESCRIPTION
- fixes issue where after deselecting a trace by clicking outside of it, no traces can be selected until a trace is drawn;
- fixes issue where when starting a trace, a teacher could draw a small line downwards which wouldn't disappear when they stopped dragging:

![Screenshot 2022-05-31 at 12 29 10](https://user-images.githubusercontent.com/4161106/171153573-cbfa5b8a-5566-4d89-9c09-20dbcb7b3091.png)
