### PR TITLE
feat(fe/find-answer): Update the empty sidebar UI

### DIFF
--- a/frontend/apps/crates/entry/module/find-answer/edit/src/base/sidebar/step_3/dom.rs
+++ b/frontend/apps/crates/entry/module/find-answer/edit/src/base/sidebar/step_3/dom.rs
@@ -91,20 +91,12 @@ pub fn render(state: Rc<Step3>) -> Dom {
                 // Make sure that the tab_kind is reset so that we can display the correct Jiggling text.
                 state.sidebar.tab_kind.set(None);
 
-                Some(html!("sidebar-empty", {
-                    .property("imagePath", "module/_common/edit/sidebar/illustration-trace-area.svg")
+                Some(html!("questions-empty", {
                     .child(html!("div", {
-                        .child(html!("p", {
-                            .text("Select the question if it's already on your page")
-                        }))
-                        .child(html!("p", {
-                            .text("or")
-                        }))
-                        .child(html!("button-main", {
+                        .child(html!("button-icon", {
                             .property("size", "medium")
                             .property("color", "blue")
-                            .property("kind", "text")
-                            .text("add a question")
+                            .property("icon", "circle-+-blue")
                             .event(clone!(state => move|_: events::Click| {
                                 state.sidebar.base.add_default_question();
                                 state.sidebar.base.current_question.set(Some(0))
@@ -122,17 +114,23 @@ pub fn render(state: Rc<Step3>) -> Dom {
                 }))
             }
         })))
-        .child(html!("button-icon-label", {
-            .property("slot", "action")
-            .property("icon", "circle-+-blue")
-            .property("label", "Add a question")
-            .property("labelcolor", "blue")
-            .event(clone!(state => move|_: events::Click| {
-                state.sidebar.base.add_default_question();
-                let index = state.sidebar.base.questions.lock_ref().len() - 1;
-                state.sidebar.base.current_question.set(Some(index));
-            }))
-        }))
+        .child_signal(empty_signal(state.clone()).map(clone!(state => move |is_empty| {
+            if !is_empty {
+                Some(html!("button-icon-label", {
+                    .property("slot", "action")
+                    .property("icon", "circle-+-blue")
+                    .property("label", "Add a question")
+                    .property("labelcolor", "blue")
+                    .event(clone!(state => move|_: events::Click| {
+                        state.sidebar.base.add_default_question();
+                        let index = state.sidebar.base.questions.lock_ref().len() - 1;
+                        state.sidebar.base.current_question.set(Some(index));
+                    }))
+                }))
+            } else {
+                None
+            }
+        })))
     })
 }
 

--- a/frontend/elements/src/_bundles/module/find-answer/edit/imports.ts
+++ b/frontend/elements/src/_bundles/module/find-answer/edit/imports.ts
@@ -4,5 +4,6 @@ import "@elements/_bundles/_sub-bundles/all";
 import "@elements/_bundles/_sub-bundles/hebrew-buttons";
 import "@elements/module/find-answer/sidebar/question";
 import "@elements/module/find-answer/sidebar/question-container";
+import "@elements/module/find-answer/sidebar/questions-empty";
 import "@elements/module/find-answer/question-banner";
 import "@elements/core/modals/confirm";

--- a/frontend/elements/src/module/find-answer/sidebar/questions-empty.ts
+++ b/frontend/elements/src/module/find-answer/sidebar/questions-empty.ts
@@ -1,0 +1,85 @@
+import { LitElement, html, css, customElement, property } from "lit-element";
+import { nothing } from "lit-html";
+
+@customElement("questions-empty")
+export class _ extends LitElement {
+    static get styles() {
+        return [
+            css`
+                :host {
+                    --image-offset: 0px;
+                    display: flex;
+                    flex-direction: column;
+                    justify-content: center;
+                    align-items: center;
+                    height: 100%;
+                }
+
+                .clear {
+                    margin-top: 88px;
+                    align-self: flex-end;
+                    width: 100%;
+                    display: flex;
+                    justify-content: center;
+                }
+
+                .block {
+                    height: 256px;
+                    border-radius: 16px;
+                    background-color: var(--light-blue-2);
+                    display: flex;
+                    flex-direction: column;
+                    align-content: center;
+                    align-items: center;
+                    justify-content: center;
+                }
+
+                .block p {
+                    margin: 0 64px;
+                    text-align: center;
+                }
+
+                .break {
+                    font-size: 24px;
+                    font-weight: 500;
+                    text-align: center;
+                    color: var(--dark-gray-6);
+                    margin: 16px 0;
+                }
+            `,
+        ];
+    }
+
+    @property({ type: String })
+    label?: string;
+
+    @property({ type: String })
+    imagePath?: string;
+
+    @property({ type: Number, reflect: true })
+    imageOffset: number = 0;
+
+    firstUpdated(_changed: any) {
+        this.style.setProperty('--image-offset', `${this.imageOffset}px`);
+    }
+
+    renderImage() {
+        return this.imagePath ? html`<img-ui path=${this.imagePath}></img-ui>` : nothing;
+    }
+
+    render() {
+        return html`
+            <div>
+                <div class="block">
+                    <slot></slot>
+                    <p>Add a question</p>
+                </div>
+                <div class="break">or</div>
+                <div class="block">
+                    <img-ui path="module/find-answer/edit/select-question.svg"></img-ui>
+                    <p>Select the question if it's already on your page</p>
+                </div>
+            </div>
+        `;
+    }
+}


### PR DESCRIPTION
Closes #2923

- The lines around the "or" text have not been added. I left those out because it was taking me too long to figure out how to add them correctly.
- The "Add a question" button which usually shows up at the bottom of the list is hidden if there are no questions present.

![Screenshot 2022-08-04 at 12 54 11](https://user-images.githubusercontent.com/4161106/182830594-b1d79b61-fcee-4966-8b89-b3a53d1a9ebf.png)
