### PR TITLE
chore(be): Improve docker image build caching

### DIFF
--- a/.github/workflows/backend-api-build-test.yml
+++ b/.github/workflows/backend-api-build-test.yml
@@ -1,0 +1,45 @@
+name: BUILD TEST Api - Backend
+
+on:
+  push:
+    branches: [ docker-ci ]
+
+jobs:
+  bundle:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v1
+
+      - name: Extract label
+        shell: bash
+        run: echo "##[set-output name=label;]$(echo \"[${GITHUB_REF#refs/heads/} - backend/api]\")"
+        id: extract_label
+
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v0'
+        with:
+          credentials_json: '${{ secrets.GOOGLE_CLOUD_SERVICE_ACCOUNT_JSON_KEY_SANDBOX }}'
+
+      - name: install google cloud sdk
+        uses: google-github-actions/setup-gcloud@v0
+
+      - name: download cargo-make release
+        run: curl -u jewish-interactive:"$GITHUB_TOKEN" -s https://api.github.com/repos/sagiegurari/cargo-make/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/' | xargs -I {} wget -c https://github.com/sagiegurari/cargo-make/releases/latest/download/cargo-make-v{}-x86_64-unknown-linux-musl.zip -O cargo-make.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: extract cargo-make to folder
+        run: unzip -j cargo-make.zip -d cargo-make
+
+      - name: add cargo-make to path
+        uses: dakom/actions-path@master
+        with:
+          path: ${{github.workspace}}/cargo-make
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: build and deploy
+        run: cargo make sandbox-api-build-test

--- a/.github/workflows/backend-pages-build-test.yml
+++ b/.github/workflows/backend-pages-build-test.yml
@@ -1,0 +1,46 @@
+name: BUILD TEST Pages - Backend
+
+on:
+  push:
+    branches: [ docker-ci ]
+
+jobs:
+  bundle:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v1
+
+      - name: Extract label
+        shell: bash
+        run: echo "##[set-output name=label;]$(echo \"[${GITHUB_REF#refs/heads/} - backend/pages]\")"
+        id: extract_label
+
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v0'
+        with:
+          credentials_json: '${{ secrets.GOOGLE_CLOUD_SERVICE_ACCOUNT_JSON_KEY_SANDBOX }}'
+
+      - name: install google cloud sdk
+        uses: google-github-actions/setup-gcloud@v0
+
+      - name: download cargo-make release
+        run: curl -u jewish-interactive:"$GITHUB_TOKEN" -s https://api.github.com/repos/sagiegurari/cargo-make/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/' | xargs -I {} wget -c https://github.com/sagiegurari/cargo-make/releases/latest/download/cargo-make-v{}-x86_64-unknown-linux-musl.zip -O cargo-make.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: extract cargo-make to folder
+        run: unzip -j cargo-make.zip -d cargo-make
+
+      - name: add cargo-make to path
+        uses: dakom/actions-path@master
+        with:
+          path: ${{github.workspace}}/cargo-make
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: build and deploy
+        run: cargo make sandbox-pages-build-test
+

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -16,6 +16,7 @@ DOCKER_BUILDKIT = "1"
 script_runner = "@shell"
 script = ["gcloud auth configure-docker"]
 
+# Configure Google Artifact Registry
 [tasks.gcloud-configure-docker-gar]
 script_runner = "@shell"
 script = ["gcloud auth configure-docker --quiet us-east1-docker.pkg.dev"]
@@ -53,6 +54,43 @@ run_task = [{name = [
     "docker-publish-sandbox-pages",
     "deploy-sandbox-pages",
 ]}]
