### PR TITLE
fix(fe/text_editor): Render fonts alphabetically

### DIFF
--- a/frontend/apps/crates/components/src/text_editor/state.rs
+++ b/frontend/apps/crates/components/src/text_editor/state.rs
@@ -119,6 +119,8 @@ impl TextEditor {
                         font_family.to_string()
                     }).collect();
                     fonts.append(&mut static_fonts);
+                    // Make sure font's are listed alphabetically
+                    fonts.sort_by_key(|font| font.to_lowercase());
                     state.fonts.set(fonts);
                     ready(())
                 })),


### PR DESCRIPTION
Resolves #2198

![image](https://user-images.githubusercontent.com/4161106/178674460-4c646ba7-816f-493a-8152-635fcf80eb39.png)
