### PR TITLE
fix(be/jig/clone): remove published_at data from original jig

### DIFF
--- a/backend/api/sqlx-data.json
+++ b/backend/api/sqlx-data.json
@@ -2987,6 +2987,29 @@
       "nullable": []
     }
   },
+  "5af456ed10859f7286c2c13a2b62e19b4fcf8d3fae4b625605eb352189adb5af": {
+    "query": "\ninsert into jig (creator_id, author_id, parents, live_id, draft_id, jig_focus)\nselect creator_id, $2, array_append(parents, $1), $3, $4, jig_focus\nfrom jig\nwhere id = $1\nreturning id as \"id!: JigId\"\n",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id!: JigId",
+          "type_info": "Uuid"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Uuid",
+          "Uuid",
+          "Uuid"
+        ]
+      },
+      "nullable": [
+        false
+      ]
+    }
+  },
   "5afaa3307160dc3533595bb23eee566063c5438ab380b5cc6b4a43ca70587f05": {
     "query": "\n        select user_id,\n        (\n           select\n             case \n                when exists(select 1 from user_auth_basic where lower(user_auth_basic.email) = lower($1::text)) = true then false\n                else true\n            end\n        )     as \"is_oauth!\"      \n         from user_email \n         where lower(email) = lower($1::text)",
     "describe": {
@@ -6452,29 +6475,6 @@
         true,
         true,
         true
-      ]
-    }
-  },
-  "ada31ac34d9d4b99d869df3190ad4e105413aa9db4e285b48d7b04eca85d63ca": {
-    "query": "\ninsert into jig (creator_id, author_id, parents, live_id, draft_id, published_at, jig_focus)\nselect creator_id, $2, array_append(parents, $1), $3, $4, published_at, jig_focus\nfrom jig\nwhere id = $1\nreturning id as \"id!: JigId\"\n",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id!: JigId",
-          "type_info": "Uuid"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Uuid",
-          "Uuid",
-          "Uuid"
-        ]
-      },
-      "nullable": [
-        false
       ]
     }
   },

--- a/backend/api/src/db/jig.rs
+++ b/backend/api/src/db/jig.rs
@@ -1240,8 +1240,8 @@ pub async fn clone_jig(
     let new_jig = sqlx::query!(
         //language=SQL
         r#"
-insert into jig (creator_id, author_id, parents, live_id, draft_id, published_at, jig_focus)
-select creator_id, $2, array_append(parents, $1), $3, $4, published_at, jig_focus
+insert into jig (creator_id, author_id, parents, live_id, draft_id, jig_focus)
+select creator_id, $2, array_append(parents, $1), $3, $4, jig_focus
 from jig
 where id = $1
 returning id as "id!: JigId"


### PR DESCRIPTION
closes https://github.com/ji-devs/ji-cloud/issues/2833

## Fix 
`Published_at` data was being cloned as well. Removing this will prevent cloned jig from showing up on published Jigs list.