### PR TITLE
fix(be/module): correct module index when updated

### DIFF
--- a/backend/api/sqlx-data.json
+++ b/backend/api/sqlx-data.json
@@ -6958,6 +6958,56 @@
     },
     "query": "\nupdate resource\nset views = views + 1\nwhere id = $1;\n            "
   },
+  "99fa41555d59f16f6c77672a3282c49bda64b93672deb98569dc677a6f987989": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id!: ModuleId",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "body!",
+          "ordinal": 1,
+          "type_info": "Jsonb"
+        },
+        {
+          "name": "created_at!",
+          "ordinal": 2,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "updated_at!",
+          "ordinal": 3,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "kind!: ModuleKind",
+          "ordinal": 4,
+          "type_info": "Int2"
+        },
+        {
+          "name": "is_complete!",
+          "ordinal": 5,
+          "type_info": "Bool"
+        }
+      ],
+      "nullable": [
+        true,
+        true,
+        true,
+        true,
+        true,
+        true
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\nselect jdm.id      as \"id!: ModuleId\",\n       contents    as \"body!\",\n       created_at  as \"created_at!\",\n       updated_at  as \"updated_at!\",\n       kind        as \"kind!: ModuleKind\",\n       is_complete as \"is_complete!\"\nfrom jig_data_module \"jdm\"\ninner join jig on jig.draft_id = jdm.jig_data_id \nwhere jdm.id is not distinct from $1 \n"
+  },
   "9a280ed5b2d646c563937e8cee1bae592f8d46322edf1769a7c89670088ac3d8": {
     "describe": {
       "columns": [],
@@ -10601,56 +10651,6 @@
       }
     },
     "query": "\nupdate jig_data\nset other_keywords = $2,\n    translated_keywords = (case when ($3::text is not null) then $3::text else (translated_keywords) end),\n    updated_at = now()\nwhere id = $1 and $2 is distinct from other_keywords"
