### PR TITLE
fix(fe): Improved age range rendering; Copy updates

### DIFF
--- a/frontend/apps/crates/components/src/lists/dual/strings.rs
+++ b/frontend/apps/crates/components/src/lists/dual/strings.rs
@@ -1,4 +1,4 @@
-pub const STR_DONE: &str = "Done";
+pub const STR_DONE: &str = "Generate";
 pub const STR_CLEAR: &str = "Clear";
 
 pub mod error {

--- a/frontend/apps/crates/components/src/lists/single/strings.rs
+++ b/frontend/apps/crates/components/src/lists/single/strings.rs
@@ -1,4 +1,4 @@
-pub const STR_DONE: &str = "Done";
+pub const STR_DONE: &str = "Generate";
 pub const STR_CLEAR: &str = "Clear";
 
 pub mod error {

--- a/frontend/apps/crates/entry/home/src/home/search_results/search_results_section/dom.rs
+++ b/frontend/apps/crates/entry/home/src/home/search_results/search_results_section/dom.rs
@@ -88,8 +88,14 @@ impl SearchResultsSection {
                     None => String::new(),
                 }
             })
-            .property_signal("ages", state.search_options.age_ranges.signal_cloned().map(move |age_ranges| {
-                age_ranges.range_string(&jig_ages)
+            .child_signal(state.search_options.age_ranges.signal_cloned().map(move |age_ranges| {
+                let range = age_ranges.range(&jig_ages);
+                Some(html!("age-range", {
+                    .property("slot", "ages")
+                    .property("icon", "entry/home/search-results/age.svg")
+                    .property("from", range.0)
+                    .property("to", range.1)
+                }))
             }))
             .property("description", jig.jig_data.description.clone())
             .child(ModuleThumbnail::render(

--- a/frontend/apps/crates/entry/jig/play/src/jig/sidebar/dom/info.rs
+++ b/frontend/apps/crates/entry/jig/play/src/jig/sidebar/dom/info.rs
@@ -10,6 +10,7 @@ use utils::{
     ages::AgeRangeVecExt,
     events,
     jig::{published_at_string, ResourceContentExt},
+    unwrap::UnwrapJiExt,
 };
 
 use super::{super::state::State, report};
@@ -70,8 +71,14 @@ fn render_jig_info(state: Rc<State>, jig: &JigResponse) -> Dom {
             }
         })
         .property("description", &jig.jig_data.description)
-        .property_signal("ages", state.all_ages.signal_cloned().map(clone!(jig => move|all_ages| {
-            all_ages.range_string(&jig.jig_data.age_ranges)
+        .child_signal(state.all_ages.signal_cloned().map(clone!(jig => move |age_ranges| {
+            let range = age_ranges.range(&jig.jig_data.age_ranges);
+            Some(html!("age-range", {
+                .property("slot", "ages")
+                .property("icon", "entry/jig/play/sidebar/age.svg")
+                .property("from", range.0)
+                .property("to", range.1)
+            }))
         })))
         .child(html!("button-empty", {
             .property("slot", "close")

--- a/frontend/apps/crates/utils/src/ages.rs
+++ b/frontend/apps/crates/utils/src/ages.rs
@@ -1,29 +1,25 @@
 use shared::domain::meta::{AgeRange, AgeRangeId};
 pub use shared::domain::module::body::ThemeId;
 
+use crate::prelude::UnwrapJiExt;
+
 const STR_ALL_AGES: &str = "All Ages";
-const STR_DASH: &str = "-";
 
 pub trait AgeRangeVecExt {
-    fn range_string(&self, selected: &[AgeRangeId]) -> String;
+    fn range(&self, selected: &[AgeRangeId]) -> (String, Option<String>);
 }
 
 impl AgeRangeVecExt for Vec<AgeRange> {
-    fn range_string(&self, selected: &[AgeRangeId]) -> String {
+    fn range(&self, selected: &[AgeRangeId]) -> (String, Option<String>) {
         if selected.len() == self.len() || selected.is_empty() {
-            STR_ALL_AGES.to_string()
+            (STR_ALL_AGES.to_string(), None)
         } else if selected.len() == 1 {
-            get_age_text(self, selected, false)
+            (get_age_text(self, selected, false), None)
         } else {
             let first_age_text = get_age_text(self, selected, false);
             let last_age_text = get_age_text(self, selected, true);
-            let mut age_text = String::new();
-            if !first_age_text.is_empty() && !last_age_text.is_empty() {
-                age_text.push_str(&first_age_text);
-                age_text.push_str(STR_DASH);
-                age_text.push_str(&last_age_text);
-            }
-            age_text
+
+            (first_age_text, Some(last_age_text))
         }
     }
 }
@@ -40,7 +36,7 @@ fn get_age_text(ages: &[AgeRange], selected: &[AgeRangeId], get_last: bool) -> S
                     .unwrap_or(&age_range.display_name)
                     .to_string()
             })
-            .unwrap_or_default(),
+            .unwrap_ji(),
         true => ages
             .iter()
             .rev()
@@ -52,6 +48,6 @@ fn get_age_text(ages: &[AgeRange], selected: &[AgeRangeId], get_last: bool) -> S
                     .unwrap_or(&age_range.display_name)
                     .to_string()
             })
-            .unwrap_or_default(),
+            .unwrap_ji(),
     }
 }

--- a/frontend/elements/src/_bundles/home/imports.ts
+++ b/frontend/elements/src/_bundles/home/imports.ts
@@ -36,3 +36,4 @@ import "@elements/entry/home/home/search-results/search-results-section";
 import "@elements/entry/home/home/search-results/search-result";
 import "@elements/entry/home/home/search-results/search-result-details";
 import "@elements/entry/home/home/search-results/search-result-category";
+import "@elements/entry/jig/_common/age-range";

--- a/frontend/elements/src/_bundles/jig/edit/imports.ts
+++ b/frontend/elements/src/_bundles/jig/edit/imports.ts
@@ -37,6 +37,7 @@ import "@elements/entry/jig/edit/sidebar/module/menu";
 import "@elements/entry/jig/edit/sidebar/module/window";
 import "@elements/entry/jig/edit/sidebar/header";
 import "@elements/entry/jig/_common/sidebar-modules/module";
+import "@elements/entry/jig/_common/age-range";
 import "@elements/entry/jig/edit/sidebar/publish";
 import "@elements/entry/jig/edit/sidebar/filler";
 import "@elements/entry/jig/edit/sidebar/close-button";

--- a/frontend/elements/src/_bundles/jig/play/imports.ts
+++ b/frontend/elements/src/_bundles/jig/play/imports.ts
@@ -24,6 +24,7 @@ import "@elements/entry/jig/play/jig/timer-indicator";
 import "@elements/entry/jig/play/jig/time-up-popup";
 import "@elements/entry/jig/play/jig/done-popup";
 import "@elements/entry/jig/_common/sidebar-modules/module";
+import "@elements/entry/jig/_common/age-range";
 import "@elements/entry/jig/play/jig/sidebar/action";
 import "@elements/entry/jig/play/jig/sidebar/jig-info";
 import "@elements/entry/jig/play/jig/sidebar/report";

--- a/frontend/elements/src/core/modals/confirm.ts
+++ b/frontend/elements/src/core/modals/confirm.ts
@@ -1,5 +1,6 @@
 import { LitElement, html, css, customElement, property } from "lit-element";
 import { classMap } from "lit-html/directives/class-map";
+import { unsafeHTML } from "lit-html/directives/unsafe-html";
 import { BaseButton } from "@elements/_styles/buttons";
 import "@elements/core/buttons/icon";
 import "@elements/core/buttons/rectangle";
@@ -200,12 +201,6 @@ export class _ extends BaseButton {
         `;
     }
 
-    renderContent() {
-        return html`
-            <div class="content">${this.content}</div>
-        `;
-    }
-
     render() {
         return html`
             <div class="overlay" @click=${this.onAnyClick}></div>
@@ -219,7 +214,11 @@ export class _ extends BaseButton {
                 <div class="contents">
                     ${this.renderTitle()}
                     <div class="divider"></div>
-                    ${this.renderContent()}
+                    <div class="content">
+                        <slot name="content">
+                            ${this.content}
+                        </slot>
+                    </div>
                     ${this.renderActions()}
                 </div>
             </div>

--- a/frontend/elements/src/entry/home/home/search-results/search-result.ts
+++ b/frontend/elements/src/entry/home/home/search-results/search-result.ts
@@ -325,9 +325,6 @@ export class _ extends LitElement {
     likedCount: number = 0;
 
     @property()
-    ages: string = "";
-
-    @property()
     language: string = "";
 
     @property({ type: Boolean, reflect: true })
@@ -394,12 +391,7 @@ export class _ extends LitElement {
                         ${this.renderCount(STR_LIKED, this.likedCount)}
                     </div>
                     <div class="ages-language">
-                        <div class="age">
-                            <img-ui
-                                path="entry/home/search-results/age.svg"
-                            ></img-ui>
-                            <span class="count">${this.ages}</span>
-                        </div>
+                        <slot name="ages"></slot>
                         <div class="language">
                             <img-ui
                                 path="entry/home/search-results/language.svg"

--- a/frontend/elements/src/entry/jig/_common/age-range.ts
+++ b/frontend/elements/src/entry/jig/_common/age-range.ts
@@ -1,0 +1,57 @@
+import { LitElement, html, css, customElement, property } from "lit-element";
+import { nothing } from "lit-html";
+
+@customElement("age-range")
+export class _ extends LitElement {
+    static get styles() {
+        return [
+            css`
+                :host {
+                    font-size: 14px;
+                    display: flex;
+                    font-weight: 600;
+                    column-gap: 4px;
+                    align-items: center;
+                }
+            `,
+        ];
+    }
+
+    @property({ type: String })
+    icon!: string;
+
+    @property({ type: String })
+    from?: string;
+
+    @property({ type: String })
+    to?: string;
+
+    renderFrom() {
+        return html`<span class="from">${this.from}</span>`
+    }
+
+    renderTo() {
+        if (!this.to) {
+            return nothing;
+        }
+
+        return html`
+            <fa-icon icon="fa-thin fa-arrow-right"></fa-icon>
+            <span class="to">${this.to}</span>
+        `;
+    }
+
+    render() {
+        if (!this.from) {
+            // If the from age isn't set then don't render anything.
+            return nothing;
+        }
+
+        return html`
+            <img-ui path=${this.icon}></img-ui>
+            ${this.renderFrom()}
+            ${this.renderTo()}
+        `;
+    }
+}
+

--- a/frontend/elements/src/entry/jig/gallery/recent.ts
+++ b/frontend/elements/src/entry/jig/gallery/recent.ts
@@ -95,9 +95,6 @@ export class _ extends LitElement {
     draft = false;
 
     @property()
-    ages: string = "";
-
-    @property()
     publishedAt: string = "";
 
     @property()
@@ -133,14 +130,7 @@ export class _ extends LitElement {
                     </div>
                     <div class="bottom-section">
                         <span class="label main-text">${this.label}</span>
-                        <span class="ages">
-                            <img-ui
-                                path="entry/jig/gallery/age-icon${this.draft
-                                    ? "-draft"
-                                    : ""}.svg"
-                            ></img-ui>
-                            ${this.ages}
-                        </span>
+                        <slot name="ages"></slot>
                         <span class="last-edited">${this.publishedAt}</span>
                     </div>
                 </div>

--- a/frontend/elements/src/entry/jig/play/jig/sidebar/jig-info.ts
+++ b/frontend/elements/src/entry/jig/play/jig/sidebar/jig-info.ts
@@ -129,9 +129,6 @@ export class _ extends LitElement {
     likedCount?: number;
 
     @property()
-    ages: string = "";
-
-    @property()
     language: string = "";
 
     @property({ type: Boolean })
@@ -176,10 +173,7 @@ export class _ extends LitElement {
                         </div>
                         <div class="second-line">
                             <span>
-                                <img-ui
-                                    path="entry/jig/play/sidebar/age.svg"
-                                ></img-ui>
-                                ${this.ages}
+                                <slot name="ages"></slot>
                             </span>
                             <span>
                                 <img-ui

--- a/frontend/elements/src/module/_groups/cards/_common/main-empty.ts
+++ b/frontend/elements/src/module/_groups/cards/_common/main-empty.ts
@@ -2,7 +2,7 @@ import { LitElement, html, css, customElement, property } from "lit-element";
 import { classMap } from "lit-html/directives/class-map";
 import { nothing } from "lit-html";
 
-const STR_EMPTY = "No preview yet";
+const STR_EMPTY = "Add words to get started";
 
 @customElement("main-empty")
 export class _ extends LitElement {


### PR DESCRIPTION
Closes #2582, #2503 and #2607

- Adds a `content_html` property;
- Updates the delete JIG modal to include a new warning;
- Updates "Done" to "Generate" for card game lists;
- Updates the copy when a card games content hasn't been generated yet;
- Updates the age range so that it uses a FontAwesome arrow instead of `-`.

![Screenshot 2022-06-10 at 12 36 45](https://user-images.githubusercontent.com/4161106/173200674-3a243ecf-19c5-42b8-8fe2-53cdb94c7c97.png)
![Screenshot 2022-06-10 at 12 41 46](https://user-images.githubusercontent.com/4161106/173200678-220388f4-da95-4c54-9125-34210969c27e.png)
![Screenshot 2022-06-11 at 20 27 03](https://user-images.githubusercontent.com/4161106/173200686-d2a2ca02-0419-4bcf-baf2-614f3e33efdf.png)
![Screenshot 2022-06-11 at 20 28 42](https://user-images.githubusercontent.com/4161106/173200689-70ef0206-45db-442a-9ded-a1b9b85e6cbf.png)
