### PR TITLE
fix(fe/menus): Increase gap between menu items

### DIFF
--- a/frontend/apps/crates/components/src/stickers/sprite/menu/dom.rs
+++ b/frontend/apps/crates/components/src/stickers/sprite/menu/dom.rs
@@ -14,6 +14,9 @@ pub fn render_sticker_sprite_menu<T: AsSticker>(
     sprite: Rc<Sprite>,
 ) -> Dom {
     html!("div", {
+        .style("display", "flex")
+        .style("flex-direction", "column")
+        .style("grid-gap", "10px")
         .children(&mut [
             html!("menu-line", {
                 .property("icon", "duplicate")

--- a/frontend/apps/crates/components/src/stickers/text/menu/dom.rs
+++ b/frontend/apps/crates/components/src/stickers/text/menu/dom.rs
@@ -15,6 +15,9 @@ pub fn render_sticker_text_menu<T: AsSticker>(
     text: Rc<Text>,
 ) -> Dom {
     html!("div", {
+        .style("display", "flex")
+        .style("flex-direction", "column")
+        .style("grid-gap", "10px")
         .children(&mut [
             html!("menu-line", {
                 .property("icon", "edit")

--- a/frontend/apps/crates/components/src/stickers/video/menu/dom.rs
+++ b/frontend/apps/crates/components/src/stickers/video/menu/dom.rs
@@ -13,6 +13,9 @@ pub fn render_sticker_video_menu<T: AsSticker>(
     video: Rc<Video>,
 ) -> Dom {
     html!("div", {
+        .style("display", "flex")
+        .style("flex-direction", "column")
+        .style("grid-gap", "10px")
         .children(&mut [
             html!("menu-line", {
                 .property("icon", "move-forward")

--- a/frontend/elements/src/core/menu/kebab.ts
+++ b/frontend/elements/src/core/menu/kebab.ts
@@ -26,6 +26,13 @@ export class _ extends LitElement {
                 .menu-container.visible {
                     display: block;
                 }
+
+                .menu {
+                    display: flex;
+                    flex-direction: column;
+                    grid-gap: 10px;
+                }
+
                 #button {
                     width: 32px;
                     height: 32px;

--- a/frontend/elements/src/entry/jig/edit/sidebar/module/menu.ts
+++ b/frontend/elements/src/entry/jig/edit/sidebar/module/menu.ts
@@ -18,6 +18,7 @@ export class _ extends LitElement {
                 .advanced {
                     display: flex;
                     flex-direction: column;
+                    grid-gap: 10px;
                 }
                 .separator {
                     display: block;


### PR DESCRIPTION
Closes #2694;
Part of #2769.

- Increases the gap between menu items.

![Screenshot 2022-08-10 at 10 40 56](https://user-images.githubusercontent.com/4161106/183856888-d894580c-18b0-4bc0-9010-63ffbfc473ec.png)
![Screenshot 2022-08-10 at 10 41 09](https://user-images.githubusercontent.com/4161106/183856901-7a24d296-fa85-40c8-afb1-b6ff3207fac3.png)
![Screenshot 2022-08-10 at 10 41 21](https://user-images.githubusercontent.com/4161106/183856913-23980834-e111-472a-bedc-d2c0255f74e8.png)
