### PR TITLE
fix(be/algolia): uses manager instead of client for deleting

### DIFF
--- a/backend/api/src/algolia.rs
+++ b/backend/api/src/algolia.rs
@@ -976,6 +976,96 @@ limit 100 for no key update skip locked;
 
         Ok(true)
     }
+
+    pub async fn delete_image(&self, id: ImageId) {
+        if let Err(e) = self.try_delete_image(id).await {
+            log::warn!(
+                "failed to delete image with id {} from algolia: {}",
+                id.0.to_hyphenated(),
+                e
+            );
+        }
+    }
+
+    pub async fn try_delete_image(&self, ImageId(id): ImageId) -> anyhow::Result<()> {
+        self.inner
+            .delete_object(&self.media_index, &id.to_string())
+            .await?;
+
+        Ok(())
+    }
+
+    pub async fn delete_jig(&self, id: JigId) {
+        if let Err(e) = self.try_delete_jig(id).await {
+            log::warn!(
+                "failed to delete jig with id {} from algolia: {}",
+                id.0.to_hyphenated(),
+                e
+            );
+        }
+    }
+
+    pub async fn try_delete_jig(&self, JigId(id): JigId) -> anyhow::Result<()> {
+        self.inner
+            .delete_object(&self.jig_index, &id.to_string())
+            .await?;
+
+        Ok(())
+    }
+
+    pub async fn delete_badge(&self, id: BadgeId) {
+        if let Err(e) = self.try_delete_badge(id).await {
+            log::warn!(
+                "failed to delete badge with id {} from algolia: {}",
+                id.0.to_hyphenated(),
+                e
+            );
+        }
+    }
+
+    pub async fn try_delete_badge(&self, BadgeId(id): BadgeId) -> anyhow::Result<()> {
+        self.inner
+            .delete_object(&self.badge_index, &id.to_string())
+            .await?;
+
+        Ok(())
+    }
+
+    pub async fn delete_course(&self, id: CourseId) {
+        if let Err(e) = self.try_delete_course(id).await {
+            log::warn!(
+                "failed to delete course with id {} from algolia: {}",
+                id.0.to_hyphenated(),
+                e
+            );
+        }
+    }
+
+    pub async fn try_delete_course(&self, CourseId(id): CourseId) -> anyhow::Result<()> {
+        self.inner
+            .delete_object(&self.course_index, &id.to_string())
+            .await?;
+
+        Ok(())
+    }
+
+    pub async fn delete_public_user(&self, id: Uuid) {
+        if let Err(e) = self.try_delete_public_user(id).await {
+            log::warn!(
+                "failed to delete public user with id {} from algolia: {}",
+                id.to_hyphenated(),
+                e
+            );
+        }
+    }
+
+    pub async fn try_delete_public_user(&self, id: Uuid) -> anyhow::Result<()> {
+        self.inner
+            .delete_object(&self.public_user_index, &id.to_string())
+            .await?;
+
+        Ok(())
+    }
 }
 
 #[derive(Clone)]
@@ -1272,24 +1362,6 @@ impl Client {
         Ok(Some((results, pages, total_hits)))
     }
 
-    pub async fn delete_image(&self, id: ImageId) {
-        if let Err(e) = self.try_delete_image(id).await {
-            log::warn!(
-                "failed to delete image with id {} from algolia: {}",
-                id.0.to_hyphenated(),
-                e
-            );
-        }
-    }
-
-    pub async fn try_delete_image(&self, ImageId(id): ImageId) -> anyhow::Result<()> {
-        self.inner
-            .delete_object(&self.media_index, &id.to_string())
-            .await?;
-
-        Ok(())
-    }
-
     #[instrument(skip_all)]
     pub async fn search_jig(
         &self,
@@ -1420,24 +1492,6 @@ impl Client {
         Ok(Some((results, pages, total_hits)))
     }
 
-    pub async fn delete_jig(&self, id: JigId) {
-        if let Err(e) = self.try_delete_jig(id).await {
-            log::warn!(
-                "failed to delete jig with id {} from algolia: {}",
-                id.0.to_hyphenated(),
-                e
-            );
-        }
-    }
-
-    pub async fn try_delete_jig(&self, JigId(id): JigId) -> anyhow::Result<()> {
-        self.inner
-            .delete_object(&self.jig_index, &id.to_string())
-            .await?;
-
-        Ok(())
-    }
-
     #[instrument(skip_all)]
     pub async fn search_course(
         &self,
@@ -1548,24 +1602,6 @@ impl Client {
         Ok(Some((results, pages, total_hits)))
     }
 
-    pub async fn delete_course(&self, id: CourseId) {
-        if let Err(e) = self.try_delete_course(id).await {
-            log::warn!(
-                "failed to delete course with id {} from algolia: {}",
-                id.0.to_hyphenated(),
-                e
-            );
-        }
-    }
-
-    pub async fn try_delete_course(&self, CourseId(id): CourseId) -> anyhow::Result<()> {
-        self.inner
-            .delete_object(&self.course_index, &id.to_string())
-            .await?;
-
-        Ok(())
-    }
-
     #[instrument(skip_all)]
     pub async fn search_badge(
         &self,
@@ -1624,24 +1660,6 @@ impl Client {
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Some((results, pages, total_hits)))
-    }
-
-    pub async fn delete_badge(&self, id: BadgeId) {
-        if let Err(e) = self.try_delete_badge(id).await {
-            log::warn!(
-                "failed to delete badge with id {} from algolia: {}",
-                id.0.to_hyphenated(),
-                e
-            );
-        }
-    }
-
-    pub async fn try_delete_badge(&self, BadgeId(id): BadgeId) -> anyhow::Result<()> {
-        self.inner
-            .delete_object(&self.badge_index, &id.to_string())
-            .await?;
-
-        Ok(())
     }
 
     #[instrument(skip_all)]
@@ -1746,23 +1764,5 @@ impl Client {
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Some((results, pages, total_hits)))
-    }
-
-    pub async fn delete_public_user(&self, id: Uuid) {
-        if let Err(e) = self.try_delete_public_user(id).await {
-            log::warn!(
-                "failed to delete public user with id {} from algolia: {}",
-                id.to_hyphenated(),
-                e
-            );
-        }
-    }
-
-    pub async fn try_delete_public_user(&self, id: Uuid) -> anyhow::Result<()> {
-        self.inner
-            .delete_object(&self.public_user_index, &id.to_string())
-            .await?;
-
-        Ok(())
     }
 }