-  },
-  "ea0bf9d029c261fd6d17e1ea5b8ea8aa10276f40dda9399e5234fcf225a98b71": {
-    "describe": {
-      "columns": [
-        {
-          "name": "id!: ModuleId",
-          "ordinal": 0,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "body!",
-          "ordinal": 1,
-          "type_info": "Jsonb"
-        },
-        {
-          "name": "created_at!",
-          "ordinal": 2,
-          "type_info": "Timestamptz"
-        },
-        {
-          "name": "updated_at!",
-          "ordinal": 3,
-          "type_info": "Timestamptz"
-        },
-        {
-          "name": "kind!: ModuleKind",
-          "ordinal": 4,
-          "type_info": "Int2"
-        },
-        {
-          "name": "is_complete!",
-          "ordinal": 5,
-          "type_info": "Bool"
-        }
-      ],
-      "nullable": [
-        true,
-        true,
-        true,
-        true,
-        true,
-        true
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid"
-        ]
-      }
-    },
-    "query": "\nselect jdm.id          as \"id!: ModuleId\",\n       contents    as \"body!\",\n       created_at  as \"created_at!\",\n       updated_at  as \"updated_at!\",\n       kind        as \"kind!: ModuleKind\",\n       is_complete as \"is_complete!\"\nfrom jig_data_module \"jdm\"\ninner join jig on jig.draft_id = jdm.jig_data_id \nwhere jdm.id is not distinct from $1 \n"
   },
   "eb44eafd34c17ff3cd679cd11f53fcde64f4b6039ba2b1625dd2c78ca2494a2d": {
     "describe": {

--- a/backend/api/src/db/jig/module.rs
+++ b/backend/api/src/db/jig/module.rs
@@ -90,7 +90,7 @@ pub async fn get_draft(pool: &PgPool, id: ModuleId) -> anyhow::Result<Option<Mod
     let module = sqlx::query!(
         //language=SQL
         r#"
-select jdm.id          as "id!: ModuleId",
+select jdm.id      as "id!: ModuleId",
        contents    as "body!",
        created_at  as "created_at!",
        updated_at  as "updated_at!",
@@ -225,7 +225,7 @@ set
     updated_at = now()
 where jig_data_id = $1 and index between $2 and $3
 "#,
-                parent_id.0,
+                draft_id,
                 index,
                 new_index
             )

--- a/backend/api/tests/integration/jig/snapshots/integration__jig__module__drag_up_down_modules-2.snap
+++ b/backend/api/tests/integration/jig/snapshots/integration__jig__module__drag_up_down_modules-2.snap
@@ -1,0 +1,77 @@
+---
+source: tests/integration/jig/module.rs
+expression: body
+---
+{
+  "id": "0cc084bc-7c83-11eb-9f77-e3218dffb008",
+  "publishedAt": "2022-06-24T17:57:33.149359Z",
+  "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
+  "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
+  "authorName": "Bobby Tables",
+  "likes": 0,
+  "plays": 0,
+  "jigData": {
+    "createdAt": "2021-03-04T00:46:26.134651Z",
+    "lastEdited": "[last_edited]",
+    "draftOrLive": "draft",
+    "displayName": "name",
+    "modules": [
+      {
+        "id": "a6b24a06-1dd7-11ec-8426-635a3a7ea572",
+        "kind": "Cover",
+        "is_complete": false
+      },
+      {
+        "id": "a6b24a88-1dd7-11ec-8426-57525d09b22c",
+        "kind": "Memory",
+        "is_complete": false
+      },
+      {
+        "id": "a6b24a42-1dd7-11ec-8426-a7165f9281a2",
+        "kind": "Flashcards",
+        "is_complete": false
+      }
+    ],
+    "ageRanges": [],
+    "affiliations": [],
+    "language": "en",
+    "categories": [],
+    "additionalResources": [
+      {
+        "id": "286b834a-1dd9-11ec-8426-6f641a50e23f",
+        "displayName": "link test",
+        "resourceTypeId": "a91aca34-519e-11ec-ab46-175eaaf1ff23",
+        "link": "url://url.url.url/urls/s"
+      },
+      {
+        "id": "286b8390-1dd9-11ec-8426-fbeb80c504d9",
+        "displayName": "link test",
+        "resourceTypeId": "a91aca34-519e-11ec-ab46-175eaaf1ff23",
+        "link": "url://url.url.url/url/s"
+      }
+    ],
+    "description": "test description",
+    "defaultPlayerSettings": {
+      "direction": "ltr",
+      "displayScore": true,
+      "trackAssessments": true,
+      "dragAssist": true
+    },
+    "theme": "Blank",
+    "audioBackground": null,
+    "audioEffects": {
+      "feedbackPositive": "[audio]",
+      "feedbackNegative": "[audio]"
+    },
+    "privacyLevel": "unlisted",
+    "locked": false,
+    "otherKeywords": "",
+    "translatedKeywords": "",
+    "translatedDescription": {}
+  },
+  "adminData": {
+    "rating": null,
+    "blocked": false,
+    "curated": false
+  }
+}

--- a/backend/api/tests/integration/jig/snapshots/integration__jig__module__drag_up_down_modules.snap
+++ b/backend/api/tests/integration/jig/snapshots/integration__jig__module__drag_up_down_modules.snap
@@ -1,0 +1,77 @@
+---
+source: tests/integration/jig/module.rs
+expression: body
+---
+{
+  "id": "0cc084bc-7c83-11eb-9f77-e3218dffb008",
+  "publishedAt": "2022-06-24T17:57:33.149359Z",
+  "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
+  "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
+  "authorName": "Bobby Tables",
+  "likes": 0,
+  "plays": 0,
+  "jigData": {
+    "createdAt": "2021-03-04T00:46:26.134651Z",
+    "lastEdited": "[last_edited]",
+    "draftOrLive": "draft",
+    "displayName": "name",
+    "modules": [
+      {
+        "id": "a6b24a06-1dd7-11ec-8426-635a3a7ea572",
+        "kind": "Cover",
+        "is_complete": false
+      },
+      {
+        "id": "a6b24a42-1dd7-11ec-8426-a7165f9281a2",
+        "kind": "Flashcards",
+        "is_complete": false
+      },
+      {
+        "id": "a6b24a88-1dd7-11ec-8426-57525d09b22c",
+        "kind": "Memory",
+        "is_complete": false
+      }
+    ],
+    "ageRanges": [],
+    "affiliations": [],
+    "language": "en",
+    "categories": [],
+    "additionalResources": [
+      {
+        "id": "286b834a-1dd9-11ec-8426-6f641a50e23f",
+        "displayName": "link test",
+        "resourceTypeId": "a91aca34-519e-11ec-ab46-175eaaf1ff23",
+        "link": "url://url.url.url/urls/s"
+      },
+      {
+        "id": "286b8390-1dd9-11ec-8426-fbeb80c504d9",
+        "displayName": "link test",
+        "resourceTypeId": "a91aca34-519e-11ec-ab46-175eaaf1ff23",
+        "link": "url://url.url.url/url/s"
+      }
+    ],
+    "description": "test description",
+    "defaultPlayerSettings": {
+      "direction": "ltr",
+      "displayScore": true,
+      "trackAssessments": true,
+      "dragAssist": true
+    },
+    "theme": "Blank",
+    "audioBackground": null,
+    "audioEffects": {
+      "feedbackPositive": "[audio]",
+      "feedbackNegative": "[audio]"
+    },
+    "privacyLevel": "unlisted",
+    "locked": false,
+    "otherKeywords": "",
+    "translatedKeywords": "",
+    "translatedDescription": {}
+  },
+  "adminData": {
+    "rating": null,
+    "blocked": false,
+    "curated": false
+  }
+}


### PR DESCRIPTION
closes https://github.com/ji-devs/ji-cloud/issues/2948

## Fix: 
- pass in `jig_data_id` instead of parent_id (`JigId`) in sql query when `new_index > index`