### PR TITLE
fix(fe/jig/edit): Set background of sidebar module window to white when active

### DIFF
--- a/frontend/elements/src/entry/jig/edit/sidebar/module/window.ts
+++ b/frontend/elements/src/entry/jig/edit/sidebar/module/window.ts
@@ -45,6 +45,7 @@ export class _ extends LitElement {
                 }
                 :host([state="active"]) .wrapper {
                     border: solid var(--light-blue-5) 3px;
+                    background-color: var(--white);
                 }
                 :host([incomplete]) .wrapper {
                     border: solid var(--light-red-4) 3px;


### PR DESCRIPTION
Resolves #3061 

![Screenshot 2022-08-15 at 13 38 54](https://user-images.githubusercontent.com/4161106/184628707-a6b41a0b-35fe-4d2a-a73b-782c06b9da06.png)
