### PR TITLE
fix(fe/stickers): Prevent user selection on chromium-based browsers in Windows/Linux

### DIFF
--- a/frontend/apps/crates/components/src/stickers/sprite/dom.rs
+++ b/frontend/apps/crates/components/src/stickers/sprite/dom.rs
@@ -128,6 +128,7 @@ pub fn render_sticker_sprite_raw(sprite: &RawSprite, opts: Option<SpriteRawRende
     let mixin = opts.base.mixin;
 
     parent
+        .style("user-select", "none")
         .style_signal("width", width_signal(size.signal_cloned()))
         .style_signal("height", height_signal(size.signal_cloned()))
         .style_signal("top", bounds::size_height_center_rem_signal(size.signal()))

--- a/frontend/apps/crates/components/src/stickers/text/dom.rs
+++ b/frontend/apps/crates/components/src/stickers/text/dom.rs
@@ -192,6 +192,7 @@ pub fn render_sticker_text_raw(
         )
         .child(
             parent
+                .style("user-select", "none")
                 .style("position", "absolute")
                 .style("transform", text.transform.rotation_matrix_string())
                 //the text determines transform size, not the other way around


### PR DESCRIPTION
- Fixes an issue that only happens in Chromium-based browsers (Edge, Chrome) on Windows and Linux where attempting to drag an inactive sticker would cause the stickers parent `empty-fragment` to be selected.