### PR TITLE
feat(be/image): add image metrics functionality

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -55,6 +55,8 @@ ALGOLIA_PROJECT_ID=<algolia_project_id>
 ALGOLIA_MEDIA_INDEX=<index_name>
 ALGOLIA_JIG_INDEX=<index_name>
 ALGOLIA_COURSE_INDEX=<index_name>
+ALGOLIA_BADGE_INDEX=<index_name>
+ALGOLIA_PUBLIC_USER_INDEX=<index_name>
 
 # The key the backend uses for managing- indexing- `MEDIA_INDEX`.
 # Needs the `addObject`, `deleteObject`, `settings`, and `editSettings` ACLs and access to `MEDIA_INDEX`.

--- a/backend/api/migrations/20220419233654_image_user_usage.sql
+++ b/backend/api/migrations/20220419233654_image_user_usage.sql
@@ -1,0 +1,29 @@
+create table image_usage (
+    image_id                uuid                                  not null
+         references image_metadata(id)
+         on delete cascade,
+
+    -- timestamp which 
+    reset_at              timestamp         default now()       not null
+);
+
+alter table image_metadata 
+
+
+create trigger update_path_like
+    after insert
+    on learning_path_like
+    for each row
+execute procedure update_imageh_like();
+
+create function update_image_usage() returns trigger
+    language plpgsql
+as
+$$
+begin
+    update learning_path
+    set liked_count = liked_count - 1
+    where id = OLD.learning_path_id;
+    return NULL;
+end;
+$$;      

--- a/backend/api/migrations/20220613233654_image_user_usage.sql
+++ b/backend/api/migrations/20220613233654_image_user_usage.sql
@@ -28,7 +28,7 @@ as
 $$
 BEGIN
     UPDATE image_metadata
-    SET user_usage = 0,
+    SET usage = 0,
         last_synced_at = NULL
     WHERE id = NEW.image_id;
     RETURN NULL;

--- a/backend/api/migrations/20220613233654_image_user_usage.sql
+++ b/backend/api/migrations/20220613233654_image_user_usage.sql
@@ -9,7 +9,7 @@ CREATE TABLE image_usage (
 );
 
 ALTER TABLE image_metadata
-    ADD COLUMN  user_usage     bigint            DEFAULT 0;
+    ADD COLUMN  usage     bigint     NOT NULL       DEFAULT 0;
 
 
 INSERT INTO image_usage(image_id)

--- a/backend/api/sqlx-data.json
+++ b/backend/api/sqlx-data.json
@@ -5687,6 +5687,132 @@
       ]
     }
   },
