### PR TITLE
feat(fe/cards): Add feedback to Answer This card games player

### DIFF
--- a/frontend/apps/crates/components/src/module/_common/play/entry/dom.rs
+++ b/frontend/apps/crates/components/src/module/_common/play/entry/dom.rs
@@ -136,6 +136,7 @@ where
     Step: StepExt + 'static,
 {
     let instructions = base.get_instructions();
+    let feedback_player = base.get_feedback_player();
     let is_screenshot = utils::screenshot::is_screenshot_url();
 
     html!("empty-fragment", {
@@ -154,7 +155,9 @@ where
                     }
                 })))
         }))
-
+        .child_signal(feedback_player.signal_cloned().map(|feedback_player| {
+            feedback_player.map(InstructionsPlayer::render)
+        }))
         .apply_if(jig_player, |dom| {
             dom
                 .global_event(|evt:dominator_helpers::events::Message| {

--- a/frontend/apps/crates/components/src/module/_common/play/entry/state.rs
+++ b/frontend/apps/crates/components/src/module/_common/play/entry/state.rs
@@ -1,7 +1,8 @@
 use crate::audio::mixer::AUDIO_MIXER;
+use crate::instructions::player::InstructionsPlayer;
 use dominator::{clone, Dom, DomHandle};
 use dominator_helpers::futures::AsyncLoader;
-use futures_signals::signal::Mutable;
+use futures_signals::signal::{Mutable, ReadOnlyMutable};
 use shared::domain::asset::{Asset, AssetId, AssetType, DraftOrLive, PrivacyLevel};
 use shared::domain::course::CourseResponse;
 use shared::domain::module::body::Instructions;
@@ -392,9 +393,15 @@ pub trait DomRenderable {
 
 pub trait BaseExt: DomRenderable {
     fn play(_state: Rc<Self>) {}
+
     fn get_instructions(&self) -> Option<Instructions> {
         None
     }
+
+    fn get_feedback_player(&self) -> ReadOnlyMutable<Option<Rc<InstructionsPlayer>>> {
+        Mutable::new(None).read_only()
+    }
+
     fn get_timer_minutes(&self) -> Option<u32> {
         None
     }
@@ -402,5 +409,6 @@ pub trait BaseExt: DomRenderable {
     fn set_play_phase(&self, phase: ModulePlayPhase) {
         self.play_phase().set_neq(phase);
     }
+
     fn play_phase(&self) -> Mutable<ModulePlayPhase>;
 }

--- a/frontend/apps/crates/entry/module/card-quiz/play/src/base/game/actions.rs
+++ b/frontend/apps/crates/entry/module/card-quiz/play/src/base/game/actions.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::Ordering;
 
 use components::{
     audio::mixer::{AudioMixer, AudioPath, AudioSourceExt, AUDIO_MIXER},
+    instructions::player::InstructionsPlayer,
     module::_common::play::prelude::*,
     module::_groups::cards::play::card::dom::FLIPPED_AUDIO_EFFECT,
 };
@@ -46,10 +47,15 @@ impl Game {
             );
         } else {
             log::info!("GAME OVER!");
-            state.base.phase.set(Phase::Ending);
-            state
-                .base
-                .set_play_phase(ModulePlayPhase::Ending(Some(ModuleEnding::Positive)));
+            state.base.feedback_player.set(Some(InstructionsPlayer::new(
+                state.base.feedback.clone(),
+                Some(clone!(state => move || {
+                    state.base.phase.set(Phase::Ending);
+                    state
+                        .base
+                        .set_play_phase(ModulePlayPhase::Ending(Some(ModuleEnding::Positive)));
+                })),
+            )));
         }
     }
 

--- a/frontend/apps/crates/entry/module/card-quiz/play/src/base/state.rs
+++ b/frontend/apps/crates/entry/module/card-quiz/play/src/base/state.rs
@@ -10,10 +10,10 @@ use shared::domain::{
     },
 };
 
-use futures_signals::signal::Mutable;
+use futures_signals::signal::{Mutable, ReadOnlyMutable};
 use std::rc::Rc;
 
-use components::module::_common::play::prelude::*;
+use components::{instructions::player::InstructionsPlayer, module::_common::play::prelude::*};
 use utils::prelude::*;
 
 use super::game::state::Game;
@@ -25,6 +25,9 @@ pub struct Base {
     pub theme_id: ThemeId,
     pub background: Option<Background>,
     pub instructions: Instructions,
+    /// Feedback to play when the activity ends
+    pub feedback: Instructions,
+    pub feedback_player: Mutable<Option<Rc<InstructionsPlayer>>>,
     pub settings: PlayerSettings,
     pub raw_pairs: Vec<CardPair>,
     pub phase: Mutable<Phase>,
@@ -57,6 +60,8 @@ impl Base {
             theme_id,
             background: content.base.background,
             instructions: content.base.instructions,
+            feedback: content.base.feedback,
+            feedback_player: Mutable::new(None),
             settings: content.player_settings,
             raw_pairs: content.base.pairs,
             phase: Mutable::new(Phase::Init),
@@ -72,6 +77,10 @@ impl Base {
 impl BaseExt for Base {
     fn get_instructions(&self) -> Option<Instructions> {
         Some(self.instructions.clone())
+    }
+
+    fn get_feedback_player(&self) -> ReadOnlyMutable<Option<Rc<InstructionsPlayer>>> {
+        self.feedback_player.read_only()
     }
 
     fn get_timer_minutes(&self) -> Option<u32> {

--- a/frontend/apps/crates/entry/module/find-answer/play/src/base/game/playing/actions.rs
+++ b/frontend/apps/crates/entry/module/find-answer/play/src/base/game/playing/actions.rs
@@ -118,9 +118,13 @@ impl PlayState {
     fn play_instructions_and_then<F: Fn() + 'static>(self: &Rc<Self>, f: F) {
         let state = self;
 
-        state.feedback_player.set(Some(InstructionsPlayer::new(
-            state.game.base.feedback.clone(),
-            Some(f),
-        )));
+        state
+            .game
+            .base
+            .feedback_player
+            .set(Some(InstructionsPlayer::new(
+                state.game.base.feedback.clone(),
+                Some(f),
+            )));
     }
 }

--- a/frontend/apps/crates/entry/module/find-answer/play/src/base/game/playing/dom.rs
+++ b/frontend/apps/crates/entry/module/find-answer/play/src/base/game/playing/dom.rs
@@ -1,6 +1,5 @@
 use components::{
     audio::mixer::{AudioSourceExt, AUDIO_MIXER},
-    instructions::player::InstructionsPlayer,
     module::_common::play::prelude::ModulePlayPhase,
     traces::{
         bubble::TraceBubble,
@@ -23,9 +22,6 @@ use super::state::*;
 
 pub fn render(state: Rc<PlayState>) -> Dom {
     html!("empty-fragment", {
-        .child_signal(state.feedback_player.signal_cloned().map(|feedback| {
-            feedback.map(InstructionsPlayer::render)
-        }))
         // We don't want the cursor to change when the student mouses over an answer trace, or even an incorrect trace.
         // Make the entire playable area use the pointer cursor.
         .style("cursor", "pointer")

--- a/frontend/apps/crates/entry/module/find-answer/play/src/base/game/playing/state.rs
+++ b/frontend/apps/crates/entry/module/find-answer/play/src/base/game/playing/state.rs
@@ -1,5 +1,4 @@
 use crate::base::game::state::*;
-use components::instructions::player::InstructionsPlayer;
 use components::traces::{bubble::TraceBubble, utils::TraceExt};
 use dominator::clone;
 use futures_signals::signal::Mutable;
@@ -25,8 +24,6 @@ pub struct PlayState {
     /// Flag indicating whether the question has already ended. When true, subsequent taps on the answer traces will
     /// not trigger any logic.
     pub ended: Mutable<bool>,
-    /// Feedback to be played when the activity ends
-    pub feedback_player: Mutable<Option<Rc<InstructionsPlayer>>>,
 }
 
 impl PlayState {
@@ -43,7 +40,6 @@ impl PlayState {
             traces,
             selected_set: Mutable::new(HashSet::new()),
             ended: Mutable::new(false),
-            feedback_player: Mutable::new(None),
         })
     }
 }

--- a/frontend/apps/crates/entry/module/find-answer/play/src/base/state.rs
+++ b/frontend/apps/crates/entry/module/find-answer/play/src/base/state.rs
@@ -17,7 +17,7 @@ use shared::domain::{
 };
 use utils::prelude::*;
 
-use futures_signals::signal::Mutable;
+use futures_signals::signal::{Mutable, ReadOnlyMutable};
 use std::{cell::RefCell, rc::Rc};
 use web_sys::HtmlElement;
 
@@ -40,6 +40,7 @@ pub struct Base {
     pub instructions_finished: Mutable<bool>,
     /// Feedback to play when the activity ends
     pub feedback: Instructions,
+    pub feedback_player: Mutable<Option<Rc<InstructionsPlayer>>>,
 }
 
 impl Base {
@@ -95,6 +96,7 @@ impl Base {
             ),
             instructions_finished: Mutable::new(false),
             feedback: content.base.feedback,
+            feedback_player: Mutable::new(None),
         });
 
         *base_ref.borrow_mut() = Some(base.clone());
@@ -106,6 +108,10 @@ impl Base {
 impl BaseExt for Base {
     fn play_phase(&self) -> Mutable<ModulePlayPhase> {
         self.module_phase.clone()
+    }
+
+    fn get_feedback_player(&self) -> ReadOnlyMutable<Option<Rc<InstructionsPlayer>>> {
+        self.feedback_player.read_only()
     }
 
     fn get_timer_minutes(&self) -> Option<u32> {

--- a/frontend/apps/crates/entry/module/matching/play/src/base/game/actions.rs
+++ b/frontend/apps/crates/entry/module/matching/play/src/base/game/actions.rs
@@ -3,7 +3,9 @@ use super::state::*;
 use std::sync::atomic::Ordering;
 
 use crate::base::state::Phase;
+use components::instructions::player::InstructionsPlayer;
 use components::module::_common::play::prelude::*;
+use dominator::clone;
 use rand::prelude::*;
 use std::convert::TryInto;
 use std::rc::Rc;
@@ -37,10 +39,15 @@ impl Game {
             );
         } else {
             log::info!("GAME OVER!");
-            state.base.phase.set(Phase::Ending);
-            state
-                .base
-                .set_play_phase(ModulePlayPhase::Ending(Some(ModuleEnding::Positive)));
+            state.base.feedback_player.set(Some(InstructionsPlayer::new(
+                state.base.feedback.clone(),
+                Some(clone!(state => move || {
+                    state.base.phase.set(Phase::Ending);
+                    state
+                        .base
+                        .set_play_phase(ModulePlayPhase::Ending(Some(ModuleEnding::Positive)));
+                })),
+            )));
         }
     }
 

--- a/frontend/apps/crates/entry/module/matching/play/src/base/state.rs
+++ b/frontend/apps/crates/entry/module/matching/play/src/base/state.rs
@@ -10,10 +10,10 @@ use shared::domain::{
     },
 };
 
-use futures_signals::signal::Mutable;
+use futures_signals::signal::{Mutable, ReadOnlyMutable};
 use std::rc::Rc;
 
-use components::module::_common::play::prelude::*;
+use components::{instructions::player::InstructionsPlayer, module::_common::play::prelude::*};
 use utils::prelude::*;
 
 use super::game::state::Game;
@@ -25,6 +25,8 @@ pub struct Base {
     pub theme_id: ThemeId,
     pub background: Option<Background>,
     pub instructions: Instructions,
+    pub feedback: Instructions,
+    pub feedback_player: Mutable<Option<Rc<InstructionsPlayer>>>,
     pub settings: PlayerSettings,
     pub raw_pairs: Vec<CardPair>,
     pub phase: Mutable<Phase>,
@@ -58,6 +60,8 @@ impl Base {
             theme_id,
             background: content.base.background,
             instructions: content.base.instructions,
+            feedback: content.base.feedback,
+            feedback_player: Mutable::new(None),
             settings: content.player_settings,
             raw_pairs: content.base.pairs,
             module_phase: init_args.play_phase,
@@ -73,6 +77,10 @@ impl Base {
 impl BaseExt for Base {
     fn get_instructions(&self) -> Option<Instructions> {
         Some(self.instructions.clone())
+    }
+
+    fn get_feedback_player(&self) -> ReadOnlyMutable<Option<Rc<InstructionsPlayer>>> {
+        self.feedback_player.read_only()
     }
 
     fn get_timer_minutes(&self) -> Option<u32> {

--- a/frontend/apps/crates/entry/module/memory/play/src/base/stage/dom.rs
+++ b/frontend/apps/crates/entry/module/memory/play/src/base/stage/dom.rs
@@ -1,5 +1,5 @@
 use super::game::dom::render as render_game;
-use components::module::_common::play::prelude::*;
+use components::{instructions::player::InstructionsPlayer, module::_common::play::prelude::*};
 use dominator::{clone, html, Dom};
 use futures_signals::signal::SignalExt;
 use std::rc::Rc;
@@ -10,7 +10,12 @@ pub fn render(state: Rc<Base>) -> Dom {
     html!("empty-fragment", {
         .future(state.all_cards_ended_signal().dedupe().for_each(clone!(state => move |ended| {
             if ended {
-                state.set_play_phase(ModulePlayPhase::Ending(Some(ModuleEnding::Positive)));
+                state.feedback_player.set(Some(InstructionsPlayer::new(
+                    state.feedback.clone(),
+                    Some(clone!(state => move || {
+                        state.set_play_phase(ModulePlayPhase::Ending(Some(ModuleEnding::Positive)));
+                    })),
+                )));
             }
             async {}
         })))

--- a/frontend/apps/crates/entry/module/memory/play/src/base/state.rs
+++ b/frontend/apps/crates/entry/module/memory/play/src/base/state.rs
@@ -14,9 +14,12 @@ use shared::{
 };
 
 use super::card::state::*;
-use components::module::{_common::play::prelude::*, _groups::cards::lookup::Side};
+use components::{
+    instructions::player::InstructionsPlayer,
+    module::{_common::play::prelude::*, _groups::cards::lookup::Side},
+};
 use futures::future::join_all;
-use futures_signals::signal::{self, Mutable, Signal, SignalExt};
+use futures_signals::signal::{self, Mutable, ReadOnlyMutable, Signal, SignalExt};
 use gloo_timers::future::TimeoutFuture;
 use rand::prelude::*;
 use std::future::Future;
@@ -35,6 +38,9 @@ pub struct Base {
     pub flip_state: Mutable<FlipState>,
     pub found_pairs: RefCell<Vec<(usize, usize)>>,
     pub instructions: Instructions,
+    /// Feedback to play when the activity ends
+    pub feedback: Instructions,
+    pub feedback_player: Mutable<Option<Rc<InstructionsPlayer>>>,
     pub settings: PlayerSettings,
     pub module_phase: Mutable<ModulePlayPhase>,
 }
@@ -131,6 +137,8 @@ impl Base {
             flip_state: Mutable::new(FlipState::None),
             found_pairs: RefCell::new(Vec::new()),
             instructions: content.base.instructions,
+            feedback: content.base.feedback,
+            feedback_player: Mutable::new(None),
             settings: content.player_settings,
             module_phase: init_args.play_phase,
         })
@@ -157,6 +165,10 @@ impl Base {
 impl BaseExt for Base {
     fn get_instructions(&self) -> Option<Instructions> {
         Some(self.instructions.clone())
+    }
+
+    fn get_feedback_player(&self) -> ReadOnlyMutable<Option<Rc<InstructionsPlayer>>> {
+        self.feedback_player.read_only()
     }
 
     fn get_timer_minutes(&self) -> Option<u32> {


### PR DESCRIPTION
Part of #2924

- Updates BaseExt to include a function to fetch an optional instructions player for feedback;
- Updates Answer This to set the instructions player in the base state;
- Adds feedback rendering to the card game activities.