### PR TITLE
fix(fe/module/matching): Prevent card reappearing when an empty-card is clicked

### DIFF
--- a/frontend/apps/crates/entry/module/matching/play/src/base/game/card/dom.rs
+++ b/frontend/apps/crates/entry/module/matching/play/src/base/game/card/dom.rs
@@ -59,7 +59,11 @@ pub fn render_bottom(state: Rc<CardBottom>) -> Dom {
         .style("touch-action", "none")
         .event(clone!(state => move |evt:events::PointerDown| {
             let elem: HtmlElement = evt.dyn_target().unwrap_ji();
-            super::actions::start_drag(state.clone(), elem, evt.x(), evt.y());
+            if let BottomPhase::Show = state.phase.get_cloned() {
+                // Only fire off start_drag if the card the teacher is attempting to drag is _not_
+                // an empty-card.
+                super::actions::start_drag(state.clone(), elem, evt.x(), evt.y());
+            }
         }))
         .child_signal(state.phase.signal_cloned().map(clone!(state => move |phase| {
             let theme_id = state.theme_id;

--- a/frontend/elements/src/module/_groups/cards/play/card/empty.ts
+++ b/frontend/elements/src/module/_groups/cards/play/card/empty.ts
@@ -21,6 +21,9 @@ export class _ extends LitElement {
         return [
             ...cardStyles,
             css`
+                :host {
+                    cursor: default;
+                }
                 .translucent {
                     border: solid 2rem var(--light-blue-4);
                     background-color: rgba(255, 255, 255, 0.8);


### PR DESCRIPTION
- Resolves issue where an empty card could be clicked and the original card shows up in it's place.

### Before 

https://user-images.githubusercontent.com/4161106/173320222-bbb9a3c6-28b5-4ae0-b1e4-5ab979bebc44.mov

### After


https://user-images.githubusercontent.com/4161106/173320395-39abafda-85c4-42c6-9362-670724603e98.mov

