### PR TITLE
fix(be/course/browse): use aggregate function to ignore duplicates courses

### DIFF
--- a/backend/api/sqlx-data.json
+++ b/backend/api/sqlx-data.json
@@ -2421,53 +2421,8 @@
       ]
     }
   },
-  "4ce0b3cd3acb70b250136f3b5d951fb79e8cfec345f875c95582f5b276cbca72": {
-    "query": "update user_audio_upload set processed_at = now(), processing_result = false where audio_id = $1",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Uuid"
-        ]
-      },
-      "nullable": []
-    }
-  },
-  "4d327320e1810b7c419009172dc1137243a3d1d67ec65c614afb0101e374c4fc": {
-    "query": "select id as \"id: PdfId\" from user_pdf_library where id = $1",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id: PdfId",
-          "type_info": "Uuid"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid"
-        ]
-      },
-      "nullable": [
-        false
-      ]
-    }
-  },
-  "4dcbd40d11584afd1488f437343dc9bdc58897c7e5c1f05dd4be25db788b5e72": {
-    "query": "\ninsert into course_data_age_range(course_data_id, age_range_id)\nselect $2, age_range_id\nfrom course_data_age_range\nwhere course_data_id = $1\n        ",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Uuid"
-        ]
-      },
-      "nullable": []
-    }
-  },
-  "4de2c77ab5716ea40775229deecb299169d9d3f1d63c9f1cf24b04c5f88b9f17": {
-    "query": "\nwith cte as (\n    select array(select cd.id as \"id!\"\n    from course_data \"cd\"\n          left join course on (draft_id = cd.id or (live_id = cd.id and cd.last_synced_at is not null and published_at is not null))\n          left join course_data_resource \"resource\" on cd.id = resource.course_data_id\n    where (author_id = $1 or $1 is null)\n        and (cd.draft_or_live = $2 or $2 is null)\n        and (cd.privacy_level = any($3) or $3 = array[]::smallint[])\n        and (resource.resource_type_id = any($4) or $4 = array[]::uuid[])\n    order by coalesce(updated_at, created_at) desc, course.id) as id\n),\ncte1 as (\n    select * from unnest((select distinct id from cte)) with ordinality t(id\n   , ord) order by ord\n)\nselect course.id                                                                as \"course_id: CourseId\",\n    privacy_level                                                               as \"privacy_level: PrivacyLevel\",\n    creator_id,\n    author_id,\n    (select given_name || ' '::text || family_name\n     from user_profile\n     where user_profile.user_id = author_id)                                     as \"author_name\",\n    published_at,\n    likes,\n    plays,\n    display_name                                                                  as \"display_name!\",\n    updated_at,\n    language                                                                      as \"language!\",\n    description                                                                   as \"description!\",\n    translated_description                                                        as \"translated_description!: Json<HashMap<String,String>>\",\n    draft_or_live                                                                 as \"draft_or_live!: DraftOrLive\",\n    other_keywords                                                                as \"other_keywords!\",\n    translated_keywords                                                           as \"translated_keywords!\",\n    (\n        select row(course_data_module.id, kind, is_complete) \n        from course_data_module                \n        where course_data_id = course_data.id and \"index\" = 0 \n        order by \"index\"\n    )                                                   as \"cover?: (ModuleId, ModuleKind, bool)\",\n    array(select row (category_id)\n            from course_data_category\n            where course_data_id = course_data.id)     as \"categories!: Vec<(CategoryId,)>\",\n    array(select row (affiliation_id)\n            from course_data_affiliation\n            where course_data_id = course_data.id)          as \"affiliations!: Vec<(AffiliationId,)>\",\n    array(select row (age_range_id)\n            from course_data_age_range\n            where course_data_id = course_data.id)          as \"age_ranges!: Vec<(AgeRangeId,)>\",\n    array(select row (id, display_name, resource_type_id, resource_content)\n                from course_data_resource \n                where course_data_id = course_data.id\n          )                                          as \"additional_resource!: Vec<(AddId, String, TypeId, Value)>\",\n    array(\n        select row(jig_id)\n        from course_data_jig\n        where course_data_jig.course_data_id = course_data.id\n    )                                                     as \"items!: Vec<(JigId,)>\"\nfrom cte1\nleft join course_data on cte1.id = course_data.id\ninner join course on (\n    course_data.id = course.draft_id \n    or (        \n        course_data.id = course.live_id\n        and last_synced_at is not null\n        and course.published_at is not null\n    )\n)\nwhere ord > (1 * $5 * $6)\nlimit $6\n",
+  "4b5b9c5ee607a1bf226912b6cdad849bf6e31b0bbf8615268cc29139f389eadc": {
+    "query": "\nwith cte as (\n    select (array_agg(cd.id))[1]\n    from course_data \"cd\"\n          left join course on (draft_id = cd.id or (live_id = cd.id and cd.last_synced_at is not null and published_at is not null))\n          left join course_data_resource \"resource\" on cd.id = resource.course_data_id\n    where (author_id = $1 or $1 is null)\n        and (cd.draft_or_live = $2 or $2 is null)\n        and (cd.privacy_level = any($3) or $3 = array[]::smallint[])\n        and (resource.resource_type_id = any($4) or $4 = array[]::uuid[])\n    group by coalesce(updated_at, created_at)\n    order by coalesce(updated_at, created_at) desc),\ncte1 as (\n    select * from unnest((select array_agg(cte.array_agg) from cte)) with ordinality t(id\n   , ord) order by ord\n)\nselect course.id                                                                as \"course_id: CourseId\",\n    privacy_level                                                               as \"privacy_level: PrivacyLevel\",\n    creator_id,\n    author_id,\n    (select given_name || ' '::text || family_name\n     from user_profile\n     where user_profile.user_id = author_id)                                     as \"author_name\",\n    published_at,\n    likes,\n    plays,\n    display_name                                                                  as \"display_name!\",\n    updated_at,\n    language                                                                      as \"language!\",\n    description                                                                   as \"description!\",\n    translated_description                                                        as \"translated_description!: Json<HashMap<String,String>>\",\n    draft_or_live                                                                 as \"draft_or_live!: DraftOrLive\",\n    other_keywords                                                                as \"other_keywords!\",\n    translated_keywords                                                           as \"translated_keywords!\",\n    (\n        select row(course_data_module.id, kind, is_complete) \n        from course_data_module                \n        where course_data_id = course_data.id and \"index\" = 0 \n        order by \"index\"\n    )                                                   as \"cover?: (ModuleId, ModuleKind, bool)\",\n    array(select row (category_id)\n            from course_data_category\n            where course_data_id = course_data.id)     as \"categories!: Vec<(CategoryId,)>\",\n    array(select row (affiliation_id)\n            from course_data_affiliation\n            where course_data_id = course_data.id)          as \"affiliations!: Vec<(AffiliationId,)>\",\n    array(select row (age_range_id)\n            from course_data_age_range\n            where course_data_id = course_data.id)          as \"age_ranges!: Vec<(AgeRangeId,)>\",\n    array(select row (id, display_name, resource_type_id, resource_content)\n                from course_data_resource \n                where course_data_id = course_data.id\n          )                                          as \"additional_resource!: Vec<(AddId, String, TypeId, Value)>\",\n    array(\n        select row(jig_id)\n        from course_data_jig\n        where course_data_jig.course_data_id = course_data.id\n    )                                                     as \"items!: Vec<(JigId,)>\"\nfrom cte1\nleft join course_data on cte1.id = course_data.id\ninner join course on (\n    course_data.id = course.draft_id \n    or (        \n        course_data.id = course.live_id\n        and last_synced_at is not null\n        and course.published_at is not null\n    )\n)\nwhere ord > (1 * $5 * $6)\norder by ord asc\nlimit $6\n",
     "describe": {
       "columns": [
         {
@@ -2615,6 +2570,51 @@
         null,
         null
       ]
+    }
+  },
+  "4ce0b3cd3acb70b250136f3b5d951fb79e8cfec345f875c95582f5b276cbca72": {
+    "query": "update user_audio_upload set processed_at = now(), processing_result = false where audio_id = $1",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      },
+      "nullable": []
+    }
+  },
+  "4d327320e1810b7c419009172dc1137243a3d1d67ec65c614afb0101e374c4fc": {
+    "query": "select id as \"id: PdfId\" from user_pdf_library where id = $1",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id: PdfId",
+          "type_info": "Uuid"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      },
+      "nullable": [
+        false
+      ]
+    }
+  },
+  "4dcbd40d11584afd1488f437343dc9bdc58897c7e5c1f05dd4be25db788b5e72": {
+    "query": "\ninsert into course_data_age_range(course_data_id, age_range_id)\nselect $2, age_range_id\nfrom course_data_age_range\nwhere course_data_id = $1\n        ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Uuid"
+        ]
+      },
+      "nullable": []
     }
   },
   "4fb49fe4ad3204755e0a09d701e36d421c6a6696509bd37c238b1a835e022d7b": {

--- a/backend/api/src/http/endpoints/scheduler.rs
+++ b/backend/api/src/http/endpoints/scheduler.rs
@@ -19,16 +19,16 @@ async fn batch_update(
     jwks: Data<JwkVerifier>,
     user_agent: UserAgent,
 ) -> Result<HttpResponse, error::ServiceSession> {
-    // if user_agent
-    //     .0
-    //     .map_or(true, |it| it != "Google-Cloud-Scheduler")
-    // {
-    //     return Err(error::ServiceSession::Unauthorized);
-    // }
+    if user_agent
+        .0
+        .map_or(true, |it| it != "Google-Cloud-Scheduler")
+    {
+        return Err(error::ServiceSession::Unauthorized);
+    }
 
-    // let _claims: IdentityClaims = jwks
-    //     .verify_iam_api_invoker_oauth(bearer_auth.token(), 3)
-    //     .await?;
+    let _claims: IdentityClaims = jwks
+        .verify_iam_api_invoker_oauth(bearer_auth.token(), 3)
+        .await?;
 
     algolia_manager.spawn_cron_jobs().await?;
 

--- a/backend/api/src/http/endpoints/scheduler.rs
+++ b/backend/api/src/http/endpoints/scheduler.rs
@@ -19,16 +19,16 @@ async fn batch_update(
     jwks: Data<JwkVerifier>,
     user_agent: UserAgent,
 ) -> Result<HttpResponse, error::ServiceSession> {
-    if user_agent
-        .0
-        .map_or(true, |it| it != "Google-Cloud-Scheduler")
-    {
-        return Err(error::ServiceSession::Unauthorized);
-    }
+    // if user_agent
+    //     .0
+    //     .map_or(true, |it| it != "Google-Cloud-Scheduler")
+    // {
+    //     return Err(error::ServiceSession::Unauthorized);
+    // }
 
-    let _claims: IdentityClaims = jwks
-        .verify_iam_api_invoker_oauth(bearer_auth.token(), 3)
-        .await?;
+    // let _claims: IdentityClaims = jwks
+    //     .verify_iam_api_invoker_oauth(bearer_auth.token(), 3)
+    //     .await?;
 
     algolia_manager.spawn_cron_jobs().await?;
 

--- a/backend/api/tests/integration/course.rs
+++ b/backend/api/tests/integration/course.rs
@@ -1,0 +1,154 @@
+use http::StatusCode;
+use serde_json::json;
+use shared::domain::{course::CourseId, CreateResponse};
+
+use crate::{
+    fixture::Fixture,
+    helpers::{initialize_server, LoginExt},
+};
+
+#[actix_rt::test]
+async fn update_and_publish_browse() -> anyhow::Result<()> {
+    let app = initialize_server(
+        &[
+            Fixture::MetaKinds,
+            Fixture::User,
+            Fixture::Jig,
+            Fixture::Course,
+        ],
+        &[],
+    )
+    .await;
+
+    let port = app.port();
+
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .get(&format!(
+            "http://0.0.0.0:{}/v1/course/3a6a3660-f3ec-11ec-b8ef-071747fa2a0d/draft",
+            port
+        ))
+        .login()
+        .send()
+        .await?
+        .error_for_status()?;
+
+    let body: serde_json::Value = resp.json().await?;
+
+    insta::assert_json_snapshot!(
+        body, {
+            ".**.lastEdited" => "[last_edited]",
+        }
+    );
+
+    let resp = client
+        .patch(&format!(
+            "http://0.0.0.0:{}/v1/course/3a6a3660-f3ec-11ec-b8ef-071747fa2a0d",
+            port
+        ))
+        .json(&json!({
+            "description": "asdasdasd",
+            "language": "en-us",
+        }))
+        .login()
+        .send()
+        .await?
+        .error_for_status()?;
+
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+    let resp = client
+        .get(&format!(
+            "http://0.0.0.0:{}/v1/course/3a6a3660-f3ec-11ec-b8ef-071747fa2a0d/draft",
+            port
+        ))
+        .login()
+        .send()
+        .await?
+        .error_for_status()?;
+
+    let body: serde_json::Value = resp.json().await?;
+
+    insta::assert_json_snapshot!(
+        body, {
+            ".**.lastEdited" => "[last_edited]",
+        }
+    );
+
+    let resp = client
+        .get(&format!(
+            "http://0.0.0.0:{}/v1/course/3a6a3660-f3ec-11ec-b8ef-071747fa2a0d/live",
+            port
+        ))
+        .login()
+        .send()
+        .await?
+        .error_for_status()?;
+
+    let body: serde_json::Value = resp.json().await?;
+
+    insta::assert_json_snapshot!(
+        body, {
+            ".**.lastEdited" => "[last_edited]",
+        }
+    );
+
+    let _resp = client
+        .put(&format!(
+            "http://0.0.0.0:{}/v1/course/3a6a3660-f3ec-11ec-b8ef-071747fa2a0d/draft/publish",
+            port
+        ))
+        .login()
+        .send()
+        .await?
+        .error_for_status()?;
+
+    let _resp = client
+        .put(&format!(
+            "http://0.0.0.0:{}/v1/course/3a6a3660-f3ec-11ec-b8ef-071747fa2a0d/draft/publish",
+            port
+        ))
+        .login()
+        .send()
+        .await?
+        .error_for_status()?;
+
+    let _resp = client
+        .put(&format!(
+            "http://0.0.0.0:{}/v1/course/3a6a3660-f3ec-11ec-b8ef-071747fa2a0d/draft/publish",
+            port
+        ))
+        .login()
+        .send()
+        .await?
+        .error_for_status()?;
+
+    let resp = client
+        .get(&format!(
+            "http://0.0.0.0:{}/v1/course/browse?authorId=1f241e1b-b537-493f-a230-075cb16315be&draftOrLive=draft",
+            port
+        ))
+        .login()
+        .send()
+        .await?
+        .error_for_status()?;
+
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body: serde_json::Value = resp.json().await?;
+
+    insta::assert_json_snapshot!(
+        body, {
+            // Really just need to redact the module ID because it is recreated for the live data,
+            // but I couldn't get a selector working correctly... So redacting all IDs.
+            ".**.id" => "[id]",
+            ".**.lastEdited" => "[last_edited]",
+            ".**.publishedAt" => "[published_at]"
+        }
+    );
+
+    app.stop(false).await;
+
+    Ok(())
+}

--- a/backend/api/tests/integration/main.rs
+++ b/backend/api/tests/integration/main.rs
@@ -3,6 +3,7 @@ mod audio;
 mod auth;
 mod category;
 mod circle;
+mod course;
 mod fixture;
 mod helpers;
 mod image;

--- a/backend/api/tests/integration/snapshots/integration__course__update_and_publish_browse-2.snap
+++ b/backend/api/tests/integration/snapshots/integration__course__update_and_publish_browse-2.snap
@@ -1,0 +1,34 @@
+---
+source: tests/integration/course.rs
+expression: body
+
+---
+{
+  "id": "3a6a3660-f3ec-11ec-b8ef-071747fa2a0d",
+  "publishedAt": "2022-06-24T18:35:33.636556Z",
+  "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
+  "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
+  "authorName": "Bobby Tables",
+  "likes": 0,
+  "plays": 0,
+  "courseData": {
+    "draftOrLive": "draft",
+    "displayName": "course name1",
+    "language": "en-us",
+    "description": "asdasdasd",
+    "lastEdited": "[last_edited]",
+    "privacyLevel": "public",
+    "otherKeywords": "",
+    "translatedKeywords": "",
+    "translatedDescription": {},
+    "cover": null,
+    "ageRanges": [],
+    "affiliations": [],
+    "categories": [],
+    "additionalResources": [],
+    "items": [
+      "0cc084bc-7c83-11eb-9f77-e3218dffb008",
+      "3a71522a-cd77-11eb-8dc1-af3e35f7c743"
+    ]
+  }
+}

--- a/backend/api/tests/integration/snapshots/integration__course__update_and_publish_browse-3.snap
+++ b/backend/api/tests/integration/snapshots/integration__course__update_and_publish_browse-3.snap
@@ -1,0 +1,34 @@
+---
+source: tests/integration/course.rs
+expression: body
+
+---
+{
+  "id": "3a6a3660-f3ec-11ec-b8ef-071747fa2a0d",
+  "publishedAt": "2022-06-24T18:35:33.636556Z",
+  "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
+  "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
+  "authorName": "Bobby Tables",
+  "likes": 0,
+  "plays": 0,
+  "courseData": {
+    "draftOrLive": "live",
+    "displayName": "course name1",
+    "language": "en",
+    "description": "live test description",
+    "lastEdited": "[last_edited]",
+    "privacyLevel": "public",
+    "otherKeywords": "",
+    "translatedKeywords": "",
+    "translatedDescription": {},
+    "cover": null,
+    "ageRanges": [],
+    "affiliations": [],
+    "categories": [],
+    "additionalResources": [],
+    "items": [
+      "0cc084bc-7c83-11eb-9f77-e3218dffb008",
+      "3a71522a-cd77-11eb-8dc1-af3e35f7c743"
+    ]
+  }
+}

--- a/backend/api/tests/integration/snapshots/integration__course__update_and_publish_browse-4.snap
+++ b/backend/api/tests/integration/snapshots/integration__course__update_and_publish_browse-4.snap
@@ -1,0 +1,68 @@
+---
+source: tests/integration/course.rs
+expression: body
+
+---
+{
+  "courses": [
+    {
+      "id": "[id]",
+      "publishedAt": "[published_at]",
+      "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
+      "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
+      "authorName": "Bobby Tables",
+      "likes": 0,
+      "plays": 0,
+      "courseData": {
+        "draftOrLive": "draft",
+        "displayName": "course name1",
+        "language": "en-us",
+        "description": "asdasdasd",
+        "lastEdited": "[last_edited]",
+        "privacyLevel": "public",
+        "otherKeywords": "",
+        "translatedKeywords": "",
+        "translatedDescription": {},
+        "cover": null,
+        "ageRanges": [],
+        "affiliations": [],
+        "categories": [],
+        "additionalResources": [],
+        "items": [
+          "0cc084bc-7c83-11eb-9f77-e3218dffb008",
+          "3a71522a-cd77-11eb-8dc1-af3e35f7c743"
+        ]
+      }
+    },
+    {
+      "id": "[id]",
+      "publishedAt": "[published_at]",
+      "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
+      "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
+      "authorName": "Bobby Tables",
+      "likes": 0,
+      "plays": 0,
+      "courseData": {
+        "draftOrLive": "draft",
+        "displayName": "course name2",
+        "language": "en",
+        "description": "draft test description",
+        "lastEdited": "[last_edited]",
+        "privacyLevel": "public",
+        "otherKeywords": "",
+        "translatedKeywords": "",
+        "translatedDescription": {},
+        "cover": null,
+        "ageRanges": [],
+        "affiliations": [],
+        "categories": [],
+        "additionalResources": [],
+        "items": [
+          "3a71522a-cd77-11eb-8dc1-af3e35f7c743"
+        ]
+      }
+    }
+  ],
+  "pages": 1,
+  "totalCourseCount": 2
+}

--- a/backend/api/tests/integration/snapshots/integration__course__update_and_publish_browse.snap
+++ b/backend/api/tests/integration/snapshots/integration__course__update_and_publish_browse.snap
@@ -1,0 +1,34 @@
+---
+source: tests/integration/course.rs
+expression: body
+
+---
+{
+  "id": "3a6a3660-f3ec-11ec-b8ef-071747fa2a0d",
+  "publishedAt": "2022-06-24T18:35:33.636556Z",
+  "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
+  "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
+  "authorName": "Bobby Tables",
+  "likes": 0,
+  "plays": 0,
+  "courseData": {
+    "draftOrLive": "draft",
+    "displayName": "course name1",
+    "language": "en",
+    "description": "draft test description",
+    "lastEdited": "[last_edited]",
+    "privacyLevel": "public",
+    "otherKeywords": "",
+    "translatedKeywords": "",
+    "translatedDescription": {},
+    "cover": null,
+    "ageRanges": [],
+    "affiliations": [],
+    "categories": [],
+    "additionalResources": [],
+    "items": [
+      "0cc084bc-7c83-11eb-9f77-e3218dffb008",
+      "3a71522a-cd77-11eb-8dc1-af3e35f7c743"
+    ]
+  }
+}

--- a/backend/api/tests/integration/user/snapshots/integration__user__public_user__browse_user_courses.snap
+++ b/backend/api/tests/integration/user/snapshots/integration__user__public_user__browse_user_courses.snap
@@ -32,35 +32,6 @@ expression: body
           "3a71522a-cd77-11eb-8dc1-af3e35f7c743"
         ]
       }
-    },
-    {
-      "id": "3a6a3660-f3ec-11ec-b8ef-071747fa2a0d",
-      "publishedAt": "2022-06-24T18:35:33.636556Z",
-      "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
-      "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
-      "authorName": "Bobby Tables",
-      "likes": 0,
-      "plays": 0,
-      "courseData": {
-        "draftOrLive": "live",
-        "displayName": "course name1",
-        "language": "en",
-        "description": "live test description",
-        "lastEdited": "[last_edited]",
-        "privacyLevel": "public",
-        "otherKeywords": "",
-        "translatedKeywords": "",
-        "translatedDescription": {},
-        "cover": null,
-        "ageRanges": [],
-        "affiliations": [],
-        "categories": [],
-        "additionalResources": [],
-        "items": [
-          "0cc084bc-7c83-11eb-9f77-e3218dffb008",
-          "3a71522a-cd77-11eb-8dc1-af3e35f7c743"
-        ]
-      }
     }
   ],
   "pages": 1,


### PR DESCRIPTION
https://github.com/ji-devs/ji-cloud/issues/2938

## Fix:
- replaced `array()` with `array_agg()` to group all like values together in the SQL query
- unnested an `array_agg(cte.array_agg)` before ordering the `course_data_id`s