### PR TITLE
fix(fe/find-answer): Play correct audio when finishing last question; Empty text when no question text added

### DIFF
--- a/frontend/apps/crates/entry/module/find-answer/play/src/base/game/playing/actions.rs
+++ b/frontend/apps/crates/entry/module/find-answer/play/src/base/game/playing/actions.rs
@@ -92,8 +92,7 @@ impl PlayState {
             }
             (_, None) => {
                 // No more questions to ask, but the activity is configured so that the student can click continue.
-                //
-                // Do nothing.
+                self.play_correct_sound(|| {});
             }
         }
     }

--- a/frontend/apps/crates/entry/module/find-answer/play/src/base/game/playing/dom.rs
+++ b/frontend/apps/crates/entry/module/find-answer/play/src/base/game/playing/dom.rs
@@ -32,7 +32,7 @@ pub fn render(state: Rc<PlayState>) -> Dom {
                 }
 
                 // Update the question sticker if it is set and the question has text
-                if !state.question.question_text.is_empty() && state.game.base.question_field.is_text() {
+                if state.game.base.question_field.is_text() {
                     if let QuestionField::Text(question_index) = state.game.base.question_field {
                         let sticker_ref = state.game.base.sticker_refs.get(question_index).unwrap_ji().get().unwrap_ji();
                         Reflect::set(


### PR DESCRIPTION
Part of #2947 