+  "a270f1b616f2b15b305f6f62a557348af3eefc9385b699d2b9d3e29501b9b94d": {
+    "query": "\nselect id,\n       name,\n       kind                                                                                     as \"kind!: ImageKind\",\n       description,\n       translated_description                                                                   as \"translated_description!: Json<HashMap<String, String>>\",\n       translated_name                                                                          as \"translated_name!: Json<HashMap<String, String>>\",\n       array((select affiliation_id from image_affiliation where image_id = image_metadata.id)) as \"affiliations!\",\n       array((select affiliation.display_name\n              from affiliation\n                       inner join image_affiliation on affiliation.id = image_affiliation.affiliation_id\n              where image_affiliation.image_id = image_metadata.id))                            as \"affiliation_names!\",\n       array((select style_id from image_style where image_id = image_metadata.id))             as \"styles!\",\n       array((select style.display_name\n              from style\n                       inner join image_style on style.id = image_style.style_id\n              where image_style.image_id = image_metadata.id))                                  as \"style_names!\",\n       array((select age_range_id from image_age_range where image_id = image_metadata.id))     as \"age_ranges!\",\n       array((select age_range.display_name\n              from age_range\n                       inner join image_age_range on age_range.id = image_age_range.age_range_id\n              where image_age_range.image_id = image_metadata.id))                              as \"age_range_names!\",\n       array((select category_id from image_category where image_id = image_metadata.id))       as \"categories!\",\n       array((select name\n              from category\n                       inner join image_category on category.id = image_category.category_id\n              where image_category.image_id = image_metadata.id))                               as \"category_names!\",\n       array((select index\n              from image_tag\n                       inner join image_tag_join on image_tag.index = image_tag_join.tag_index\n              where image_tag_join.image_id = image_metadata.id))                               as \"tags!\",\n       array((select display_name\n              from image_tag\n                       inner join image_tag_join on image_tag.index = image_tag_join.tag_index\n              where image_tag_join.image_id = image_metadata.id))                               as \"tag_names!\",\n       (publish_at < now() is true)                                                             as \"is_published!\",\n       is_premium,\n       usage                                                                               as \"usage!\"\nfrom image_metadata\n         join image_upload on id = image_id\nwhere ((last_synced_at is null and publish_at is not null) or\n       (updated_at is not null and last_synced_at < updated_at) or\n       (publish_at < now() is true and last_synced_at < publish_at))\n  and processed_at is not null\nlimit 100 for no key update skip locked;\n     ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 1,
+          "name": "name",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 2,
+          "name": "kind!: ImageKind",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 3,
+          "name": "description",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 4,
+          "name": "translated_description!: Json<HashMap<String, String>>",
+          "type_info": "Jsonb"
+        },
+        {
+          "ordinal": 5,
+          "name": "translated_name!: Json<HashMap<String, String>>",
+          "type_info": "Jsonb"
+        },
+        {
+          "ordinal": 6,
+          "name": "affiliations!",
+          "type_info": "UuidArray"
+        },
+        {
+          "ordinal": 7,
+          "name": "affiliation_names!",
+          "type_info": "TextArray"
+        },
+        {
+          "ordinal": 8,
+          "name": "styles!",
+          "type_info": "UuidArray"
+        },
+        {
+          "ordinal": 9,
+          "name": "style_names!",
+          "type_info": "TextArray"
+        },
+        {
+          "ordinal": 10,
+          "name": "age_ranges!",
+          "type_info": "UuidArray"
+        },
+        {
+          "ordinal": 11,
+          "name": "age_range_names!",
+          "type_info": "TextArray"
+        },
+        {
+          "ordinal": 12,
+          "name": "categories!",
+          "type_info": "UuidArray"
+        },
+        {
+          "ordinal": 13,
+          "name": "category_names!",
+          "type_info": "TextArray"
+        },
+        {
+          "ordinal": 14,
+          "name": "tags!",
+          "type_info": "Int2Array"
+        },
+        {
+          "ordinal": 15,
+          "name": "tag_names!",
+          "type_info": "TextArray"
+        },
+        {
+          "ordinal": 16,
+          "name": "is_published!",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 17,
+          "name": "is_premium",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 18,
+          "name": "usage!",
+          "type_info": "Int8"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        false,
+        false
+      ]
+    }
+  },
   "a293497e635f9a60d77be04ce0babce3020ea53f4a0e230ba5725914125e9120": {
     "query": "\nselect id                                                                 as \"id!: CategoryId\",\n       name                                                               as \"name!\",\n       created_at                                                         as \"created_at!\",\n       updated_at,\n       user_scopes                                                        as \"user_scopes!\"\nfrom category\n         inner join unnest($1::uuid[]) with ordinality t(id, ord) USING (id)\norder by t.ord\n",
     "describe": {
@@ -6145,6 +6271,16 @@
         true,
         true
       ]
+    }
+  },
+  "ab3f65700794b2255239083c9b4a2f553f0cd5764404fd40325b6bdff3724243": {
+    "query": "\n        update image_usage \n        set usage_reset_at = now()\n        where usage_reset_at < now() - interval '14 days'\n            ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": []
     }
   },
   "ab605fef6d23ea4a74e80999574296f7b4fce2ed0029455be3d6541ee379d329": {
@@ -7579,126 +7715,6 @@
       ]
     }
   },
