### PR TITLE
feat(fe/component/instruction): Add support for multiple instruction types

### DIFF
--- a/frontend/apps/crates/components/src/instructions/editor/dom.rs
+++ b/frontend/apps/crates/components/src/instructions/editor/dom.rs
@@ -8,9 +8,6 @@ use crate::audio::input::{AudioInput, AudioInputCallbacks, AudioInputOptions};
 use futures_signals::signal::SignalExt;
 use shared::domain::module::body::Audio;
 
-pub const STR_INSTRUCTIONS_LABEL: &str = "Written instructions";
-pub const STR_INSTRUCTIONS_PLACEHOLDER: &str = "Type instructions";
-
 pub fn render(state: Rc<State>) -> Dom {
     html!("div", {
         .children(&mut [
@@ -32,11 +29,11 @@ pub fn render_text(state: Rc<State>) -> Dom {
         (state.callbacks.save)(lock.clone(), push_history);
     }
     html!("input-wrapper", {
-        .property("label", STR_INSTRUCTIONS_LABEL)
+        .property("label", state.instructions_text.label)
         .child(html!("textarea" => HtmlTextAreaElement, {
             .with_node!(elem => {
                 .text_signal(state.text_signal())
-                .property("placeholder", STR_INSTRUCTIONS_PLACEHOLDER)
+                .property("placeholder", state.instructions_text.placeholder)
                 .property("rows", 4)
                 //Input saves every character
                 //Change also pushes history

--- a/frontend/apps/crates/components/src/instructions/editor/state.rs
+++ b/frontend/apps/crates/components/src/instructions/editor/state.rs
@@ -3,16 +3,54 @@ use shared::domain::module::body::{Audio, Instructions};
 
 use super::callbacks::Callbacks;
 
+pub const STR_LABEL_INSTRUCTIONS: &str = "Written instructions";
+pub const STR_PLACEHOLDER_INSTRUCTIONS: &str = "Type instructions";
+pub const STR_LABEL_FEEDBACK: &str = "Written feedback";
+pub const STR_PLACEHOLDER_FEEDBACK: &str = "Type feedback";
+
 pub struct State {
     pub instructions: Mutable<Instructions>,
     pub callbacks: Callbacks,
+    pub instructions_text: InstructionsText,
+}
+
+pub enum InstructionsType {
+    Instructions,
+    Feedback,
+    Custom(InstructionsText),
+}
+
+pub struct InstructionsText {
+    pub label: &'static str,
+    pub placeholder: &'static str,
+}
+
+impl From<InstructionsType> for InstructionsText {
+    fn from(instructions_type: InstructionsType) -> Self {
+        match instructions_type {
+            InstructionsType::Instructions => Self {
+                label: STR_LABEL_INSTRUCTIONS,
+                placeholder: STR_PLACEHOLDER_INSTRUCTIONS,
+            },
+            InstructionsType::Feedback => Self {
+                label: STR_LABEL_FEEDBACK,
+                placeholder: STR_PLACEHOLDER_FEEDBACK,
+            },
+            InstructionsType::Custom(instructions_text) => instructions_text,
+        }
+    }
 }
 
 impl State {
-    pub fn new(instructions: Mutable<Instructions>, callbacks: Callbacks) -> Self {
+    pub fn new(
+        instructions: Mutable<Instructions>,
+        callbacks: Callbacks,
+        instructions_type: InstructionsType,
+    ) -> Self {
         Self {
             instructions,
             callbacks,
+            instructions_text: instructions_type.into(),
         }
     }
 

--- a/frontend/apps/crates/components/src/module/_groups/cards/edit/sidebar/step_3/state.rs
+++ b/frontend/apps/crates/components/src/module/_groups/cards/edit/sidebar/step_3/state.rs
@@ -1,7 +1,7 @@
 use crate::{
     instructions::editor::{
         callbacks::Callbacks as InstructionsEditorCallbacks,
-        state::State as InstructionsEditorState,
+        state::{InstructionsType, State as InstructionsEditorState},
     },
     module::_groups::cards::edit::state::*,
     tabs::MenuTabKind,
@@ -108,7 +108,11 @@ impl<SettingsState> Tab<SettingsState> {
                     }),
                 );
 
-                let state = InstructionsEditorState::new(base.instructions.clone(), callbacks);
+                let state = InstructionsEditorState::new(
+                    base.instructions.clone(),
+                    callbacks,
+                    InstructionsType::Instructions,
+                );
 
                 Self::Instructions(Rc::new(state))
             }
@@ -131,7 +135,11 @@ impl<SettingsState> Tab<SettingsState> {
                     }),
                 );
 
-                let state = InstructionsEditorState::new(base.feedback.clone(), callbacks);
+                let state = InstructionsEditorState::new(
+                    base.feedback.clone(),
+                    callbacks,
+                    InstructionsType::Feedback,
+                );
 
                 Self::Feedback(Rc::new(state))
             }

--- a/frontend/apps/crates/entry/module/drag-drop/edit/src/base/sidebar/step_4/state.rs
+++ b/frontend/apps/crates/entry/module/drag-drop/edit/src/base/sidebar/step_4/state.rs
@@ -2,7 +2,7 @@ use crate::base::state::*;
 use components::{
     instructions::editor::{
         callbacks::Callbacks as InstructionsEditorCallbacks,
-        state::State as InstructionsEditorState,
+        state::{InstructionsType, State as InstructionsEditorState},
     },
     tabs::MenuTabKind,
 };
@@ -69,7 +69,11 @@ impl Tab {
                     }),
                 );
 
-                let state = InstructionsEditorState::new(base.instructions.clone(), callbacks);
+                let state = InstructionsEditorState::new(
+                    base.instructions.clone(),
+                    callbacks,
+                    InstructionsType::Instructions,
+                );
 
                 Self::Instructions(Rc::new(state))
             }
@@ -92,7 +96,11 @@ impl Tab {
                     }),
                 );
 
-                let state = InstructionsEditorState::new(base.feedback.clone(), callbacks);
+                let state = InstructionsEditorState::new(
+                    base.feedback.clone(),
+                    callbacks,
+                    InstructionsType::Feedback,
+                );
 
                 Self::Feedback(Rc::new(state))
             }

--- a/frontend/apps/crates/entry/module/find-answer/edit/src/base/sidebar/step_4/state.rs
+++ b/frontend/apps/crates/entry/module/find-answer/edit/src/base/sidebar/step_4/state.rs
@@ -2,7 +2,7 @@ use crate::base::state::Base;
 use components::{
     instructions::editor::{
         callbacks::Callbacks as InstructionsEditorCallbacks,
-        state::State as InstructionsEditorState,
+        state::{InstructionsType, State as InstructionsEditorState},
     },
     tabs::MenuTabKind,
 };
@@ -68,7 +68,11 @@ impl Tab {
                     }),
                 );
 
-                let state = InstructionsEditorState::new(base.instructions.clone(), callbacks);
+                let state = InstructionsEditorState::new(
+                    base.instructions.clone(),
+                    callbacks,
+                    InstructionsType::Instructions,
+                );
 
                 Self::Instructions(Rc::new(state))
             }
