### PR TITLE
fix(shared/find-answer): Make QuestionField Dynamic variants transform optional

### DIFF
--- a/shared/rust/src/domain/module/body/find_answer.rs
+++ b/shared/rust/src/domain/module/body/find_answer.rs
@@ -148,12 +148,19 @@ pub enum QuestionField {
     ///
     /// Note (Ty): We won't make use of the scale field right now, but at some point we should add
     /// the ability to scale the label text
-    Dynamic(Transform),
+    Dynamic(Option<Transform>),
+}
+
+impl QuestionField {
+    /// Whether the current variant is `Dynamic`
+    pub fn is_dynamic(&self) -> bool {
+        matches!(self, Self::Dynamic(_))
+    }
 }
 
 impl Default for QuestionField {
     fn default() -> Self {
-        QuestionField::Dynamic(Transform::default())
+        QuestionField::Dynamic(None)
     }
 }
 


### PR DESCRIPTION
Part of #2658 

- Makes the Dynamic variant of QuestionField optional.

Note: I need to merge this in separately so that I can use the remote backend.