### PR TITLE
fix(fe/jig/edit): Show error popup in correct location; Open sidebar when there's an error

### DIFF
--- a/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/actions.rs
+++ b/frontend/apps/crates/entry/jig/edit/src/edit/sidebar/actions.rs
@@ -20,6 +20,8 @@ pub fn navigate_to_publish(state: Rc<State>) {
 
 pub fn set_highlight_modules(state: &Rc<State>, highlight: bool) {
     if highlight {
+        state.collapsed.set_neq(false);
+
         let modules = state.modules.lock_ref();
 
         if modules
@@ -32,8 +34,7 @@ pub fn set_highlight_modules(state: &Rc<State>, highlight: bool) {
                 .highlight_modules
                 .set_neq(Some(ModuleHighlight::Publish))
         } else {
-            let idx = modules.iter().position(|module| //match &*module {
-                !module.is_incomplete.get());
+            let idx = modules.iter().position(|module| module.is_incomplete.get());
             match idx {
                 Some(idx) => state
                     .highlight_modules


### PR DESCRIPTION
Resolves #3127

- Places the error popup in the correct location and scrolls the sidebar to the incomplete module;
- Opens the sidebar if it was closed so that the teacher can see the highlighted module.