### PR TITLE
fix(fe/find-answer): Drop audio lock when saving uploaded audio

### DIFF
--- a/frontend/apps/crates/entry/module/find-answer/edit/src/base/sidebar/step_3/dom.rs
+++ b/frontend/apps/crates/entry/module/find-answer/edit/src/base/sidebar/step_3/dom.rs
@@ -379,13 +379,17 @@ fn render_tab_body(state: Rc<Step3>, tab: Tab) -> Dom {
 
                         let callbacks = AudioInputCallbacks::new(
                             Some(clone!(state, question => move |audio: Audio| {
-                                let mut lock = question.question_audio.lock_mut();
-                                *lock = Some(audio);
+                                {
+                                    let mut lock = question.question_audio.lock_mut();
+                                    *lock = Some(audio);
+                                }
                                 state.sidebar.base.save_question(index, question.clone());
                             })),
                             Some(clone!(state, question => move || {
-                                let mut lock = question.question_audio.lock_mut();
-                                *lock = None;
+                                {
+                                    let mut lock = question.question_audio.lock_mut();
+                                    *lock = None;
+                                }
                                 state.sidebar.base.save_question(index, question.clone());
                             })),
                         );

--- a/frontend/elements/src/module/_common/edit/widgets/audio-input/audio-input.ts
+++ b/frontend/elements/src/module/_common/edit/widgets/audio-input/audio-input.ts
@@ -53,8 +53,10 @@ export class _ extends LitElement {
                     width: 100%;
                 }
                 .actions {
-                    padding: 0 26px;
-                    display: grid;
+                    padding: 0;
+                    display: flex;
+                    flex-direction: row;
+                    justify-content: space-around;
                 }
                 .actions ::slotted(*) {
                     grid-column: 1;


### PR DESCRIPTION
Part of #2658

- Fixes failure to upload/record audio;
- Improves spacing of items in the audio-input element.