### PR TITLE
feat(fe/elements/lists): Make list headers and actions sticky so that they're always visible

### DIFF
--- a/frontend/elements/src/module/_common/edit/widgets/lists/dual/dual-list.ts
+++ b/frontend/elements/src/module/_common/edit/widgets/lists/dual/dual-list.ts
@@ -1,22 +1,12 @@
 import { LitElement, html, css, customElement } from "lit-element";
 
-const STR_ADD_WORDS = "Add Your Words";
+const STR_ADD_WORDS = "Add words here";
 
 @customElement("sidebar-widget-dual-list")
 export class _ extends LitElement {
     static get styles() {
         return [
             css`
-                :host {
-                    display: grid;
-                    /*
-                        using minmax(0, 1fr) instead of just 1fr to allow the items inside to overflow without growing the container.
-                        https://stackoverflow.com/a/52861514/5253155
-                        https://stackoverflow.com/a/43312314/5253155
-                    */
-                    grid-template-rows: auto auto minmax(0, 1fr);
-                    height: 100%;
-                }
                 .lists {
                     width: 100%;
                     display: grid;
@@ -31,7 +21,11 @@ export class _ extends LitElement {
                         gap: 12px;
                     }
                 }
-
+                .header {
+                    top: 0;
+                    position: sticky;
+                    background-color: #e9eff8;
+                }
                 /* weird mechanism to get scrollbar margin-left https://stackoverflow.com/a/45420691/5253155 */
                 .lists::-webkit-scrollbar {
                     width: 9px; /* 6px, plus 3px for border */
@@ -51,11 +45,9 @@ export class _ extends LitElement {
                 }
 
                 .input-buttons {
-                    margin-top: 34px;
+                    padding: 12px 0;
                     display: flex;
                     justify-content: flex-end;
-                    margin-bottom: 12px;
-                    margin-right: 4px;
                 }
                 @media (min-width: 1920px) {
                     .input-buttons {
@@ -67,8 +59,10 @@ export class _ extends LitElement {
                 .done-btn {
                     display: flex;
                     justify-content: flex-end;
-                    margin-top: 16px;
-                    padding-bottom: 40px;
+                    padding: 16px 0;
+                    bottom: 0;
+                    position: sticky;
+                    background-color: #e9eff8;
                 }
             `,
         ];
@@ -76,12 +70,14 @@ export class _ extends LitElement {
 
     render() {
         return html`
-            <header>
-                <div>${STR_ADD_WORDS}</div>
-                <div><slot name="clear"></slot></div>
-            </header>
-            <div class="input-buttons">
-                <slot name="hebrew-buttons"></slot>
+            <div class="header">
+                <header>
+                    <div>${STR_ADD_WORDS}</div>
+                    <div><slot name="clear"></slot></div>
+                </header>
+                <div class="input-buttons">
+                    <slot name="hebrew-buttons"></slot>
+                </div>
             </div>
             <div class="lists-and-actions">
                 <div class="lists">

--- a/frontend/elements/src/module/_common/edit/widgets/lists/single/single-list.ts
+++ b/frontend/elements/src/module/_common/edit/widgets/lists/single/single-list.ts
@@ -1,38 +1,31 @@
 import { LitElement, html, css, customElement } from "lit-element";
 
-const STR_ADD_WORDS = "Add Your Words";
+const STR_ADD_WORDS = "Add words here";
 
 @customElement("sidebar-widget-single-list")
 export class _ extends LitElement {
     static get styles() {
         return [
             css`
-                :host {
-                    display: grid;
-                    /*
-                        using minmax(0, 1fr) instead of just 1fr to allow the items inside to overflow without growing the container.
-                        https://stackoverflow.com/a/52861514/5253155
-                        https://stackoverflow.com/a/43312314/5253155
-                    */
-                    grid-template-rows: auto auto minmax(0, 1fr);
-                    height: 100%;
-                }
                 header {
                     display: flex;
                     justify-content: space-between;
                 }
                 .input-buttons {
-                    margin-top: 34px;
+                    padding: 12px 0;
                     display: flex;
                     justify-content: flex-end;
-                    margin-bottom: 12px;
-                    margin-right: 4px;
                 }
                 @media (min-width: 1920px) {
                     .input-buttons {
                         margin-bottom: 18px;
                         margin-right: 0px;
                     }
+                }
+                .header {
+                    top: 0;
+                    position: sticky;
+                    background-color: #e9eff8;
                 }
                 .list {
                     box-sizing: border-box;
@@ -67,8 +60,10 @@ export class _ extends LitElement {
                 .done-btn {
                     display: flex;
                     justify-content: flex-end;
-                    margin-top: 16px;
-                    padding-bottom: 40px;
+                    padding: 16px 0;
+                    bottom: 0;
+                    position: sticky;
+                    background-color: #e9eff8;
                 }
             `,
         ];
@@ -76,12 +71,14 @@ export class _ extends LitElement {
 
     render() {
         return html`
-            <header>
-                <div>${STR_ADD_WORDS}</div>
-                <div><slot name="clear"></slot></div>
-            </header>
-            <div class="input-buttons">
-                <slot name="hebrew-buttons"></slot>
+            <div class="header">
+                <header>
+                    <div>${STR_ADD_WORDS}</div>
+                    <div><slot name="clear"></slot></div>
+                </header>
+                <div class="input-buttons">
+                    <slot name="hebrew-buttons"></slot>
+                </div>
             </div>
             <div class="lists-and-actions">
                 <div class="list">


### PR DESCRIPTION
Part of #2987;
Closes #3103.

- Ensures that the Hebrew text controls and the generate button are always visible when creating card game activities;
- Updates the instruction text for the lists.