### PR TITLE
chore(fe/drag-drop): Update interaction select and trace tabs copy

### DIFF
--- a/frontend/apps/crates/entry/module/drag-drop/edit/src/base/sidebar/step_3/dom.rs
+++ b/frontend/apps/crates/entry/module/drag-drop/edit/src/base/sidebar/step_3/dom.rs
@@ -49,8 +49,9 @@ pub fn render_step_3(state: Rc<Step3>) -> Dom {
                 .child_signal(state.tab.signal_cloned().map(clone!(state => move |tab| {
                     match tab {
                         Tab::Select => {
-                            Some(html!("div", {
-                                .text(crate::strings::STR_SIDEBAR_SELECT)
+                            Some(html!("sidebar-empty", {
+                                .property("label", crate::strings::STR_SIDEBAR_SELECT)
+                                .property("imagePath", "module/_common/edit/sidebar/illustration-trace-area.svg")
                             }))
                         },
                         Tab::Audio(audio_signal_fn) => {

--- a/frontend/apps/crates/entry/module/drag-drop/edit/src/strings.rs
+++ b/frontend/apps/crates/entry/module/drag-drop/edit/src/strings.rs
@@ -1,3 +1,3 @@
-pub const STR_SIDEBAR_SELECT: &str = "Select the items that can be dragged";
+pub const STR_SIDEBAR_SELECT: &str = "Select ALL items that students can drag";
 
-pub const STR_SIDEBAR_TRACE: &str = "Trace the areas where items can be dropped.";
+pub const STR_SIDEBAR_TRACE: &str = "Trace areas where items can be dropped";

--- a/frontend/elements/src/module/_common/edit/widgets/sidebar-drag-prompt.ts
+++ b/frontend/elements/src/module/_common/edit/widgets/sidebar-drag-prompt.ts
@@ -1,6 +1,6 @@
 import { LitElement, html, css, customElement } from "lit-element";
 
-const STR_LABEL = "Put each item where it should be dropped.";
+const STR_LABEL = "Place each item in their correct areas";
 
 @customElement("module-sidebar-drag-prompt")
 export class _ extends LitElement {


### PR DESCRIPTION
Part of #3119

- Updates the copy on the Select and Trace tabs for Step 3;
- Uses the Trace graphic for now until we have the svg for the select tab's graphic.