### PR TITLE
feat(fe/admin): Add Created date column to the curation tool

### DIFF
--- a/frontend/apps/crates/entry/admin/src/curation/editable_jig.rs
+++ b/frontend/apps/crates/entry/admin/src/curation/editable_jig.rs
@@ -44,6 +44,7 @@ pub struct EditableJig {
     pub blocked: Mutable<bool>,
     pub jig_focus: JigFocus,
     pub author_name: String,
+    pub created_at: DateTime<Utc>,
     pub published_at: Option<DateTime<Utc>>,
     pub loader: AsyncLoader,
 }
@@ -68,6 +69,7 @@ impl From<JigResponse> for EditableJig {
             blocked: Mutable::new(jig.admin_data.blocked),
             jig_focus: jig.jig_focus,
             author_name: jig.author_name.unwrap_or_default(),
+            created_at: jig.jig_data.created_at,
             published_at: jig.published_at,
             loader: AsyncLoader::new(),
         }

--- a/frontend/apps/crates/entry/admin/src/curation/state.rs
+++ b/frontend/apps/crates/entry/admin/src/curation/state.rs
@@ -2,7 +2,10 @@ use std::{cell::RefCell, rc::Rc};
 
 use dominator_helpers::futures::AsyncLoader;
 use futures_signals::{signal::Mutable, signal_vec::MutableVec};
-use shared::domain::{meta::{Affiliation, AgeRange}, asset::OrderBy};
+use shared::domain::{
+    asset::OrderBy,
+    meta::{Affiliation, AgeRange},
+};
 use utils::routes::AdminCurationRoute;
 
 use super::EditableJig;

--- a/frontend/apps/crates/entry/admin/src/curation/table/dom.rs
+++ b/frontend/apps/crates/entry/admin/src/curation/table/dom.rs
@@ -17,10 +17,7 @@ use utils::{events, languages::Language, routes::AdminCurationRoute};
 
 impl CurationTable {
     pub fn render(self: Rc<Self>) -> Dom {
-        let order_by_options = vec![
-            OrderBy::PublishedAt,
-            OrderBy::CreatedAt,
-        ];
+        let order_by_options = vec![OrderBy::PublishedAt, OrderBy::CreatedAt];
 
         let state = self;
         html!("admin-curation-table", {
@@ -180,6 +177,9 @@ impl CurationTable {
                                     None => 0,
                                 }
                             }))
+                        }),
+                        html!("span", {
+                            .text(&jig.created_at.format("%b %e, %Y").to_string())
                         }),
                         html!("span", {
                             .text(&match jig.published_at {

--- a/frontend/elements/src/entry/admin/curation/table.ts
+++ b/frontend/elements/src/entry/admin/curation/table.ts
@@ -51,6 +51,7 @@ export class _ extends LitElement {
         "Author",
         "Rating",
         // "Author's Badge",
+        "Created",
         "Last published",
         "Language",
         // "Curators",


### PR DESCRIPTION
Closes #2852

- Adds the "Created" date column to the curation tool

![image](https://user-images.githubusercontent.com/4161106/180430851-ee91d5e3-61a8-478f-8e83-30b69d5ca143.png)
