### PR TITLE
fix(fe/transform-widget): Reposition transform box menu button

### DIFF
--- a/frontend/elements/src/module/_common/edit/widgets/transform/box.ts
+++ b/frontend/elements/src/module/_common/edit/widgets/transform/box.ts
@@ -378,7 +378,8 @@ export class TransformBox extends LitElement {
             const [x, y] = dotPositions[menuButtonDot];
 
             let style = `left: calc(${x}px - ${MENU_BUTTON_RADIUS}px);`;
-            style += ` top: calc(${y}px - ${MENU_BUTTON_RADIUS}px);`;
+            // Move the menu button up by 1.5x it's diameter
+            style += ` top: calc(${RECT_STROKE_SIZE}px - ${MENU_BUTTON_RADIUS * 3}px);`;
 
             return !isTransforming && hasMenu && !buttonHack
                 ? html`<div id="menu-btn" style="${style}">


### PR DESCRIPTION
Closes #2815

- Repositions the menu button for stickers so that it is above the border box and out of the way
  - Note that the menu button does not scale in size like the rotate button, so depending on screen resolution, the alignment and size of the buttons will likely be different.

![Screenshot 2022-08-10 at 09 40 27](https://user-images.githubusercontent.com/4161106/183843452-2ee3e4d1-90ec-4539-92bd-1f0889598d74.png)