+
+[tasks.sandbox-pages-build-test]
+run_task = [{name = [
+    "gcloud-configure-docker-gar",
+    "docker-build-pages-builder",
+    "deploy-sandbox-pages-test",
+]}]
+
+[tasks.docker-build-pages-builder]
+command = "docker"
+args = [
+    "buildx",
+    "build",
+    "--file",
+    "backend/pages/Dockerfile",
+    "--cache-from",
+    "us-east1-docker.pkg.dev/ji-cloud-developer-sandbox/docker/ji-cloud-pages-builder:latest",
+    "--cache-to",
+    "type=registry,mode=max,ref=us-east1-docker.pkg.dev/ji-cloud-developer-sandbox/docker/ji-cloud-pages-builder:latest",
+    "--tag",
+    "us-east1-docker.pkg.dev/ji-cloud-developer-sandbox/docker/ji-cloud-pages-test:latest",
+    "--push",
+    "--target",
+    "app",
+    "."
+]
+
+[tasks.deploy-sandbox-pages-test]
+script_runner = "@shell"
+script = ["""\
+    gcloud run deploy \
+        ji-cloud-pages-test \
+        --project ji-cloud-developer-sandbox \
+        --region europe-west1 \
+        --image us-east1-docker.pkg.dev/ji-cloud-developer-sandbox/docker/ji-cloud-pages-test:latest \
+        --platform managed
+"""]
 
 [tasks.docker-build-sandbox-pages]
 command = "docker"
