### PR TITLE
fix(be/badge): redo triggers for badge_member

### DIFF
--- a/backend/api/migrations/20220616210310_fix-badge-trigger.sql
+++ b/backend/api/migrations/20220616210310_fix-badge-trigger.sql
@@ -1,0 +1,65 @@
+-- Fixes
+-- 1. incorrect variable name for badge member functions and 
+-- 2. rename function and trigger names
+
+drop trigger add_members_count on badge_member;
+drop trigger members_count_leave on badge_member;
+drop function update_members_count_join();
+drop function update_members_count_leave();
+drop function bump_badge_updated_at(); 
+
+alter table badge_member
+    add column joined_at        timestamp with time zone      not null    default now();
+
+create function update_member_count_join() returns trigger
+    language plpgsql
+as
+$$
+begin
+    update badge
+    set member_count = member_count + 1
+    where id = NEW.id;
+    return NEW;
+end;
+$$;
+
+create trigger member_count_add
+    after insert
+    on badge_member
+    for each row
+execute procedure update_member_count_join();
+
+create function update_member_count_leave() returns trigger
+    language plpgsql
+as
+$$
+begin
+    update badge
+    set member_count = member_count - 1
+    where id = OLD.id;
+    return NULL;
+end;
+$$;
+
+create trigger member_count_leave
+    after delete
+    on badge_member
+    for each row
+execute procedure update_member_count_leave();
+
+create function bump_badge_updated_at() returns trigger
+    language plpgsql
+as
+$$
+begin
+    update badge set last_synced_at = null where new.id = badge.id or old.id = badge.id;
+    return null;
+end;
+$$;
+
+create trigger bump_badge_updated
+    after insert or delete
+    on badge_member
+    for each row
+execute procedure bump_badge_updated_at();
+

--- a/backend/api/sqlx-data.json
+++ b/backend/api/sqlx-data.json
@@ -668,58 +668,6 @@
       ]
     }
   },
-  "0ed109c3a80e39c71fee8fbd935ac8d21a0862c559c49a09ac708f5749d2bbd7": {
-    "query": "\n        with cte as (\n            select array(select id  as \"id!\"\n            from \"badge\"\n            where creator_id = $1 or $1 is null\n            order by coalesce(updated_at, created_at)) as id\n        ),\n        cte1 as (\n            select * from unnest((select distinct id from cte)) with ordinality t(id\n           , ord) order by ord\n        )\n        select  badge.id            as \"badge_id!: BadgeId\",\n                display_name        as \"display_name!\",\n                description         as \"description!\",\n                thumbnail           as \"thumbnail!\",\n                member_count  as \"member_count!: u32\",\n                creator_id    as \"creator_id!\"\n        from \"badge\"\n            inner join cte1 on cte1.id = \"badge\".id\n            where ord > (1 * $2 * $3)\n            order by ord \n            limit $3\n            ",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "badge_id!: BadgeId",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 1,
-          "name": "display_name!",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 2,
-          "name": "description!",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 3,
-          "name": "thumbnail!",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 4,
-          "name": "member_count!: u32",
-          "type_info": "Int8"
-        },
-        {
-          "ordinal": 5,
-          "name": "creator_id!",
-          "type_info": "Uuid"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Int4",
-          "Int4"
-        ]
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false,
-        false
-      ]
-    }
-  },
   "0eef5ce484b8cb531f0475e452c41a554fcdc8a2788c3ce5079f5992cac8991e": {
     "query": "\nselect id            as \"badge_id: BadgeId\",\n       display_name,\n       description,\n       thumbnail,\n       member_count,\n       creator_id\nfrom badge\nwhere id = $1\n",
     "describe": {
@@ -5414,6 +5362,58 @@
         ]
       },
       "nullable": []
+    }
+  },
+  "954f689bd8a447d0d4a611bc7a44ab0d5c478e223941be58d6fc48bb70d0a019": {
+    "query": "\n        with cte as (\n            select array(select id  as \"id!\"\n            from \"badge\"\n            where creator_id = $1 or $1 is null\n            order by coalesce(updated_at, created_at)) as id\n        ),\n        cte1 as (\n            select * from unnest((select distinct id from cte)) with ordinality t(id\n           , ord) order by ord\n        )\n        select  badge.id            as \"badge_id!: BadgeId\",\n                display_name        as \"display_name!\",\n                description         as \"description!\",\n                thumbnail           as \"thumbnail!\",\n                member_count        as \"member_count!\",\n                creator_id          as \"creator_id!\"\n        from \"badge\"\n            inner join cte1 on cte1.id = \"badge\".id\n            where ord > (1 * $2 * $3)\n            order by ord \n            limit $3\n            ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "badge_id!: BadgeId",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 1,
+          "name": "display_name!",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 2,
+          "name": "description!",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 3,
+          "name": "thumbnail!",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 4,
+          "name": "member_count!",
+          "type_info": "Int8"
+        },
+        {
+          "ordinal": 5,
+          "name": "creator_id!",
+          "type_info": "Uuid"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Int4",
+          "Int4"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
+      ]
     }
   },
   "95e80749cb3ce69fdb52cbc6de1835b2e5770c6a350ad0a8d05541eb17c788aa": {

--- a/backend/api/src/db/badge.rs
+++ b/backend/api/src/db/badge.rs
@@ -146,7 +146,7 @@ insert into badge_member(id, user_id) values($1, $2)
         id.0,
         user_id
     )
-    .fetch_one(db)
+    .execute(db)
     .await
     .map_err(|_| anyhow::anyhow!("User is already a member of this badge"))?;
 
@@ -190,8 +190,8 @@ pub async fn browse(
                 display_name        as "display_name!",
                 description         as "description!",
                 thumbnail           as "thumbnail!",
-                member_count  as "member_count!: u32",
-                creator_id    as "creator_id!"
+                member_count        as "member_count!",
+                creator_id          as "creator_id!"
         from "badge"
             inner join cte1 on cte1.id = "badge".id
             where ord > (1 * $2 * $3)
@@ -213,7 +213,7 @@ pub async fn browse(
             created_by: row.creator_id,
             description: row.description,
             thumbnail: Url::parse(&row.thumbnail).unwrap(),
-            member_count: row.member_count,
+            member_count: row.member_count as u32,
         })
         .collect();
 

--- a/shared/rust/src/api/endpoints/badge.rs
+++ b/shared/rust/src/api/endpoints/badge.rs
@@ -97,7 +97,7 @@ impl ApiEndpoint for JoinBadge {
     type Req = ();
     type Res = ();
     type Err = EmptyError;
-    const PATH: &'static str = "/v1/badge/{id}";
+    const PATH: &'static str = "/v1/badge/{id}/join";
     const METHOD: Method = Method::Post;
 }
 
@@ -107,7 +107,7 @@ impl ApiEndpoint for LeaveBadge {
     type Req = ();
     type Res = ();
     type Err = EmptyError;
-    const PATH: &'static str = "/v1/badge/{id}";
+    const PATH: &'static str = "/v1/badge/{id}/leave";
     const METHOD: Method = Method::Delete;
 }
 


### PR DESCRIPTION
@MendyBerger 

## Fixes
- corrected routes for join and leaving badges
- corrected `member_count` field in functions for `badge_member` table
- corrected query fetch for `member_count`
- added trigger to set `last_synced_at` to `null` after insert or delete on `badge_member` table