@@ -91,7 +95,11 @@ impl Tab {
                     }),
                 );
 
-                let state = InstructionsEditorState::new(base.feedback.clone(), callbacks);
+                let state = InstructionsEditorState::new(
+                    base.feedback.clone(),
+                    callbacks,
+                    InstructionsType::Feedback,
+                );
 
                 Self::Feedback(Rc::new(state))
             }

--- a/frontend/apps/crates/entry/module/tapping-board/edit/src/base/sidebar/step_4/state.rs
+++ b/frontend/apps/crates/entry/module/tapping-board/edit/src/base/sidebar/step_4/state.rs
@@ -2,7 +2,7 @@ use crate::base::state::Base;
 use components::{
     instructions::editor::{
         callbacks::Callbacks as InstructionsEditorCallbacks,
-        state::State as InstructionsEditorState,
+        state::{InstructionsType, State as InstructionsEditorState},
     },
     tabs::MenuTabKind,
 };
@@ -67,7 +67,11 @@ impl Tab {
                     }),
                 );
 
-                let state = InstructionsEditorState::new(base.instructions.clone(), callbacks);
+                let state = InstructionsEditorState::new(
+                    base.instructions.clone(),
+                    callbacks,
+                    InstructionsType::Instructions,
+                );
 
                 Self::Instructions(Rc::new(state))
             }

--- a/frontend/apps/crates/entry/module/video/edit/src/base/sidebar/step_3/state.rs
+++ b/frontend/apps/crates/entry/module/video/edit/src/base/sidebar/step_3/state.rs
@@ -4,7 +4,7 @@ use crate::base::state::Base;
 use components::{
     instructions::editor::{
         callbacks::Callbacks as InstructionsEditorCallbacks,
-        state::State as InstructionsEditorState,
+        state::{InstructionsType, State as InstructionsEditorState},
     },
     tabs::MenuTabKind,
 };
@@ -68,7 +68,11 @@ impl Tab {
                     }),
                 );
 
-                let state = InstructionsEditorState::new(base.instructions.clone(), callbacks);
+                let state = InstructionsEditorState::new(
+                    base.instructions.clone(),
+                    callbacks,
+                    InstructionsType::Instructions,
+                );
 
                 Self::Instructions(Rc::new(state))
             }


### PR DESCRIPTION
Closes #2924

- Change the label and placeholder text in the Feedback tab;
- Updates the Instruction component to allow for multiple `InstructionsType`'s. 
  - This component needs to be renamed now that we're reusing it in more places than just the dragdrop activity.