### PR TITLE
fix(fe/home): Correct overflow on search filter values for Chrome browsers

### DIFF
--- a/frontend/elements/src/entry/home/home/search-section/search-section-select.ts
+++ b/frontend/elements/src/entry/home/home/search-section/search-section-select.ts
@@ -30,6 +30,7 @@ export class _ extends LitElement {
                 }
                 base-select::part(anchored-overlay) {
                     display: block;
+                    width: 100%;
                 }
                 base-select::part(anchored-overlay_overlay) {
                     border-radius: 0 0 14px 14px;


### PR DESCRIPTION
Closes #2878 

- This applies a `width: 100%` to the anchored-overlay element _just_ in the `home-search-section-select` element - I'm worried that other usages of this element breaks. For example, the JIG settings icon in jig/edit will stretch with this new rule.

@MendyBerger this change _should_ fix the issue on Chrome browsers, however I cannot work out why the rule is not being picked up by Chrome. 

I've confirmed that in Firefox the rule is being applied correctly:

![image](https://user-images.githubusercontent.com/4161106/178246299-acd70c86-905f-4051-8ed4-56eaaa380c79.png)

Chrome doesn't show any of the rules:

![image](https://user-images.githubusercontent.com/4161106/178246489-5cb44657-0fc6-4486-97b6-ab6ca702bc26.png)
