### PR TITLE
feat(fe/tapping-board): Improve interaction label input

### DIFF
--- a/frontend/apps/crates/entry/module/tapping-board/edit/src/strings.rs
+++ b/frontend/apps/crates/entry/module/tapping-board/edit/src/strings.rs
@@ -1,4 +1,4 @@
 pub mod step_3 {
-    pub const STR_LABEL: &str = "Text";
-    pub const STR_PLACEHOLDER: &str = "Type the text";
+    pub const STR_LABEL: &str = "Label this item as:";
+    pub const STR_PLACEHOLDER: &str = "Optional text to appear on active item";
 }

--- a/frontend/elements/src/_bundles/module/tapping-board/edit/imports.ts
+++ b/frontend/elements/src/_bundles/module/tapping-board/edit/imports.ts
@@ -2,3 +2,6 @@ import "@elements/_bundles/_sub-bundles/module/edit";
 import "@elements/_bundles/_sub-bundles/module/_groups/design/edit";
 import "@elements/_bundles/_sub-bundles/all";
 import "@elements/_bundles/_sub-bundles/hebrew-buttons";
+import "@elements/module/tapping-board/edit/interaction-label";
+import "@elements/module/tapping-board/edit/interaction-preview";
+import "@elements/module/tapping-board/edit/interaction-delete";

--- a/frontend/elements/src/module/tapping-board/edit/interaction-delete.ts
+++ b/frontend/elements/src/module/tapping-board/edit/interaction-delete.ts
@@ -1,0 +1,36 @@
+import { LitElement, html, css, customElement } from "lit-element";
+
+const STR_DELETE = "Delete";
+
+@customElement("interaction-delete-action")
+export class _ extends LitElement {
+    static get styles() {
+        return [
+            css`
+                :host {
+                    display: grid;
+                    justify-self: start;
+                }
+                .content {
+                    display: flex;
+                    align-items: center;
+                    column-gap: 3px;
+                }
+            `,
+        ];
+    }
+
+    render() {
+        return html`
+            <button-rect kind="text" color="blue">
+                <div class="content">
+                    <img-ui
+                        path="module/_common/edit/widgets/sidebar/icons/delete.svg"
+                    ></img-ui>
+                    ${STR_DELETE}
+                </div>
+            </button-rect>
+        `;
+    }
+}
+

--- a/frontend/elements/src/module/tapping-board/edit/interaction-label.ts
+++ b/frontend/elements/src/module/tapping-board/edit/interaction-label.ts
@@ -1,0 +1,59 @@
+import { LitElement, html, css, customElement, property } from "lit-element";
+
+export type mode = "default" | "active" | "success" | "done";
+
+@customElement("tapping-board-interaction-label")
+export class _ extends LitElement {
+    static get styles() {
+        return [
+            css`
+                :host {
+                    display: flex;
+                    flex-direction: column;
+                    row-gap: 20px;
+                }
+                @media (min-width: 1920px) {
+                    :host {
+                        grid-template-rows: 24px 320px auto;
+                    }
+                }
+                .main-content {
+                    border-radius: 16px;
+                    background-color: var(--white);
+                    border-width: 2px;
+                    display: grid;
+                    place-items: center;
+                }
+                .actions {
+                    padding: 0;
+                    display: flex;
+                    flex-direction: row;
+                    justify-content: space-around;
+                }
+                .actions ::slotted(*) {
+                    grid-column: 1;
+                    grid-row: 1;
+                }
+                ::slotted([slot="main-action"]) {
+                    justify-self: center;
+                }
+            `,
+        ];
+    }
+
+    @property({ type: String, reflect: true })
+    mode: mode = "default";
+
+    render() {
+        return html`
+            <div class="main-content">
+                <slot></slot>
+            </div>
+            <div class="actions">
+                <slot name="delete"></slot>
+                <slot name="main-action"></slot>
+            </div>
+        `;
+    }
+}
+

--- a/frontend/elements/src/module/tapping-board/edit/interaction-preview.ts
+++ b/frontend/elements/src/module/tapping-board/edit/interaction-preview.ts
@@ -1,0 +1,62 @@
+import { LitElement, html, css, customElement, property } from "lit-element";
+
+const STR_LABEL: string = "Preview";
+
+@customElement("interaction-preview-action")
+export class _ extends LitElement {
+    static get styles() {
+        return [
+            css`
+                button {
+                    height: 40px;
+                    border: 0;
+                    box-sizing: border-box;
+                    background-color: var(--dark-blue-3);
+                    color: #fff;
+                    padding: 0 24px;
+                    border-radius: 20px;
+                    display: flex;
+                    align-items: center;
+                    column-gap: 12px;
+                    font-family: Poppins;
+                    font-size: 16px;
+                    font-weight: 500;
+                    cursor: pointer;
+                    transition: filter 100ms;
+                }
+                :host(:not([disabled])) button {
+                    filter: opacity(85%);
+                }
+                :host(:not([disabled])) button:hover {
+                    filter: opacity(100%);
+                }
+                :host([disabled]) button {
+                    background-color: var(--light-gray-4);
+                }
+                img-ui {
+                    display: inline-block;
+                    height: 18px;
+                }
+            `,
+        ];
+    }
+
+    @property({ type: Boolean, reflect: true })
+    disabled: boolean = false;
+
+    render() {
+        const iconUrl = `action-preview${
+            this.disabled ? "-disabled" : ""
+        }`;
+
+        return html`
+            <button ?disabled="${this.disabled}">
+                ${STR_LABEL}
+                <img-ui
+                    path="module/_common/edit/widgets/sidebar/icons/${iconUrl}.svg"
+                ></img-ui>
+            </button>
+        `;
+    }
+}
+


### PR DESCRIPTION
Closes #2976

- Updates the interaction label field so that it has similar feel and functionality to the audio input field:
  - Delete and preview button are positioned similarly;
  - Both are styled the same.
- The delete button is visible only if there is text present;
- The preview button is enabled only if there is text present;
- Adds the Hebrew text controls to the field.

![Screenshot 2022-08-11 at 09 41 25](https://user-images.githubusercontent.com/4161106/184086850-2de63d3e-6ad4-4c39-8263-f955f7d662a2.png)
![Screenshot 2022-08-11 at 09 41 36](https://user-images.githubusercontent.com/4161106/184086868-2731bc63-a965-48c5-a8d9-0f18cf6b21b2.png)
