### PR TITLE
chore(fe/tapping-board): Change hint default to not highlight traces

### DIFF
--- a/shared/rust/src/domain/module/body/tapping_board/play_settings.rs
+++ b/shared/rust/src/domain/module/body/tapping_board/play_settings.rs
@@ -22,7 +22,7 @@ pub enum Hint {
 
 impl Default for Hint {
     fn default() -> Self {
-        Self::Highlight
+        Self::None
     }
 }
 


### PR DESCRIPTION
Closes #3142 