### PR TITLE
fix(be/resource): group name and language conditions in update

### DIFF
--- a/backend/api/sqlx-data.json
+++ b/backend/api/sqlx-data.json
@@ -67,20 +67,6 @@
     },
     "query": "\nupdate jig_data\nset description = $2,\n    translated_description = '{}',\n    updated_at = now()\nwhere id = $1 and $2 is distinct from description"
   },
-  "020be2c772185ee700939f8e6bd1cb1d8ff5c0e8d9103eeb6f4426d3cfc2716f": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Text",
-          "Text"
-        ]
-      }
-    },
-    "query": "\nupdate resource_data\nset display_name     = coalesce($2, display_name),\n    language         = coalesce($3, language),\n    updated_at = now()\nwhere id = $1\n  and ($2::text is not null and $2 is distinct from display_name) or\n       ($3::text is not null and $3 is distinct from language)\n"
-  },
   "0275b21fac8ef6473d7a30163979cfca243fe9fcfa294dbe0d4d3f8b22ee7c67": {
     "describe": {
       "columns": [
@@ -2190,22 +2176,22 @@
         }
       ],
       "nullable": [
+        false,
+        false,
+        false,
         true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true
+        false,
+        false,
+        false,
+        null,
+        null,
+        null,
+        null,
+        null,
+        false,
+        false,
+        false,
+        false
       ],
       "parameters": {
         "Left": [
@@ -2311,15 +2297,15 @@
         }
       ],
       "nullable": [
+        false,
         true,
         true,
+        null,
+        false,
+        false,
         true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true
+        false,
+        false
       ],
       "parameters": {
         "Left": [
@@ -3564,21 +3550,21 @@
         }
       ],
       "nullable": [
+        false,
+        false,
         true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
       ],
       "parameters": {
         "Left": [
@@ -4906,6 +4892,20 @@
       }
     },
     "query": "\nselect id                               as \"id!: ImageId\",\n       name\nfrom image_metadata\n     inner join image_upload on id = image_id\nwhere name <> '' and translated_name = '{}'\nand processed_at is not null\norder by coalesce(updated_at, created_at) desc\nlimit 50 for no key update skip locked;\n "
+  },
+  "6e2623b5778df6f4793ecc354dd6b50ec1eb969dc307e43ce66ae9e46b8001eb": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Text",
+          "Text"
+        ]
+      }
+    },
+    "query": "\nupdate resource_data\nset display_name     = coalesce($2, display_name),\n    language         = coalesce($3, language),\n    updated_at = now()\nwhere id = $1\n  and (($2::text is not null and $2 is distinct from display_name) or\n       ($3::text is not null and $3 is distinct from language))\n"
   },
   "6ea38ea0c905f9d7aa943145a64b10e5d0cdc86d8f365dfdac9a8c45bba8e67c": {
     "describe": {

--- a/backend/api/src/db/resource.rs
+++ b/backend/api/src/db/resource.rs
@@ -695,8 +695,8 @@ set display_name     = coalesce($2, display_name),
     language         = coalesce($3, language),
     updated_at = now()
 where id = $1
-  and ($2::text is not null and $2 is distinct from display_name) or
-       ($3::text is not null and $3 is distinct from language)
+  and (($2::text is not null and $2 is distinct from display_name) or
+       ($3::text is not null and $3 is distinct from language))
 "#,
         draft_id,
         display_name,

--- a/backend/api/src/http/endpoints/resource.rs
+++ b/backend/api/src/http/endpoints/resource.rs
@@ -239,28 +239,6 @@ pub(super) async fn publish_draft_to_live(
         .await
         .ok_or(error::CloneDraft::ResourceNotFound)?;
 
-    // let draft = db::resource::get_one(&db, resource_id, DraftOrLive::Draft)
-    //     .await?
-    //     .ok_or(error::CloneDraft::ResourceNotFound)?; // Not strictly necessary, we already know the Resource exists.
-
-    // let modules = draft.resource_data.modules;
-    // Check that modules have been configured on the Resource
-    // let has_modules = !modules.is_empty();
-    // Check whether the draft's modules all have content
-    // let modules_valid = modules
-    //     .into_iter()
-    //     .filter(|module| !module.is_complete)
-    //     .collect::<Vec<LiteModule>>()
-    //     .is_empty();
-
-    // If no modules or modules without content, prevent publishing.
-    // NOTE: we temporarily allow publishing resource without content
-    // since curation also uses this endpoint and some resources have already been published without content
-    // and those resources have to be curated
-    // if !modules_valid || !has_modules {
-    //     return Err(error::CloneDraft::IncompleteModules);
-    // }
-
     let new_live_id = db::resource::clone_data(&mut txn, &draft_id, DraftOrLive::Live).await?;
 
     sqlx::query!(

--- a/backend/api/tests/integration/snapshots/integration__resource__update_and_publish-3.snap
+++ b/backend/api/tests/integration/snapshots/integration__resource__update_and_publish-3.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/resource.rs
 expression: body
-
 ---
 {
   "id": "d8067526-1518-11ed-87fa-ebaf880b6d9c",
@@ -21,7 +20,7 @@ expression: body
     },
     "ageRanges": [],
     "affiliations": [],
-    "language": "en-us",
+    "language": "en",
     "categories": [],
     "description": "test description",
     "createdAt": "2021-03-04T00:46:26.134651Z",


### PR DESCRIPTION
@MendyBerger 

## Fix:
- In SQL query where languages or display_name are updated, the `where` conditions should be in parenthesis for both inputs. 