@@ -104,9 +142,7 @@ run_task = [{name = [
 run_task = [{name = [
     "gcloud-configure-docker-gar",
     "docker-build-api-builder",
-    # "docker-pull-api-builder",
-    # "docker-build-test-api",
-    # "docker-publish-test-api",
+    "deploy-sandbox-api-test",
 ]}]
 
 [tasks.docker-build-api-builder]
@@ -128,31 +164,16 @@ args = [
     "."
 ]
 
-# [tasks.docker-pull-api-builder]
-# command = "docker"
-# args = ["pull", "us-east1-docker.pkg.dev/ji-cloud-developer-sandbox/docker/ji-cloud-api-builder:latest"]
-
-# [tasks.docker-build-test-api]
-# command = "docker"
-# args = [
-#     "buildx",
-#     "build",
-#     "-f",
-#     "backend/api/Dockerfile",
-#     "--target",
-#     "sandbox",
-#     "--cache-from",
-#     "us-east1-docker.pkg.dev/ji-cloud-developer-sandbox/docker/ji-cloud-api-builder:latest",
-#     "-t",
-#     "us-east1-docker.pkg.dev/ji-cloud-developer-sandbox/docker/ji-cloud-api-build:test",
-#     "-o",
-#     "type=registry",
-#     "."
-# ]
-
-# [tasks.docker-publish-test-api]
-# command = "docker"
-# args = ["push", "us-east1-docker.pkg.dev/ji-cloud-developer-sandbox/docker/ji-cloud-api-build:test"]
+[tasks.deploy-sandbox-api-test]
+script_runner = "@shell"
+script = ["""\
+    gcloud run deploy \
+        ji-cloud-api-test \
+        --project ji-cloud-developer-sandbox \
+        --region europe-west1 \
+        --image us-east1-docker.pkg.dev/ji-cloud-developer-sandbox/docker/ji-cloud-api-test:latest \
+        --platform managed
+"""]
 
 [tasks.docker-build-sandbox-api]
 command = "docker"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -16,6 +16,10 @@ DOCKER_BUILDKIT = "1"
 script_runner = "@shell"
 script = ["gcloud auth configure-docker"]
 
+[tasks.gcloud-configure-docker-gar]
+script_runner = "@shell"
+script = ["gcloud auth configure-docker --quiet us-east1-docker.pkg.dev"]
+
 ###################
 ## PAGES         ##
 ###################
@@ -95,6 +99,60 @@ run_task = [{name = [
     "docker-publish-sandbox-api",
     "deploy-sandbox-api",
 ]}]
+
+[tasks.sandbox-api-build-test]
+run_task = [{name = [
+    "gcloud-configure-docker-gar",
+    "docker-build-api-builder",
+    # "docker-pull-api-builder",
+    # "docker-build-test-api",
+    # "docker-publish-test-api",
+]}]
+
+[tasks.docker-build-api-builder]
+command = "docker"
+args = [
+    "buildx",
+    "build",
+    "--file",
+    "backend/api/Dockerfile",
+    "--cache-from",
+    "us-east1-docker.pkg.dev/ji-cloud-developer-sandbox/docker/ji-cloud-api-builder:latest",
+    "--cache-to",
+    "type=registry,mode=max,ref=us-east1-docker.pkg.dev/ji-cloud-developer-sandbox/docker/ji-cloud-api-builder:latest",
+    "--tag",
+    "us-east1-docker.pkg.dev/ji-cloud-developer-sandbox/docker/ji-cloud-api-test:latest",
+    "--push",
+    "--target",
+    "app",
+    "."
+]
+
+# [tasks.docker-pull-api-builder]
+# command = "docker"
+# args = ["pull", "us-east1-docker.pkg.dev/ji-cloud-developer-sandbox/docker/ji-cloud-api-builder:latest"]
+
+# [tasks.docker-build-test-api]
+# command = "docker"
+# args = [
+#     "buildx",
+#     "build",
+#     "-f",
+#     "backend/api/Dockerfile",
+#     "--target",
+#     "sandbox",
+#     "--cache-from",
+#     "us-east1-docker.pkg.dev/ji-cloud-developer-sandbox/docker/ji-cloud-api-builder:latest",
+#     "-t",
+#     "us-east1-docker.pkg.dev/ji-cloud-developer-sandbox/docker/ji-cloud-api-build:test",
+#     "-o",
+#     "type=registry",
+#     "."
+# ]
+
+# [tasks.docker-publish-test-api]
+# command = "docker"
+# args = ["push", "us-east1-docker.pkg.dev/ji-cloud-developer-sandbox/docker/ji-cloud-api-build:test"]
 
 [tasks.docker-build-sandbox-api]
 command = "docker"

--- a/backend/api/Cargo.toml
+++ b/backend/api/Cargo.toml
@@ -3,7 +3,6 @@ authors = [
   "dakom <david.komer@gmail.com>",
   "Chloe Ross <orangesnowfox@gmail.com>", # chloe@launchbadge.com
 ]
-default-run = "ji-cloud-api"
 edition = "2018"
 name = "ji-cloud-api"
 version = "0.1.0"

--- a/backend/api/Dockerfile
+++ b/backend/api/Dockerfile
@@ -1,109 +1,133 @@
+ARG ZIG_VERSION="0.9.1"
+ARG ALPINE_VERSION="3.16.0"
+ARG MOLD_VERSION="1.3.1"
+
+####################
+## BASE           ##
+####################
+#
+# This stage does a bit of extra work to try and improve layer caching and build performance. See individual comments for
+# more details.
+#
+# The base image also has cargo-zigbuild and ziglang installed for _much_ easier cross-compilation to musl.
+#
+# rust nightly is used for access to the sparse-registry unstable flag.
+FROM rustlang/rust:nightly-buster AS base
+# Enabling the `-Z sparse-registry` flag considerably reduces the amount of time it takes for the crates-io registry to be
+# updated. For more information, have a look at https://internals.rust-lang.org/t/call-for-testing-cargo-sparse-registry/16862
+ENV CARGO_UNSTABLE_SPARSE_REGISTRY=true
+# Make these arguments available to this stage
+ARG MOLD_VERSION
+ARG ZIG_VERSION
+# mold drastically improves linking times.
+# Use mold whenever we're not using zigbuild.
+RUN wget \
+    -q \
+    -O- \
+    "https://github.com/rui314/mold/releases/download/v$MOLD_VERSION/mold-$MOLD_VERSION-$(uname -m)-linux.tar.gz" \
+    | tar \
+        -C /usr/local \
+        --strip-components=1 \
+        -xzf \
+        -
+RUN ln -sf /usr/local/bin/mold $(realpath /usr/bin/ld)
+
+# We need the musl toolchain available for cross-compiling with zig
+RUN rustup target add x86_64-unknown-linux-musl
+
+# Install Zig
+RUN cargo +nightly install cargo-zigbuild
+RUN curl -L "https://ziglang.org/download/${ZIG_VERSION}/zig-linux-$(uname -m)-${ZIG_VERSION}.tar.xz" | tar -J -x -C /usr/local
+RUN ln -s "/usr/local/zig-linux-$(uname -m)-${ZIG_VERSION}/zig" /usr/local/bin/zig
+
+# Create the project dirs so that we don't need to later
+RUN mkdir -p /shared/rust/src
+RUN mkdir -p /backend/core/src
+RUN mkdir -p /backend/api/src
+
+####################
+## DEPENDENCIES   ##
+####################
+#
+# Build just the dependencies.
+#
+# We create dummy crates with just the Cargo.toml files and a lib.rs, and tell all the dependencies for these crates. In
+# the actual build step, we then update the timestamps on the Cargo.toml and lib.rs files so that cargo can rebuild the
+# _local_ dependencies and the app itself.
+# This has a drawback that a change in backend/api will trigger a rebuild for the shared/rust crate, but
+# overall, that's an easy price to pay.
+FROM base AS dependencies
+COPY ./shared/rust/Cargo.toml /shared/rust/Cargo.toml
+RUN touch /shared/rust/src/lib.rs
+
+COPY ./backend/core/Cargo.toml /backend/core/Cargo.toml
+RUN touch /backend/core/src/lib.rs
+
+COPY ./backend/api/Cargo.toml /backend/api/Cargo.toml
+# For the main api package, we need to include the lock file so that cargo builds the correct versions of our dependencies.
+COPY ./backend/api/Cargo.lock /backend/api/Cargo.lock
+RUN touch /backend/api/src/lib.rs
+
+# Build just our dependencies
+WORKDIR /backend/api
+RUN cargo +nightly zigbuild --release --target x86_64-unknown-linux-musl
+
 ####################
 ## BUILDER        ##
 ####################
+#
+# Build the actual project.
+#
+# This stage copies _all_ our project files over, and also copies the entire target directory generated in the api-cooker
+# stage. `cargo build` does the rest of the work.
+FROM base AS builder
+COPY ./shared /shared
+COPY ./backend/core /backend/core
+COPY ./backend/api /backend/api
+COPY --from=dependencies /backend/api/target /backend/api/target
 
-FROM ekidd/rust-musl-builder:latest AS api-builder
+# We need to touch these files so that their timestamps are newer than what was used in the api-cooker layer, otherwise
+# cargo will not know to rebuild these crates. See the comment in the api-cooker stage.
+# Very hacky indeed.
+RUN touch /shared/rust/Cargo.toml
+RUN touch /shared/rust/src/lib.rs
+RUN touch /backend/core/Cargo.toml
+RUN touch /backend/core/src/lib.rs
+RUN touch /backend/api/Cargo.toml
+RUN touch /backend/api/Cargo.lock
+RUN touch /backend/api/src/lib.rs
 
-# Add our source code.
-
-RUN mkdir -p ./backend/api
-COPY ./shared ./shared
-COPY ./backend/core ./backend/core
-COPY ./backend/api ./backend/api
-
-# Fix permissions on source code.
-RUN sudo chown -R rust:rust /home/rust
-
-# Build our application.
-WORKDIR ./backend/api
-RUN cargo build --release --no-default-features
+# Build the actual application
+WORKDIR /backend/api
+RUN cargo +nightly zigbuild --release --no-default-features --target x86_64-unknown-linux-musl
 
 ####################
-## Release        ##
+## App            ##
 ####################
-
-FROM alpine:latest as release
-
-# Used at runtime
-ENV PROJECT_ID=ji-cloud
+#
+# Creates a minimal image for running the app, but without setting the entrypoint or command to run.
+# When running the container, the `PROJECT_ID` should be passed in as an environment variable, and the
+# command should be set.
+#
+# Valid project ID's are:
+# - ji-cloud (release)
+# - ji-cloud-developer-sandbox (sandbox)
+#
+# Valid commands:
+# - ji-cloud-api [release|sandbox]
+# - media-watch [release|sandbox]
+FROM alpine:$ALPINE_VERSION as app
 
 RUN apk --no-cache add ca-certificates
 
-RUN mkdir /usr/local/bin/cloud-run-app
+RUN mkdir -p /usr/local/bin
 
-COPY --from=api-builder \
-    /home/rust/src/backend/api/target/x86_64-unknown-linux-musl/release/ji-cloud-api \
-    /usr/local/bin/cloud-run-app/ji-cloud-api
+COPY --from=builder \
+    /backend/api/target/x86_64-unknown-linux-musl/release/ji-cloud-api \
+    /usr/local/bin/ji-cloud-api
 
-WORKDIR /usr/local/bin/cloud-run-app/
+COPY --from=builder \
+    /backend/api/target/x86_64-unknown-linux-musl/release/media-watch \
+    /usr/local/bin/media-watch
 
-
-CMD ["./ji-cloud-api", "release"]
-
-####################
-## Sandbox        ##
-####################
-
-FROM alpine:latest as sandbox
-
-# Used at runtime
-ENV PROJECT_ID=ji-cloud-developer-sandbox
-
-RUN apk --no-cache add ca-certificates
-
-RUN mkdir /usr/local/bin/cloud-run-app
-
-COPY --from=api-builder \
-    /home/rust/src/backend/api/target/x86_64-unknown-linux-musl/release/ji-cloud-api \
-    /usr/local/bin/cloud-run-app/ji-cloud-api
-
-WORKDIR /usr/local/bin/cloud-run-app/
-
-
-CMD ["./ji-cloud-api", "sandbox"]
-
-
-
-#####################
-## Release (media) ##
-#####################
-
-FROM alpine:latest as release_media_watch
-
-# Used at runtime
-ENV PROJECT_ID=ji-cloud
-
-RUN apk --no-cache add ca-certificates
-
-RUN mkdir /usr/local/bin/cloud-run-app
-
-COPY --from=api-builder \
-    /home/rust/src/backend/api/target/x86_64-unknown-linux-musl/release/media-watch \
-    /usr/local/bin/cloud-run-app/media-watch
-
-WORKDIR /usr/local/bin/cloud-run-app/
-
-
-CMD ["./media-watch", "release"]
-
-#####################
-## Sandbox (media) ##
-#####################
-
-FROM alpine:latest as sandbox_media_watch
-
-# Used at runtime
-ENV PROJECT_ID=ji-cloud-developer-sandbox
-
-RUN apk --no-cache add ca-certificates
-
-RUN mkdir /usr/local/bin/cloud-run-app
-
-COPY --from=api-builder \
-    /home/rust/src/backend/api/target/x86_64-unknown-linux-musl/release/media-watch \
-    /usr/local/bin/cloud-run-app/media-watch
-
-WORKDIR /usr/local/bin/cloud-run-app/
-
-
-CMD ["./media-watch", "sandbox"]
+WORKDIR /usr/local/bin/

--- a/backend/api/Dockerfile
+++ b/backend/api/Dockerfile
@@ -78,7 +78,7 @@ RUN cargo +nightly zigbuild --release --target x86_64-unknown-linux-musl
 #
 # Build the actual project.
 #
-# This stage copies _all_ our project files over, and also copies the entire target directory generated in the api-cooker
+# This stage copies _all_ our project files over, and also copies the entire target directory generated in the dependencies
 # stage. `cargo build` does the rest of the work.
 FROM base AS builder
 COPY ./shared /shared
@@ -86,8 +86,8 @@ COPY ./backend/core /backend/core
 COPY ./backend/api /backend/api
 COPY --from=dependencies /backend/api/target /backend/api/target
 
-# We need to touch these files so that their timestamps are newer than what was used in the api-cooker layer, otherwise
-# cargo will not know to rebuild these crates. See the comment in the api-cooker stage.
+# We need to touch these files so that their timestamps are newer than what was used in the dependencies layer, otherwise
+# cargo will not know to rebuild these crates. See the comment in the dependencies stage.
 # Very hacky indeed.
 RUN touch /shared/rust/Cargo.toml
 RUN touch /shared/rust/src/lib.rs

--- a/backend/api/docker/.cargo/config.toml
+++ b/backend/api/docker/.cargo/config.toml
@@ -1,0 +1,12 @@
+# Config for use inside docker images. This helps speed up the time it takes cargo to
+# update the crates-io registry by using a local clone of the registry instead.
+[net]
+git-fetch-with-cli = true
+
+[source]
+
+[source.mirror]
+registry = "file:///.cargo-build-index"
+
+[source.crates-io]
+replace-with = "mirror"

--- a/backend/api/rust-toolchain.toml
+++ b/backend/api/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "stable"
+channel = "1.61.0"

--- a/backend/pages/Dockerfile
+++ b/backend/pages/Dockerfile
@@ -1,67 +1,131 @@
+ARG ZIG_VERSION="0.9.1"
+ARG ALPINE_VERSION="3.16.0"
+ARG MOLD_VERSION="1.3.1"
+
+####################
+## BASE           ##
+####################
+#
+# This stage does a bit of extra work to try and improve layer caching and build performance. See individual comments for
+# more details.
+#
+# The base image also has cargo-zigbuild and ziglang installed for _much_ easier cross-compilation to musl.
+#
+# rust nightly is used for access to the sparse-registry unstable flag.
+FROM rustlang/rust:nightly-buster AS base
+# Enabling the `-Z sparse-registry` flag considerably reduces the amount of time it takes for the crates-io registry to be
+# updated. For more information, have a look at https://internals.rust-lang.org/t/call-for-testing-cargo-sparse-registry/16862
+ENV CARGO_UNSTABLE_SPARSE_REGISTRY=true
+# Make these arguments available to this stage
+ARG MOLD_VERSION
+ARG ZIG_VERSION
+# mold drastically improves linking times.
+# Use mold whenever we're not using zigbuild.
+RUN wget \
+    -q \
+    -O- \
+    "https://github.com/rui314/mold/releases/download/v$MOLD_VERSION/mold-$MOLD_VERSION-$(uname -m)-linux.tar.gz" \
+    | tar \
+        -C /usr/local \
+        --strip-components=1 \
+        -xzf \
+        -
+RUN ln -sf /usr/local/bin/mold $(realpath /usr/bin/ld)
+
+# We need the musl toolchain available for cross-compiling with zig
+RUN rustup target add x86_64-unknown-linux-musl
+
+# Install Zig
+RUN cargo +nightly install cargo-zigbuild
+RUN curl -L "https://ziglang.org/download/${ZIG_VERSION}/zig-linux-$(uname -m)-${ZIG_VERSION}.tar.xz" | tar -J -x -C /usr/local
+RUN ln -s "/usr/local/zig-linux-$(uname -m)-${ZIG_VERSION}/zig" /usr/local/bin/zig
+
+# Create the project dirs so that we don't need to later
+RUN mkdir -p /shared/rust/src
+RUN mkdir -p /backend/core/src
+RUN mkdir -p /backend/pages/src
+
+####################
+## DEPENDENCIES   ##
+####################
+#
+# Build just the dependencies.
+#
+# We create dummy crates with just the Cargo.toml files and a lib.rs, and tell all the dependencies for these crates. In
+# the actual build step, we then update the timestamps on the Cargo.toml and lib.rs files so that cargo can rebuild the
+# _local_ dependencies and the app itself.
+# This has a drawback that a change in backend/pages will trigger a rebuild for the shared/rust crate, but
+# overall, that's an easy price to pay.
+FROM base AS dependencies
+COPY ./shared/rust/Cargo.toml /shared/rust/Cargo.toml
+RUN touch /shared/rust/src/lib.rs
+
+COPY ./backend/core/Cargo.toml /backend/core/Cargo.toml
+RUN touch /backend/core/src/lib.rs
+
+COPY ./backend/pages/Cargo.toml /backend/pages/Cargo.toml
+# For the main pages package, we need to include the lock file so that cargo builds the correct versions of our dependencies.
+COPY ./backend/pages/Cargo.lock /backend/pages/Cargo.lock
+RUN touch /backend/pages/src/lib.rs
+
+# Build just our dependencies
+WORKDIR /backend/pages
+RUN cargo +nightly zigbuild --release --target x86_64-unknown-linux-musl
+
 ####################
 ## BUILDER        ##
 ####################
+#
+# Build the actual project.
+#
+# This stage copies _all_ our project files over, and also copies the entire target directory generated in the dependencies
+# stage. `cargo build` does the rest of the work.
+FROM base AS builder
+COPY ./shared /shared
+COPY ./backend/core /backend/core
+COPY ./backend/pages /backend/pages
+COPY --from=dependencies /backend/pages/target /backend/pages/target
 
-FROM ekidd/rust-musl-builder:latest AS pages-builder
+# We need to touch these files so that their timestamps are newer than what was used in the dependencies layer, otherwise
+# cargo will not know to rebuild these crates. See the comment in the dependencies stage.
+# Very hacky indeed.
+RUN touch /shared/rust/Cargo.toml
+RUN touch /shared/rust/src/lib.rs
+RUN touch /backend/core/Cargo.toml
+RUN touch /backend/core/src/lib.rs
+RUN touch /backend/pages/Cargo.toml
+RUN touch /backend/pages/Cargo.lock
+RUN touch /backend/pages/src/lib.rs
 
-# Add our source code.
-
-RUN mkdir -p ./backend/pages
-COPY ./shared ./shared
-COPY ./backend/core ./backend/core
-COPY ./backend/pages ./backend/pages
-
-# Fix permissions on source code.
-RUN sudo chown -R rust:rust /home/rust
-
-# Build our application.
-WORKDIR ./backend/pages
-RUN cargo build --release --no-default-features
+# Build the actual application
+WORKDIR /backend/pages
+RUN cargo +nightly zigbuild --release --no-default-features --target x86_64-unknown-linux-musl
 
 ####################
-## RELEASE        ##
+## App            ##
 ####################
-
-FROM alpine:latest as release
-
-# Used at runtime
-ENV PROJECT_ID=ji-cloud
+#
+# Creates a minimal image for running the app, but without setting the entrypoint or command to run.
+# When running the container, the `PROJECT_ID` should be passed in as an environment variable, and the
+# command should be set.
+#
+# Valid project ID's are:
+# - ji-cloud (release)
+# - ji-cloud-developer-sandbox (sandbox)
+#
+# Valid commands:
+# - ji-cloud-pages [release|sandbox]
+FROM alpine:$ALPINE_VERSION as app
 
 RUN apk --no-cache add ca-certificates
 
-RUN mkdir /usr/local/bin/cloud-run-app
+RUN mkdir -p /usr/local/bin
 
-COPY --from=pages-builder \
-    /home/rust/src/backend/pages/target/x86_64-unknown-linux-musl/release/ji-cloud-pages \
-    /usr/local/bin/cloud-run-app/ji-cloud-pages
+COPY --from=builder \
+    /backend/pages/target/x86_64-unknown-linux-musl/release/ji-cloud-pages \
+    /usr/local/bin/ji-cloud-pages
 
 COPY ./backend/pages/public /usr/local/bin/cloud-run-app/public
 COPY ./backend/pages/templates /usr/local/bin/cloud-run-app/templates
 
-
-WORKDIR /usr/local/bin/cloud-run-app/
-
-CMD ["./ji-cloud-pages", "release"]
-
-####################
-## Sandbox        ##
-####################
-
-FROM alpine:latest as sandbox 
-
-# Used at runtime
-ENV PROJECT_ID=ji-cloud-developer-sandbox
-
-RUN apk --no-cache add ca-certificates
-
-RUN mkdir /usr/local/bin/cloud-run-app
-
-COPY --from=pages-builder \
-    /home/rust/src/backend/pages/target/x86_64-unknown-linux-musl/release/ji-cloud-pages \
-    /usr/local/bin/cloud-run-app/ji-cloud-pages
-
-COPY ./backend/pages/public /usr/local/bin/cloud-run-app/public
-
-WORKDIR /usr/local/bin/cloud-run-app/
-
-CMD ["./ji-cloud-pages", "sandbox"]
+WORKDIR /usr/local/bin/


### PR DESCRIPTION
Updates the backend/api Dockerfile to enable more efficient caching of dependencies.

This change should mean that any changes which don't update dependencies will be considerably quicker. See [initial build](https://github.com/ji-devs/ji-cloud/actions/runs/2595924106), vs subsequent build with a code change and no dependency changes: https://github.com/ji-devs/ji-cloud/runs/7148586590.

Changing the toolchain version, or dependencies will invalidate most or all cached image layers, resulting in a complete rebuild of the image which would take roughly the same amount of time as before this change. When changing the toolchain version, it'll invalidate the entire cache so that a build will take the full amount of time, roughly 20 to 24 minutes. Fortunately, the backend is built on the stable channel, so changes to the toolchain are less frequent.

Compiling the backend in release mode takes roughly 5minutes and this update doesn't do anything improve that time except pre-compiling and caching the dependencies.

The updated Dockerfile for the backend/api package only builds a single container containing both binaries. The cloud run deployment will be updated to specify the command to run (`./ji-cloud-api sandbox` for example) and the `PROJECT_ID` environment variable.

This change also requires switching to Google Artifact Registry from Container Registry and giving the relevant github-actions service account reader and writer permissions. GAR supports uploading layer caches which are essential for improving build times.

Another change to note is the removal of the `default-run` property from backend/api/Cargo.toml. This is to allow us to build dependencies before building the full application. It means that for local dev, instead of `cargo run`, `cargo run --target ji-cloud-api` needs to be used instead.