### PR TITLE
feat(fe/stickers): Add edit menu item to the text stickers menu

### DIFF
--- a/frontend/apps/crates/components/src/stickers/text/menu/dom.rs
+++ b/frontend/apps/crates/components/src/stickers/text/menu/dom.rs
@@ -17,6 +17,17 @@ pub fn render_sticker_text_menu<T: AsSticker>(
     html!("div", {
         .children(&mut [
             html!("menu-line", {
+                .property("icon", "edit")
+                .event(clone!(stickers, index, text => move |_evt:events::Click| {
+                    text.transform.close_menu();
+                    if let Some(index) = index.get() {
+                        if let Some(text_sticker) = stickers.get_as_text(index) {
+                            text_sticker.is_editing.set_neq(true);
+                        }
+                    }
+                }))
+            }),
+            html!("menu-line", {
                 .property("icon", "duplicate")
                 .event(clone!(stickers, index, text => move |_evt:events::Click| {
                     text.transform.close_menu();

--- a/frontend/elements/src/core/wysiwyg/wysiwyg-base.ts
+++ b/frontend/elements/src/core/wysiwyg/wysiwyg-base.ts
@@ -6,7 +6,7 @@ import {
     property,
     PropertyValues,
     css,
-    internalProperty,
+    state,
 } from "lit-element";
 import React, { useMemo } from "react";
 import ReactDOM from "react-dom";
@@ -82,7 +82,7 @@ export class _ extends LitElement {
         return v;
     }
 
-    @internalProperty()
+    @state()
     private value: WysiwygValue = this.createValue();
 
     public set valueAsString(v: string) {
@@ -96,6 +96,14 @@ export class _ extends LitElement {
 
     firstUpdated() {
         this.reactRender();
+        // Focus the editor field.
+        //
+        // Note: This is different from calling reFocus which uses the _blurSelection property.
+        (
+            this.shadowRoot!.querySelector(
+                "[contenteditable=true]"
+            ) as HTMLElement
+        ).focus();
     }
 
     updated(changedProperties: PropertyValues) {
@@ -278,7 +286,7 @@ export class _ extends LitElement {
 
             eventData[key] = controlValue;
         }
-        
+
         this.dispatchEvent(
             new CustomEvent("wysiwyg-controls-change", {
                 detail: eventData,


### PR DESCRIPTION
Closes #3033

- Adds the "edit" option to text stickers;
- Updates the edit logic so that when going into the edit state, the input field is focused immediately.

![image](https://user-images.githubusercontent.com/4161106/183849396-653bed59-fbc9-4682-a605-0cf0a5fcdac0.png)