-  "ce9e27f3b2f4fb74c3b4ce289cb0cf3376cd84ff6b514a8b5fb783fc555bcea0": {
-    "query": "\nselect id,\n       name,\n       kind                                                                                     as \"kind!: ImageKind\",\n       description,\n       translated_description                                                                   as \"translated_description!: Json<HashMap<String, String>>\",\n       translated_name                                                                          as \"translated_name!: Json<HashMap<String, String>>\",\n       array((select affiliation_id from image_affiliation where image_id = image_metadata.id)) as \"affiliations!\",\n       array((select affiliation.display_name\n              from affiliation\n                       inner join image_affiliation on affiliation.id = image_affiliation.affiliation_id\n              where image_affiliation.image_id = image_metadata.id))                            as \"affiliation_names!\",\n       array((select style_id from image_style where image_id = image_metadata.id))             as \"styles!\",\n       array((select style.display_name\n              from style\n                       inner join image_style on style.id = image_style.style_id\n              where image_style.image_id = image_metadata.id))                                  as \"style_names!\",\n       array((select age_range_id from image_age_range where image_id = image_metadata.id))     as \"age_ranges!\",\n       array((select age_range.display_name\n              from age_range\n                       inner join image_age_range on age_range.id = image_age_range.age_range_id\n              where image_age_range.image_id = image_metadata.id))                              as \"age_range_names!\",\n       array((select category_id from image_category where image_id = image_metadata.id))       as \"categories!\",\n       array((select name\n              from category\n                       inner join image_category on category.id = image_category.category_id\n              where image_category.image_id = image_metadata.id))                               as \"category_names!\",\n       array((select index\n              from image_tag\n                       inner join image_tag_join on image_tag.index = image_tag_join.tag_index\n              where image_tag_join.image_id = image_metadata.id))                               as \"tags!\",\n       array((select display_name\n              from image_tag\n                       inner join image_tag_join on image_tag.index = image_tag_join.tag_index\n              where image_tag_join.image_id = image_metadata.id))                               as \"tag_names!\",\n       (publish_at < now() is true)                                                             as \"is_published!\",\n       is_premium\nfrom image_metadata\n         join image_upload on id = image_id\nwhere ((last_synced_at is null and publish_at is not null) or\n       (updated_at is not null and last_synced_at < updated_at) or\n       (publish_at < now() is true and last_synced_at < publish_at))\n  and processed_at is not null\nlimit 100 for no key update skip locked;\n     ",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 1,
-          "name": "name",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 2,
-          "name": "kind!: ImageKind",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 3,
-          "name": "description",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 4,
-          "name": "translated_description!: Json<HashMap<String, String>>",
-          "type_info": "Jsonb"
-        },
-        {
-          "ordinal": 5,
-          "name": "translated_name!: Json<HashMap<String, String>>",
-          "type_info": "Jsonb"
-        },
-        {
-          "ordinal": 6,
-          "name": "affiliations!",
-          "type_info": "UuidArray"
-        },
-        {
-          "ordinal": 7,
-          "name": "affiliation_names!",
-          "type_info": "TextArray"
-        },
-        {
-          "ordinal": 8,
-          "name": "styles!",
-          "type_info": "UuidArray"
-        },
-        {
-          "ordinal": 9,
-          "name": "style_names!",
-          "type_info": "TextArray"
-        },
-        {
-          "ordinal": 10,
-          "name": "age_ranges!",
-          "type_info": "UuidArray"
-        },
-        {
-          "ordinal": 11,
-          "name": "age_range_names!",
-          "type_info": "TextArray"
-        },
-        {
-          "ordinal": 12,
-          "name": "categories!",
-          "type_info": "UuidArray"
-        },
-        {
-          "ordinal": 13,
-          "name": "category_names!",
-          "type_info": "TextArray"
-        },
-        {
-          "ordinal": 14,
-          "name": "tags!",
-          "type_info": "Int2Array"
-        },
-        {
-          "ordinal": 15,
-          "name": "tag_names!",
-          "type_info": "TextArray"
-        },
-        {
-          "ordinal": 16,
-          "name": "is_published!",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 17,
-          "name": "is_premium",
-          "type_info": "Bool"
-        }
-      ],
-      "parameters": {
-        "Left": []
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        false
-      ]
-    }
-  },
   "ceee83d2943409d2f3a3e5a70b7ae3d423d39cf2b15af44565c6f4100abcfc31": {
     "query": "insert into user_pdf_upload (pdf_id) values($1)",
     "describe": {
@@ -8805,6 +8821,18 @@
         true,
         true
       ]
+    }
+  },
+  "eb44eafd34c17ff3cd679cd11f53fcde64f4b6039ba2b1625dd2c78ca2494a2d": {
+    "query": "\nupdate image_metadata \nset usage = usage + 1\nwhere id = $1\n",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      },
+      "nullable": []
     }
   },
   "eb85238e221f20b3ad291f2bc9f6db1c632136d7e15358dbf5d0947c60a3aaa6": {

--- a/backend/api/src/algolia.rs
+++ b/backend/api/src/algolia.rs
@@ -83,7 +83,7 @@ struct BatchImage<'a> {
     tags: Vec<&'static str>,
     translated_name: &'a Vec<String>,
     translated_description: &'a Vec<String>,
-    user_usage: &'a i64,
+    usage: &'a i64,
 }
 #[derive(Serialize)]
 struct BatchCourse<'a> {
