### PR TITLE
fix(be/image/search): correct order of image results from algolia

### DIFF
--- a/backend/api/src/db/image.rs
+++ b/backend/api/src/db/image.rs
@@ -253,7 +253,7 @@ from image_metadata
          inner join unnest($1::uuid[])
     with ordinality t(id, ord) USING (id)
 where processing_result is not distinct from true
-order by id
+order by ord
 "#)
     .bind(ids)
     .fetch(db)


### PR DESCRIPTION
This will return the same order of images that returns from Algolia instead of order by id.