### PR TITLE
fix(fe/module/matching): Improve placement of option row during play

### DIFF
--- a/frontend/elements/src/module/matching/_common/main/container.ts
+++ b/frontend/elements/src/module/matching/_common/main/container.ts
@@ -14,21 +14,26 @@ export class _ extends LitElement {
                     display: flex;
                     flex-direction: column;
                     align-items: center;
-                    justify-content: space-between;
+                    justify-content: center;
                     width: 100%;
                     height: 100%;
                 }
 
                 .top {
+                    display: flex;
                     margin-top: 38rem;
                     gap: 64rem;
                 }
                 .bottom {
+                    display: flex;
                     margin-bottom: 38rem;
                     gap: 38rem;
                 }
-                section {
+                .container {
                     display: flex;
+                    flex-direction: column;
+                    align-items: center;
+                    gap: 38rem;
                 }
                 .drag {
                     position: absolute;
@@ -41,15 +46,17 @@ export class _ extends LitElement {
 
     render() {
         return html`
-            <section class="top">
-                <slot name="top"></slot>
+            <section class="container">
+                <section class="top">
+                    <slot name="top"></slot>
+                </section>
+                <section class="bottom">
+                    <slot name="bottom"></slot>
+                </section>
+                <div class="drag">
+                    <slot name="drag"></slot>
+                </div>
             </section>
-            <section class="bottom">
-                <slot name="bottom"></slot>
-            </section>
-            <div class="drag">
-                <slot name="drag"></slot>
-            </div>
         `;
     }
 }


### PR DESCRIPTION
Resolves #2757

- Updates matching activity layout to be similar to card-quiz so that the bottom row should not be behind the navigation bar.