### PR TITLE
feat(fe/find-answer): Detect incorrect choice and play negative feedback audio

### DIFF
--- a/frontend/apps/crates/entry/module/find-answer/edit/src/base/sidebar/step_4/play_settings/dom.rs
+++ b/frontend/apps/crates/entry/module/find-answer/edit/src/base/sidebar/step_4/play_settings/dom.rs
@@ -35,35 +35,35 @@ pub fn render(state: Rc<State>) -> Dom {
                     )),
                 ],
             ),
-            (
-                LineKind::Attempts,
-                vec![
-                    Some(SettingsButton::new_click(
-                        SettingsButtonKind::NoLimit,
-                        clone!(state => move || {
-                            state.base.play_settings.has_attempts_limit.signal_ref(|flag| !flag)
-                        }),
-                        clone!(state => move || {
-                            state.set_has_attempts_limit(false);
-                        }),
-                    )),
-                    Some(SettingsButton::new_value_click(
-                        SettingsButtonKind::Attempts,
-                        clone!(state => move || {
-                            state.base.play_settings.has_attempts_limit.signal()
-                        }),
-                        SettingsValue::new(
-                            state.base.play_settings.n_attempts.get(),
-                            clone!(state => move |value| {
-                                state.set_attempts_limit(value);
-                            }),
-                        ),
-                        clone!(state => move || {
-                            state.set_has_attempts_limit(true);
-                        }),
-                    )),
-                ],
-            ),
+            // (
+            //     LineKind::Attempts,
+            //     vec![
+            //         Some(SettingsButton::new_click(
+            //             SettingsButtonKind::NoLimit,
+            //             clone!(state => move || {
+            //                 state.base.play_settings.has_attempts_limit.signal_ref(|flag| !flag)
+            //             }),
+            //             clone!(state => move || {
+            //                 state.set_has_attempts_limit(false);
+            //             }),
+            //         )),
+            //         Some(SettingsButton::new_value_click(
+            //             SettingsButtonKind::Attempts,
+            //             clone!(state => move || {
+            //                 state.base.play_settings.has_attempts_limit.signal()
+            //             }),
+            //             SettingsValue::new(
+            //                 state.base.play_settings.n_attempts.get(),
+            //                 clone!(state => move |value| {
+            //                     state.set_attempts_limit(value);
+            //                 }),
+            //             ),
+            //             clone!(state => move || {
+            //                 state.set_has_attempts_limit(true);
+            //             }),
+            //         )),
+            //     ],
+            // ),
             (
                 LineKind::TimeLimit,
                 vec![

--- a/frontend/apps/crates/entry/module/find-answer/play/src/base/game/playing/actions.rs
+++ b/frontend/apps/crates/entry/module/find-answer/play/src/base/game/playing/actions.rs
@@ -20,6 +20,15 @@ impl PlayState {
         }
     }
 
+    pub fn incorrect_choice(_state: Rc<Self>, _incorrect_index: Option<usize>) {
+        AUDIO_MIXER.with(move |mixer| {
+            let audio_path: AudioPath<'_> = mixer.get_random_negative().into();
+            mixer.play_oneshot_on_ended(audio_path, move || {
+                // TODO once the advanced mdoal has been added, negative feedback audio can be added here.
+            });
+        });
+    }
+
     fn play_correct_sound<F: Fn() + 'static>(self: &Rc<Self>, f: F) {
         AUDIO_MIXER.with(move |mixer| {
             let audio_path: AudioPath<'_> = mixer.get_random_positive().into();


### PR DESCRIPTION
Closes #2947

- Detects an incorrect choice (any tap which doesn't select an answer trace) and plays a negative feedback audio clip;
- Hides the attempts play setting for now.