### PR TITLE
fix(fe/find-answer): Remove title requirement from is_complete check

### DIFF
--- a/shared/rust/src/domain/module/body/find_answer.rs
+++ b/shared/rust/src/domain/module/body/find_answer.rs
@@ -194,11 +194,10 @@ pub struct Question {
 impl Question {
     /// Convenience method to determine whether a question has been configured correctly
     pub fn is_valid(&self) -> bool {
-        let has_title = !self.title.trim().is_empty();
         let has_question = !self.question_text.is_empty() || self.question_audio.is_some();
         let has_traces = !self.traces.is_empty();
 
-        has_title && has_question && has_traces
+        has_question && has_traces
     }
 }
 


### PR DESCRIPTION
Part of #2947 

- Removes the title requirement from the is_complete check - The title is only set if the teacher sets it, or it is set automatically when they enter content into the question text, or select a question sticker. If it's empty, the text defaults to "Question <n>", example, "Question 1".