@@ -291,16 +291,13 @@ impl Manager {
         for i in index {
             match i.as_str() {
                 migration::MEDIA_INDEX => {
-                    continue;
-                    // migration::media_index(&mut txn, &self.inner, &self.media_index).await?
+                    migration::media_index(&mut txn, &self.inner, &self.media_index).await?
                 }
                 migration::JIG_INDEX => {
-                    continue;
-                    // migration::jig_index(&mut txn, &self.inner, &self.jig_index).await?
+                    migration::jig_index(&mut txn, &self.inner, &self.jig_index).await?
                 }
                 migration::COURSE_INDEX => {
-                    continue;
-                    // migration::course_index(&mut txn, &self.inner, &self.course_index).await?
+                    migration::course_index(&mut txn, &self.inner, &self.course_index).await?
                 }
                 migration::BADGE_INDEX => {
                     migration::badge_index(&mut txn, &self.inner, &self.badge_index).await?
@@ -595,7 +592,7 @@ select id,
               where image_tag_join.image_id = image_metadata.id))                               as "tag_names!",
        (publish_at < now() is true)                                                             as "is_published!",
        is_premium,
-       user_usage                                                                               as "user_usage!"
+       usage                                                                               as "usage!"
 from image_metadata
          join image_upload on id = image_id
 where ((last_synced_at is null and publish_at is not null) or
@@ -645,7 +642,7 @@ limit 100 for no key update skip locked;
                 categories: &row.categories,
                 category_names: &row.category_names,
                 tags,
-                user_usage: &row.user_usage
+                usage: &row.usage
             }))
             .expect("failed to serialize BatchImage to json")
             {

--- a/backend/api/src/algolia/migration.rs
+++ b/backend/api/src/algolia/migration.rs
@@ -23,7 +23,6 @@ pub(crate) async fn media_index(
         searchable_attributes: Some(
             SearchableAttributes::build()
                 .single(Attribute("name".to_owned()))
-                .single(Attribute("description".to_owned()))
                 .single(Attribute("translated_description".to_owned()))
                 .single(Attribute("translated_name".to_owned()))
                 .finish(),

--- a/backend/api/src/db/image.rs
+++ b/backend/api/src/db/image.rs
@@ -263,7 +263,7 @@ pub async fn add_usage(db: &PgPool, id: ImageId) -> sqlx::Result<()> {
     sqlx::query!(
         r#"
 update image_metadata 
-set user_usage = user_usage + 1
+set usage = usage + 1
 where id = $1
 "#,
         id.0,

--- a/backend/api/src/db/image.rs
+++ b/backend/api/src/db/image.rs
@@ -259,6 +259,21 @@ order by ord
     .fetch(db)
 }
 
+pub async fn add_usage(db: &PgPool, id: ImageId) -> sqlx::Result<()> {
+    sqlx::query!(
+        r#"
+update image_metadata 
+set user_usage = user_usage + 1
+where id = $1
+"#,
+        id.0,
+    )
+    .execute(db)
+    .await?;
+
+    Ok(())
+}
+
 pub async fn delete(db: &PgPool, image: ImageId) -> sqlx::Result<()> {
     let mut conn = db.begin().await?;
 

--- a/backend/api/src/http/endpoints/image.rs
+++ b/backend/api/src/http/endpoints/image.rs
@@ -304,7 +304,7 @@ fn check_usage_exists(err: sqlx::Error) -> error::NotFound {
 }
 
 /// Add user usage of an Image
-async fn put_image_usage(
+async fn use_image(
     db: Data<PgPool>,
     _claims: TokenUser,
     req: Path<ImageId>,
@@ -356,7 +356,7 @@ pub fn configure(cfg: &mut ServiceConfig) {
     )
     .route(
         image::PutImageUsage::PATH,
-        image::PutImageUsage::METHOD.route().to(put_image_usage),
+        image::PutImageUsage::METHOD.route().to(use_image),
     )
     .route(
         image::Upload::PATH,

--- a/backend/api/src/jwk.rs
+++ b/backend/api/src/jwk.rs
@@ -146,13 +146,6 @@ pub struct IdentityClaims {
     pub expire_at: u64,
 }
 
-#[derive(Debug, Deserialize)]
-struct FirebaseClaims {
-    pub sub: String,
-    pub iat: u64,
-    pub auth_time: u64,
-}
-
 #[derive(Debug)]
 pub struct JwkVerifier {
     // use a vec instead of a hashmap because there are typically

--- a/shared/rust/src/api/endpoints/image.rs
+++ b/shared/rust/src/api/endpoints/image.rs
@@ -150,6 +150,6 @@ impl ApiEndpoint for PutImageUsage {
     type Req = ();
     type Res = ();
     type Err = EmptyError;
-    const PATH: &'static str = "/v1/image/{id}/usage";
-    const METHOD: Method = Method::Put;
+    const PATH: &'static str = "/v1/image/{id}/use";
+    const METHOD: Method = Method::Patch;
 }

--- a/shared/rust/src/api/endpoints/image.rs
+++ b/shared/rust/src/api/endpoints/image.rs
@@ -143,3 +143,13 @@ impl ApiEndpoint for Delete {
     const PATH: &'static str = "/v1/image/{id}";
     const METHOD: Method = Method::Delete;
 }
+
+/// Update usage of an Image for metric purposes
+pub struct PutImageUsage;
+impl ApiEndpoint for PutImageUsage {
+    type Req = ();
+    type Res = ();
+    type Err = EmptyError;
+    const PATH: &'static str = "/v1/image/{id}/usage";
+    const METHOD: Method = Method::Put;
+}


### PR DESCRIPTION
closes https://github.com/ji-devs/ji-cloud/issues/2762

## What?
Image metrics to improve Algolia searches with the most used images, yielding the most popular images to appear at the top of the search list. After two weeks, the api will reset the `usage` count for images, and a new rotation of popular images will be displayed first. 

## How? 
I added a new table, `image_usage`, with columns `image_id` and `usage_reset_at`(holds a timestamp for 14 days). When `PATCH v1/image/{image_id}/use` is called, this will increment an images `usage` field in `image_metadata`. In the Algolia image updater task, the `usage_reset_at` will reset to the current timestamp after two weeks. In Algolia, I set ranking to be a  custom rank attribute.