--- a/backend/api/src/http/endpoints/badge.rs
+++ b/backend/api/src/http/endpoints/badge.rs
@@ -76,7 +76,7 @@ async fn delete(
     db: Data<PgPool>,
     claims: TokenUser,
     path: Path<BadgeId>,
-    algolia: ServiceData<crate::algolia::Client>,
+    algolia: ServiceData<crate::algolia::Manager>,
 ) -> Result<HttpResponse, error::Delete> {
     let id = path.into_inner();
 

--- a/backend/api/src/http/endpoints/course.rs
+++ b/backend/api/src/http/endpoints/course.rs
@@ -144,7 +144,7 @@ async fn delete(
     db: Data<PgPool>,
     claims: TokenUser,
     path: web::Path<CourseId>,
-    algolia: ServiceData<crate::algolia::Client>,
+    algolia: ServiceData<crate::algolia::Manager>,
 ) -> Result<HttpResponse, error::Delete> {
     let id = path.into_inner();
 

--- a/backend/api/src/http/endpoints/image.rs
+++ b/backend/api/src/http/endpoints/image.rs
@@ -271,7 +271,7 @@ fn check_conflict_delete(err: sqlx::Error) -> error::Delete {
 /// Delete an image from the global image library.
 async fn delete(
     db: Data<PgPool>,
-    algolia: ServiceData<crate::algolia::Client>,
+    algolia: ServiceData<crate::algolia::Manager>,
     _claims: TokenUserWithScope<ScopeManageImage>,
     req: Path<ImageId>,
     s3: ServiceData<s3::Client>,

--- a/backend/api/src/http/endpoints/jig.rs
+++ b/backend/api/src/http/endpoints/jig.rs
@@ -159,7 +159,7 @@ async fn delete(
     db: Data<PgPool>,
     claims: TokenUser,
     path: web::Path<JigId>,
-    algolia: ServiceData<crate::algolia::Client>,
+    algolia: ServiceData<crate::algolia::Manager>,
 ) -> Result<HttpResponse, error::Delete> {
     let id = path.into_inner();
 
@@ -176,7 +176,7 @@ async fn delete(
 async fn delete_all(
     db: Data<PgPool>,
     claims: TokenUser,
-    algolia: ServiceData<crate::algolia::Client>,
+    algolia: ServiceData<crate::algolia::Manager>,
 ) -> Result<HttpResponse, error::Delete> {
     db::jig::authz(&*db, claims.0.user_id, None).await?;
 

--- a/backend/api/src/http/endpoints/user.rs
+++ b/backend/api/src/http/endpoints/user.rs
@@ -838,7 +838,7 @@ async fn get_profile(
 async fn delete(
     db: Data<PgPool>,
     session: TokenSessionOf<SessionDelete>,
-    algolia: ServiceData<crate::algolia::Client>,
+    algolia: ServiceData<crate::algolia::Manager>,
 ) -> Result<NoContentClearAuth, error::Server> {
     sqlx::query!(
         r#"delete from "user" where id = $1"#,


### PR DESCRIPTION
https://github.com/ji-devs/ji-cloud/issues/2825

## What?
Fix for deleting assets and users

## Why? 
Delete functionality was using Algolia `Client` instead of Algolia `Manager` so the api was using the wrong api key to delete.

## How?
I relocated the delete functionality into `Manager` from `Client`. 