### PR TITLE
fix(fe/module/matching): Ensure that play navigation bar is always clickable

### DIFF
--- a/frontend/apps/crates/entry/module/matching/play/src/base/game/card/dom.rs
+++ b/frontend/apps/crates/entry/module/matching/play/src/base/game/card/dom.rs
@@ -75,10 +75,7 @@ pub fn render_bottom(state: Rc<CardBottom>) -> Dom {
                 BottomPhase::Show => {
                     let mut options = CardOptions::new(card, theme_id, mode, side, Size::Matching);
                     options.flipped = true;
-                    render_card_mixin(options, |dom| {
-                        // block events on the element so that it's parent gets them (needed for touch)
-                        dom.style("pointer-events", "none")
-                    })
+                    render_card(options)
                 },
                 BottomPhase::Remove => {
                     let options = EmptyCardOptions::new(EmptyKind::Translucent, theme_id, Size::Matching);


### PR DESCRIPTION
- Fixes issue when clicking/dragging a matching activity option, the play nav bar becomes temporarily unclickable and the student would have to click it twice to navigate to the next/previous activity.
  - I have tested that pointer events still work correctly using the xcode simulator with 9th gen Ipad