### PR TITLE
feat(fe/design): Add feedback field to design content struct

### DIFF
--- a/backend/api/tests/integration/jig/snapshots/integration__jig__module__update_contents-2.snap
+++ b/backend/api/tests/integration/jig/snapshots/integration__jig__module__update_contents-2.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/jig/module.rs
 expression: body
-
 ---
 {
   "module": {
@@ -15,6 +14,10 @@ expression: body
               "steps_completed": []
             },
             "instructions": {
+              "text": null,
+              "audio": null
+            },
+            "feedback": {
               "text": null,
               "audio": null
             },

--- a/backend/api/tests/integration/jig/snapshots/integration__jig__module__update_contents.snap
+++ b/backend/api/tests/integration/jig/snapshots/integration__jig__module__update_contents.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/jig/module.rs
 expression: body
-
 ---
 {
   "module": {
@@ -15,6 +14,10 @@ expression: body
               "steps_completed": []
             },
             "instructions": {
+              "text": null,
+              "audio": null
+            },
+            "feedback": {
               "text": null,
               "audio": null
             },

--- a/frontend/apps/crates/components/src/module/_groups/cards/edit/sidebar/step_3/dom.rs
+++ b/frontend/apps/crates/components/src/module/_groups/cards/edit/sidebar/step_3/dom.rs
@@ -40,6 +40,7 @@ where
         .children(&mut [
             render_tab(state.clone(), MenuTabKind::PlaySettings),
             render_tab(state.clone(), MenuTabKind::Instructions),
+            render_tab(state.clone(), MenuTabKind::Feedback),
             html!("module-sidebar-body", {
                 .property("slot", "body")
                 .child_signal(state.tab.signal_cloned().map(clone!(render_settings => move |tab| {
@@ -50,6 +51,9 @@ where
                         Tab::Instructions(state) => {
                             Some(render_instructions(state))
                         },
+                        Tab::Feedback(state) => {
+                            Some(render_instructions(state))
+                        }
                     }
                 })))
             })

--- a/frontend/apps/crates/components/src/module/_groups/cards/edit/state.rs
+++ b/frontend/apps/crates/components/src/module/_groups/cards/edit/state.rs
@@ -71,6 +71,7 @@ pub struct CardsBase<RawData: RawDataExt, E: ExtraExt> {
     pub step: ReadOnlyMutable<Step>,
     pub theme_id: Mutable<ThemeId>,
     pub instructions: Mutable<Instructions>,
+    pub feedback: Mutable<Instructions>,
     pub mode: Mode,
     pub module_kind: ModuleKind,
     pub tooltips: Tooltips,
@@ -138,6 +139,7 @@ impl<RawData: RawDataExt, E: ExtraExt> CardsBase<RawData, E> {
 
         let mode = content.mode;
         let instructions = Mutable::new(content.instructions);
+        let feedback = Mutable::new(content.feedback);
 
         let background = Mutable::new(content.background);
 
@@ -148,6 +150,7 @@ impl<RawData: RawDataExt, E: ExtraExt> CardsBase<RawData, E> {
             step: step.read_only(),
             theme_id,
             instructions,
+            feedback,
             mode,
             tooltips: Tooltips::new(),
             pairs,

--- a/frontend/apps/crates/entry/module/find-answer/edit/src/base/sidebar/step_4/dom.rs
+++ b/frontend/apps/crates/entry/module/find-answer/edit/src/base/sidebar/step_4/dom.rs
@@ -24,6 +24,7 @@ pub fn render(state: Rc<Step4>) -> Dom {
         .children(&mut [
             render_tab(state.clone(), MenuTabKind::PlaySettings),
             render_tab(state.clone(), MenuTabKind::Instructions),
+            render_tab(state.clone(), MenuTabKind::Feedback),
             html!("module-sidebar-body", {
                 .property("slot", "body")
                 .child_signal(state.tab.signal_cloned().map(|tab| {
@@ -34,6 +35,9 @@ pub fn render(state: Rc<Step4>) -> Dom {
                         Tab::Instructions(state) => {
                             Some(render_instructions(state))
                         },
+                        Tab::Feedback(state) => {
+                            Some(render_instructions(state))
+                        }
                     }
                 }))
             })

--- a/frontend/apps/crates/entry/module/find-answer/edit/src/base/state.rs
+++ b/frontend/apps/crates/entry/module/find-answer/edit/src/base/state.rs
@@ -40,6 +40,7 @@ pub struct Base {
     pub step: ReadOnlyMutable<Step>,
     pub theme_id: Mutable<ThemeId>,
     pub instructions: Mutable<Instructions>,
+    pub feedback: Mutable<Instructions>,
     pub jig_id: JigId,
     pub module_id: ModuleId,
     // FindAnswer-specific
@@ -170,6 +171,7 @@ impl Base {
         let _self_ref: Rc<RefCell<Option<Rc<Self>>>> = Rc::new(RefCell::new(None));
 
         let instructions = Mutable::new(content.base.instructions);
+        let feedback = Mutable::new(content.base.feedback);
 
         let stickers_ref: Rc<RefCell<Option<Rc<Stickers<Sticker>>>>> = Rc::new(RefCell::new(None));
 
@@ -294,6 +296,7 @@ impl Base {
             history,
             step: step.read_only(),
             instructions,
+            feedback,
             text_editor,
             phase: Mutable::new(Phase::Layout),
             backgrounds,

--- a/frontend/apps/crates/entry/module/find-answer/edit/src/debug.rs
+++ b/frontend/apps/crates/entry/module/find-answer/edit/src/debug.rs
@@ -63,6 +63,7 @@ impl DebugSettings {
                         base: BaseContent {
                             theme: ThemeId::Chalkboard,
                             instructions: Instructions::default(),
+                            feedback: Instructions::default(),
                             stickers: init_data
                                 .stickers
                                 .iter()

--- a/shared/rust/src/domain/module/body/_groups/cards.rs
+++ b/shared/rust/src/domain/module/body/_groups/cards.rs
@@ -19,6 +19,10 @@ pub struct BaseContent {
     /// The instructions for the module.
     pub instructions: Instructions,
 
+    /// The feedback for the module.
+    #[serde(default)]
+    pub feedback: Instructions,
+
     /// The mode the module uses.
     pub mode: Mode,
 

--- a/shared/rust/src/domain/module/body/_groups/design.rs
+++ b/shared/rust/src/domain/module/body/_groups/design.rs
@@ -10,6 +10,10 @@ pub struct BaseContent {
     /// The instructions for the module.
     pub instructions: Instructions,
 
+    /// The feedback for the module.
+    #[serde(default)]
+    pub feedback: Instructions,
+
     /// The module's theme.
     pub theme: ThemeId,
 
@@ -24,6 +28,7 @@ impl Default for BaseContent {
     fn default() -> Self {
         Self {
             instructions: Default::default(),
+            feedback: Default::default(),
             theme: Default::default(),
             backgrounds: Default::default(),
             stickers: vec![Sticker::Text(Default::default())],


### PR DESCRIPTION
Part of #2924

- Adds the feedback tab for Answer This;
- Adds the feedback tab for all card game activities (including flashcards).