### PR TITLE
fix(fe/find-answer): Ensure every text sticker has an associated renderer_ref

### DIFF
--- a/frontend/apps/crates/components/src/stickers/text/dom.rs
+++ b/frontend/apps/crates/components/src/stickers/text/dom.rs
@@ -96,10 +96,10 @@ pub fn render_sticker_text<T: AsSticker>(
                         }
                     }))
                     .after_inserted(clone!(text => move |elem| {
-                        text.editor.renderer_ref.set(Some(elem));
+                        text.renderer_ref.set(Some(elem));
                     }))
                     .after_removed(clone!(text => move |_elem| {
-                        text.editor.renderer_ref.set(None);
+                        text.renderer_ref.set(None);
                     }))
                 }))
             } else {

--- a/frontend/apps/crates/components/src/text_editor/state.rs
+++ b/frontend/apps/crates/components/src/text_editor/state.rs
@@ -24,8 +24,6 @@ use super::wysiwyg_types::{
 pub struct TextEditor {
     pub controls: Mutable<ControlsState>,
     pub wysiwyg_ref: Mutable<Option<HtmlElement>>,
-    /// Optional reference to the wysiwyg-output-renderer
-    pub renderer_ref: Mutable<Option<HtmlElement>>,
     pub fonts: Mutable<Vec<String>>,
     pub value: RefCell<Option<String>>,
     pub theme_id: ReadOnlyMutable<ThemeId>,
@@ -44,7 +42,6 @@ impl TextEditor {
         let _self = Rc::new(Self {
             controls: Mutable::new(ControlsState::new()),
             wysiwyg_ref: Mutable::new(None),
-            renderer_ref: Mutable::new(None),
             fonts: Mutable::new(vec![]),
             callbacks,
             value: RefCell::new(value),
@@ -92,20 +89,6 @@ impl TextEditor {
                 let _ = reset_value_method.call0(wysiwyg_ref);
             }
         };
-    }
-
-    /// Retrieves the text value without any formatting or tags
-    pub fn get_text_value(&self) -> Option<String> {
-        let renderer_ref = &*self.renderer_ref.lock_ref();
-        renderer_ref
-            .clone()
-            .map(|renderer_ref| {
-                let value =
-                    Reflect::get(&renderer_ref, &JsValue::from_str("textValue")).unwrap_ji();
-
-                value.as_string()
-            })
-            .unwrap_or_default()
     }
 
     fn handle_fonts(state: Rc<TextEditor>) {

--- a/frontend/apps/crates/entry/module/find-answer/edit/src/base/main/dom.rs
+++ b/frontend/apps/crates/entry/module/find-answer/edit/src/base/main/dom.rs
@@ -24,7 +24,7 @@ impl DomRenderable for Main {
                     if is_empty {
                         if let Some(selected) = selected {
                             if let Some(Sticker::Text(text)) = state.base.stickers.list.lock_ref().get(selected) {
-                                let text = text.editor.get_text_value();
+                                let text = text.get_text_value();
                                 state.base.add_question(text, Some(selected));
                                 state.base.current_question.set(Some(0));
                             }

--- a/frontend/apps/crates/entry/module/find-answer/play/src/base/dom.rs
+++ b/frontend/apps/crates/entry/module/find-answer/play/src/base/dom.rs
@@ -1,13 +1,14 @@
 use super::state::*;
 use components::{
     backgrounds::dom::render_backgrounds_raw,
+    instructions::player::InstructionsPlayer,
     module::_common::play::prelude::{DomRenderable, ModulePlayPhase},
     stickers::{
         dom::{render_sticker_raw, StickerRawRenderOptions},
         sprite::dom::SpriteRawRenderOptions,
         text::dom::TextRawRenderOptions,
         video::dom::VideoRawRenderOptions,
-    }, instructions::player::InstructionsPlayer,
+    },
 };
 use dominator::{apply_methods, clone, html, Dom};
 use futures_signals::signal::SignalExt;

--- a/frontend/apps/crates/entry/module/find-answer/play/src/base/state.rs
+++ b/frontend/apps/crates/entry/module/find-answer/play/src/base/state.rs
@@ -1,4 +1,4 @@
-use components::{module::_common::play::prelude::*, instructions::player::InstructionsPlayer};
+use components::{instructions::player::InstructionsPlayer, module::_common::play::prelude::*};
 use dominator::clone;
 use once_cell::sync::OnceCell;
 use shared::domain::{
@@ -16,7 +16,7 @@ use shared::domain::{
 use utils::prelude::*;
 
 use futures_signals::signal::Mutable;
-use std::{rc::Rc, cell::RefCell};
+use std::{cell::RefCell, rc::Rc};
 use web_sys::HtmlElement;
 
 pub struct Base {
@@ -74,11 +74,14 @@ impl Base {
             sticker_refs,
             question_field: content.question_field,
             module_phase: init_args.play_phase,
-            instructions_player: InstructionsPlayer::new(content.base.instructions, Some(clone!(base_ref => move || {
-                if let Some(base_ref) = &*base_ref.borrow() {
-                    base_ref.instructions_finished.set_neq(true);
-                }
-            }))),
+            instructions_player: InstructionsPlayer::new(
+                content.base.instructions,
+                Some(clone!(base_ref => move || {
+                    if let Some(base_ref) = &*base_ref.borrow() {
+                        base_ref.instructions_finished.set_neq(true);
+                    }
+                })),
+            ),
             instructions_finished: Mutable::new(false),
         });
 


### PR DESCRIPTION
Resolves #2977

- Moves the `renderer_ref` field out of the `TextEditor` and into the `Text` sticker component