### PR TITLE
feat(fe/modal-confirm): Update delete button colors, ordering and layout

### DIFF
--- a/frontend/apps/crates/components/src/lists/dual/dom.rs
+++ b/frontend/apps/crates/components/src/lists/dual/dom.rs
@@ -22,8 +22,8 @@ use futures_signals::{
 
 const STR_DELETE_TITLE: &str = "Warning";
 const STR_DELETE_CONTENT: &str = "Are you sure you want to delete this list?";
-const STR_DELETE_CONFIRM: &str = "Yes, go ahead!";
-const STR_DELETE_CANCEL: &str = "No, keep this list";
+const STR_DELETE_CONFIRM: &str = "Yes, delete";
+const STR_DELETE_CANCEL: &str = "Don't delete";
 
 pub fn render(state: Rc<State>) -> Dom {
     html!("sidebar-widget-dual-list", {
@@ -88,6 +88,7 @@ pub fn render(state: Rc<State>) -> Dom {
                             .property("content", STR_DELETE_CONTENT)
                             .property("cancel_text", STR_DELETE_CANCEL)
                             .property("confirm_text", STR_DELETE_CONFIRM)
+                            .property("confirmIcon", "core/menus/delete-white.svg")
                             .event(clone!(state => move |_evt: events::CustomCancel| state.confirm_clear.set_neq(false)))
                             .event(clone!(state => move |_evt: events::CustomConfirm| {
                                 state.confirm_clear.set_neq(false);

--- a/frontend/apps/crates/components/src/lists/single/dom.rs
+++ b/frontend/apps/crates/components/src/lists/single/dom.rs
@@ -18,8 +18,8 @@ use futures_signals::{map_ref, signal::SignalExt, signal_vec::SignalVecExt};
 
 const STR_DELETE_TITLE: &str = "Warning";
 const STR_DELETE_CONTENT: &str = "Are you sure you want to delete this list?";
-const STR_DELETE_CONFIRM: &str = "Yes, go ahead!";
-const STR_DELETE_CANCEL: &str = "No, keep this list";
+const STR_DELETE_CONFIRM: &str = "Yes, delete";
+const STR_DELETE_CANCEL: &str = "Don't delete";
 
 pub fn render(state: Rc<State>) -> Dom {
     html!("sidebar-widget-single-list", {
@@ -122,6 +122,7 @@ pub fn render(state: Rc<State>) -> Dom {
                             .property("content", STR_DELETE_CONTENT)
                             .property("cancel_text", STR_DELETE_CANCEL)
                             .property("confirm_text", STR_DELETE_CONFIRM)
+                            .property("confirmIcon", "core/menus/delete-white.svg")
                             .event(clone!(state => move |_evt: events::CustomCancel| state.confirm_clear.set_neq(false)))
                             .event(clone!(state => move |_evt: events::CustomConfirm| {
                                 state.confirm_clear.set_neq(false);

--- a/frontend/apps/crates/components/src/module/_groups/cards/edit/main/pair/card/dom.rs
+++ b/frontend/apps/crates/components/src/module/_groups/cards/edit/main/pair/card/dom.rs
@@ -26,11 +26,11 @@ const STR_CONFIRM_TITLE: &str = "Warning";
 
 const STR_REMOVE_CONTENT_IMAGE: &str = "Are you sure you want to remove this image?";
 const STR_REMOVE_CONTENT_AUDIO: &str = "Are you sure you want to remove this audio clip?";
-const STR_REMOVE_CONFIRM: &str = "Remove";
+const STR_REMOVE_CONFIRM: &str = "Yes, remove";
 const STR_REMOVE_CANCEL: &str = "Don't remove";
 
 const STR_DELETE_CONTENT_PAIR: &str = "Are you sure you want to delete this pair?";
-const STR_DELETE_CONFIRM: &str = "Delete Pair";
+const STR_DELETE_CONFIRM: &str = "Yes, delete";
 const STR_DELETE_CANCEL: &str = "Don't delete";
 
 pub fn render<RawData: RawDataExt, E: ExtraExt>(state: Rc<MainCard<RawData, E>>) -> Dom {
@@ -49,6 +49,7 @@ pub fn render<RawData: RawDataExt, E: ExtraExt>(state: Rc<MainCard<RawData, E>>)
                             .property("content", confirm_action.content)
                             .property("cancel_text", confirm_action.cancel)
                             .property("confirm_text", confirm_action.confirm)
+                            .property("confirmIcon", "core/menus/delete-white.svg")
                             .event(clone!(state => move |_evt: events::CustomCancel| state.confirm_action.set(None)))
                             .event(clone!(state => move |_evt: events::CustomConfirm| {
                                 state.confirm_action.set(None);

--- a/frontend/apps/crates/components/src/module/_groups/cards/edit/sidebar/step_1/dom.rs
+++ b/frontend/apps/crates/components/src/module/_groups/cards/edit/sidebar/step_1/dom.rs
@@ -22,8 +22,8 @@ const STR_EMPTY_AUDIO_SELECTION: &str = "Select a card or a pair of cards to add
 
 const STR_DELETE_TITLE: &str = "Warning";
 const STR_DELETE_CONTENT: &str = "Are you sure you want to delete this list?";
-const STR_DELETE_CONFIRM: &str = "Yes, go ahead!";
-const STR_DELETE_CANCEL: &str = "No, keep this list";
+const STR_DELETE_CONFIRM: &str = "Yes, delete";
+const STR_DELETE_CANCEL: &str = "Don't delete";
 
 pub fn render<RawData: RawDataExt, E: ExtraExt>(state: Rc<Step1<RawData, E>>) -> Dom {
     let continue_signal = map_ref! {
@@ -246,6 +246,7 @@ fn render_non_empty<RawData: RawDataExt, E: ExtraExt>(state: Rc<Step1<RawData, E
                             .property("content", STR_DELETE_CONTENT)
                             .property("cancel_text", STR_DELETE_CANCEL)
                             .property("confirm_text", STR_DELETE_CONFIRM)
+                            .property("confirmIcon", "core/menus/delete-white.svg")
                             .event(clone!(state => move |_evt: events::CustomCancel| state.confirm_clear.set_neq(false)))
                             .event(clone!(state => move |_evt: events::CustomConfirm| {
                                 state.confirm_clear.set_neq(false);

--- a/frontend/apps/crates/entry/admin/src/categories/dom.rs
+++ b/frontend/apps/crates/entry/admin/src/categories/dom.rs
@@ -9,7 +9,7 @@ use utils::events;
 
 const STR_DELETE_TITLE: &str = "Warning";
 const STR_DELETE_CONTENT: &str = "Deleting the category \"{category}\" will also remove it from any images or JIGs associated with it. Are you sure you want to delete this category?";
-const STR_DELETE_CONFIRM: &str = "Delete category";
+const STR_DELETE_CONFIRM: &str = "Yes, delete";
 const STR_DELETE_CANCEL: &str = "Don't delete";
 
 pub struct CategoriesPage {}
@@ -28,6 +28,7 @@ impl CategoriesPage {
                         .property("content", STR_DELETE_CONTENT.replace("{category}", &content_state.cat.name.get_cloned()))
                         .property("cancel_text", STR_DELETE_CANCEL)
                         .property("confirm_text", STR_DELETE_CONFIRM)
+                        .property("confirmIcon", "core/menus/delete-white.svg")
                         .event(clone!(state => move |_evt: events::CustomCancel| state.deleting.set(None)))
                         .event(clone!(state => move |_evt: events::CustomConfirm| {
                             state.deleting.set(None);

--- a/frontend/apps/crates/entry/admin/src/images/meta/dom.rs
+++ b/frontend/apps/crates/entry/admin/src/images/meta/dom.rs
@@ -22,6 +22,8 @@ const STR_PUBLISH: &str = "Publish";
 
 const STR_DELETE_TITLE: &str = "Warning";
 const STR_DELETE_CONTENT: &str = "Are you sure you want to delete this image?";
+const STR_DELETE_CONFIRM: &str = "Yes, delete";
+const STR_DELETE_CANCEL: &str = "Don't delete";
 
 pub struct ImageMetaPage {}
 
@@ -195,6 +197,9 @@ impl ImageMetaPage {
                                         .property("dangerous", true)
                                         .property("title", STR_DELETE_TITLE)
                                         .property("content", STR_DELETE_CONTENT)
+                                        .property("cancel_text", STR_DELETE_CANCEL)
+                                        .property("confirm_text", STR_DELETE_CONFIRM)
+                                        .property("confirmIcon", "core/menus/delete-white.svg")
                                         .event(clone!(state => move |_evt: events::CustomCancel| state.delete_modal.set_neq(false)))
                                         .event(clone!(state => move |_evt: events::CustomConfirm| {
                                             state.delete_modal.set_neq(false);

--- a/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/spot/dom.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/spot/dom.rs
@@ -21,7 +21,7 @@ use utils::prelude::*;
 
 const STR_DELETE_TITLE: &str = "Warning";
 const STR_DELETE_CONTENT: &str = "Are you sure you want to delete this activity?";
-const STR_DELETE_CONFIRM: &str = "Delete activity";
+const STR_DELETE_CONFIRM: &str = "Yes, delete";
 const STR_DELETE_CANCEL: &str = "Don't delete";
 
 pub struct ItemDom {}
@@ -61,6 +61,7 @@ impl ItemDom {
                         .property("content", STR_DELETE_CONTENT)
                         .property("cancel_text", STR_DELETE_CANCEL)
                         .property("confirm_text", STR_DELETE_CONFIRM)
+                        .property("confirmIcon", "core/menus/delete-white.svg")
                         .event(clone!(state => move |_evt: events::CustomCancel| state.confirm_delete.set_neq(false)))
                         .event(clone!(state => move |_evt: events::CustomConfirm| {
                             state.confirm_delete.set_neq(false);

--- a/frontend/apps/crates/entry/jig/edit/src/gallery/dom.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/gallery/dom.rs
@@ -25,7 +25,7 @@ const STR_DELETE_CONTENT: &str = "Are you sure you want to delete this JIG?";
 const STR_DELETE_CONTENT_WARNING_1: &str = "Deleting in Jigzi is ";
 const STR_DELETE_CONTENT_WARNING_2: &str = "permanent";
 const STR_DELETE_CONTENT_WARNING_3: &str = " and cannot be undone.";
-const STR_DELETE_CONFIRM: &str = "Delete JIG";
+const STR_DELETE_CONFIRM: &str = "Yes, delete";
 const STR_DELETE_CANCEL: &str = "Don't delete";
 
 const STR_LOAD_MORE: &str = "See more";
@@ -66,6 +66,7 @@ impl Gallery {
                         .property("title", STR_DELETE_TITLE)
                         .property("cancel_text", STR_DELETE_CANCEL)
                         .property("confirm_text", STR_DELETE_CONFIRM)
+                        .property("confirmIcon", "core/menus/delete-white.svg")
                         .child(html!("div", {
                             .property("slot", "content")
                             .child(html!("p", {

--- a/frontend/apps/crates/entry/module/find-answer/edit/src/base/sidebar/step_3/dom.rs
+++ b/frontend/apps/crates/entry/module/find-answer/edit/src/base/sidebar/step_3/dom.rs
@@ -331,7 +331,8 @@ pub fn render_question(
                             .property("title", "Warning")
                             .property("content", "Are you sure you want to delete this question?")
                             .property("cancel_text", "Don't delete")
-                            .property("confirm_text", "Delete question")
+                            .property("confirm_text", "Yes, delete")
+                            .property("confirmIcon", "core/menus/delete-white.svg")
                             .event(clone!(question => move |_evt: events::CustomCancel| question.confirm_delete.set_neq(false)))
                             .event(clone!(state, index, question => move |_evt: events::CustomConfirm| {
                                 question.confirm_delete.set_neq(false);

--- a/frontend/elements/src/core/buttons/rectangle.ts
+++ b/frontend/elements/src/core/buttons/rectangle.ts
@@ -1,7 +1,7 @@
 import { LitElement, html, css, customElement, property } from "lit-element";
 import { ifDefined } from "lit-html/directives/if-defined";
 
-export type Color = "red" | "blue" | "green" | "darkGray" | "lightBlue";
+export type Color = "red" | "blue" | "green" | "darkGray" | "lightBlue" | "alert";
 export type Size = "small" | "medium" | "large";
 export type Kind = "filled" | "text" | "outline";
 
@@ -54,7 +54,13 @@ export class _ extends LitElement {
                     --color: var(--main-red);
                 }
                 :host([color="red"]:hover) {
-                    --color: #ed6065;
+                    --color: var(--dark-red-2);
+                }
+                :host([color="alert"]) {
+                    --color: var(--dark-red-2);
+                }
+                :host([color="alert"]:hover) {
+                    --color: var(--red-alert);
                 }
                 :host([color="blue"]) {
                     --color: #5590fc;
@@ -131,6 +137,12 @@ export class _ extends LitElement {
                     color: inherit;
                     display: flex;
                     column-gap: 6px;
+                }
+
+                button {
+                    display: flex;
+                    flex-direction: row;
+                    align-items: center;
                 }
             `,
         ];

--- a/frontend/elements/src/core/modals/confirm.ts
+++ b/frontend/elements/src/core/modals/confirm.ts
@@ -1,13 +1,12 @@
-import { LitElement, html, css, customElement, property } from "lit-element";
+import { html, css, customElement, property } from "lit-element";
+import { nothing } from "lit-html";
 import { classMap } from "lit-html/directives/class-map";
-import { unsafeHTML } from "lit-html/directives/unsafe-html";
 import { BaseButton } from "@elements/_styles/buttons";
 import "@elements/core/buttons/icon";
 import "@elements/core/buttons/rectangle";
 
 const STR_DEFAULT_CANCEL_TEXT = "Cancel";
 const STR_DEFAULT_CONFIRM_TEXT = "Confirm";
-const STR_TITLE_WARNING = "Warning";
 
 @customElement("modal-confirm")
 export class _ extends BaseButton {
@@ -132,7 +131,13 @@ export class _ extends BaseButton {
     cancel_text: string = STR_DEFAULT_CANCEL_TEXT;
 
     @property({ type: String })
+    cancelIcon?: string;
+
+    @property({ type: String })
     confirm_text: string = STR_DEFAULT_CONFIRM_TEXT;
+
+    @property({ type: String })
+    confirmIcon?: string;
 
     @property({ type: Boolean })
     dangerous: boolean = false;
@@ -143,7 +148,9 @@ export class _ extends BaseButton {
 
         if (!isPrimary && this.dangerous) {
             color = "red";
-            kind = "text";
+            kind = "outline";
+        } else if (isPrimary && this.dangerous) {
+            color = "alert"
         } else if (!isPrimary && !this.dangerous) {
             kind = "text";
         }
@@ -151,42 +158,47 @@ export class _ extends BaseButton {
         return [color, kind];
     }
 
-    renderConfirm(isPrimary: Boolean) {
-        const [color, kind] = this.buttonProps(isPrimary);
+    renderConfirm() {
+        const [color, kind] = this.buttonProps(true);
+
+        const icon = this.confirmIcon
+            ? html`<img-ui path="${this.confirmIcon}"></img-ui>`
+            : nothing;
 
         return html`
             <div @click=${this.onConfirm}>
-                <button-rect color=${color} kind=${kind}>${this.confirm_text}</button-rect>
+                <button-rect color=${color} kind=${kind} size="small">
+                    ${icon}
+                    ${this.confirm_text}
+                </button-rect>
             </div>
         `;
     }
 
-    renderCancel(isPrimary: Boolean) {
-        const [color, kind] = this.buttonProps(isPrimary);
+    renderCancel() {
+        const [color, kind] = this.buttonProps(false);
+
+        const icon = this.cancelIcon
+            ? html`<img-ui path="${this.cancelIcon}"></img-ui>`
+            : nothing;
 
         return html`
             <div @click=${this.onCancel}>
-                <button-rect color=${color} kind=${kind}>${this.cancel_text}</button-rect>
+                <button-rect color=${color} kind=${kind} size="small">
+                    ${icon}
+                    ${this.cancel_text}
+                </button-rect>
             </div>
         `;
     }
 
     renderActions() {
-        if (this.dangerous) {
-            return html`
-                <div class="options">
-                    ${this.renderConfirm(false)}
-                    ${this.renderCancel(true)}
-                </div>
-            `;
-        } else {
-            return html`
-                <div class="options">
-                    ${this.renderCancel(false)}
-                    ${this.renderConfirm(true)}
-                </div>
-            `;
-        }
+        return html`
+            <div class="options">
+                ${this.renderCancel()}
+                ${this.renderConfirm()}
+            </div>
+        `;
     }
 
     renderTitle() {


### PR DESCRIPTION
Closes #2830

- Updates "dangerous" button primary colors to `dark-red-2` and `red-alert` for hover;
- Switches buttons so that the primary is always on the right for deletes;
- Updates the secondary button so that it uses the outline styling;
- Adds `confirmIcon` and `cancelIcon` properties to modal-confirm so that icons can be added to buttons;
- Uses the `delete-white.svg` icon for all deletes.

![Screenshot 2022-08-29 at 13 50 14](https://user-images.githubusercontent.com/4161106/187195001-73f26320-3b53-492b-a896-8ec4d8777373.png)
![Screenshot 2022-08-29 at 13 50 27](https://user-images.githubusercontent.com/4161106/187195014-316e7ae7-161e-4536-a282-5e2a68fd23ea.png)
