### PR TITLE
fix(fe/find-answer): Clear the question sticker when starting the activity

### DIFF
--- a/frontend/apps/crates/entry/module/find-answer/play/src/base/dom.rs
+++ b/frontend/apps/crates/entry/module/find-answer/play/src/base/dom.rs
@@ -12,8 +12,13 @@ use components::{
 };
 use dominator::{apply_methods, clone, html, Dom};
 use futures_signals::signal::SignalExt;
-use shared::domain::module::body::_groups::design::Sticker as RawSticker;
+use js_sys::Reflect;
+use shared::domain::module::body::{
+    _groups::design::Sticker as RawSticker, find_answer::QuestionField,
+};
 use std::rc::Rc;
+use utils::unwrap::UnwrapJiExt;
+use wasm_bindgen::JsValue;
 
 use super::game::{dom::render as render_game, state::Game};
 
@@ -48,6 +53,17 @@ impl DomRenderable for Base {
                                             apply_methods!(dom, {
                                                 .after_inserted(clone!(state => move |elem| {
                                                     if let Some(sticker_ref) = state.sticker_refs.get(index) {
+                                                        // If this is the question field sticker, then clear its content.
+                                                        if let QuestionField::Text(question_index) = state.question_field {
+                                                            if question_index == index {
+                                                                Reflect::set(
+                                                                    &elem,
+                                                                    &JsValue::from_str("textValue"),
+                                                                    &JsValue::from_str(" ") // This is weird. If we use "", then subsequent calls to set textValue don't work correctly.
+                                                                ).unwrap_ji();
+                                                            }
+                                                        }
+
                                                         let _ = sticker_ref.set(elem);
                                                     }
                                                 }))

--- a/frontend/apps/crates/entry/module/find-answer/play/src/base/game/playing/dom.rs
+++ b/frontend/apps/crates/entry/module/find-answer/play/src/base/game/playing/dom.rs
@@ -35,15 +35,21 @@ pub fn render(state: Rc<PlayState>) -> Dom {
                 }
 
                 // Update the question sticker if it is set and the question has text
-                if state.game.base.question_field.is_text() {
-                    if let QuestionField::Text(question_index) = state.game.base.question_field {
-                        let sticker_ref = state.game.base.sticker_refs.get(question_index).unwrap_ji().get().unwrap_ji();
-                        Reflect::set(
-                            sticker_ref,
-                            &JsValue::from_str("textValue"),
-                            &JsValue::from_str(&state.question.question_text)
-                        ).unwrap_ji();
-                    }
+                if let QuestionField::Text(question_index) = state.game.base.question_field {
+                    let sticker_ref = state.game.base.sticker_refs.get(question_index).unwrap_ji().get().unwrap_ji();
+
+                    // This is weird. If we use "", then subsequent calls to set textValue don't work correctly.
+                    let question_text = if state.question.question_text.is_empty() {
+                        " "
+                    } else {
+                        &state.question.question_text
+                    };
+
+                    Reflect::set(
+                        sticker_ref,
+                        &JsValue::from_str("textValue"),
+                        &JsValue::from_str(question_text)
+                    ).unwrap_ji();
                 }
             }
 


### PR DESCRIPTION
Part of #2978

- Clears the question sticker when starting an activity;
- Fixes a bug when a question had no text, subsequent questions _with text_ wouldn't render.