### PR TITLE
feat(fe/settings): Show settings bubble when clicking a settings button

### DIFF
--- a/frontend/apps/crates/components/src/module/_common/edit/settings/button/state.rs
+++ b/frontend/apps/crates/components/src/module/_common/edit/settings/button/state.rs
@@ -8,6 +8,7 @@ pub struct SettingsButton {
     pub(super) active_signal: BoxSignalFn<bool>,
     pub(super) value: Option<Box<dyn SettingsValueExt>>,
     pub(super) on_click: Option<Box<dyn Fn()>>,
+    pub(super) bubble_open: Mutable<bool>,
 }
 
 impl SettingsButton {
@@ -22,6 +23,7 @@ impl SettingsButton {
             active_signal: box_signal_fn(active_signal),
             value: value.map(|v| Box::new(v) as _),
             on_click: on_click.map(|f| Box::new(f) as _),
+            bubble_open: Mutable::new(false),
         })
     }
 

--- a/frontend/elements/src/module/_common/edit/widgets/settings/bubble.ts
+++ b/frontend/elements/src/module/_common/edit/widgets/settings/bubble.ts
@@ -65,6 +65,23 @@ export class _ extends LitElement {
         ];
     }
 
+    connectedCallback() {
+        super.connectedCallback();
+
+        window.addEventListener("keyup", this.onKeyup);
+    }
+
+    disconnectedCallback() {
+        super.disconnectedCallback();
+        window.removeEventListener("keyup", this.onKeyup);
+    }
+
+    onKeyup = (event: KeyboardEvent) => {
+        if (event.key.toLowerCase() === "enter") {
+            this.dispatchEvent(new Event("close"));
+        }
+    };
+
     render() {
         return html`
             ${renderSvgArrow()}

--- a/frontend/elements/src/module/_common/edit/widgets/settings/button.ts
+++ b/frontend/elements/src/module/_common/edit/widgets/settings/button.ts
@@ -153,7 +153,7 @@ export class _ extends LitElement {
 		the bubble will nudge itself to the left;
 		*/
                 .bubble {
-                    display: none;
+                    display: block;
                     position: relative;
                     top: 0;
                     left: 0;
@@ -162,10 +162,6 @@ export class _ extends LitElement {
                     white-space: nowrap;
                     overflow: visible;
                     z-index: 1000;
-                }
-
-                :host([hover]) .bubble {
-                    display: block;
                 }
             `,
         ];
@@ -181,6 +177,9 @@ export class _ extends LitElement {
     hover: boolean = false;
 
     @property({ type: Boolean })
+    bubbleOpen: boolean = false;
+
+    @property({ type: Boolean })
     active: boolean = false;
 
     @property({ type: Number })
@@ -188,25 +187,20 @@ export class _ extends LitElement {
 
     connectedCallback() {
         super.connectedCallback();
-
-        this.addEventListener("mouseenter", this.onMouseEnter);
-        this.addEventListener("mouseleave", this.onMouseLeave);
+        window.addEventListener("mousedown", this.onGlobalMouseDown);
     }
 
     disconnectedCallback() {
         super.disconnectedCallback();
-
-        this.removeEventListener("mouseenter", this.onMouseEnter);
-        this.removeEventListener("mouseleave", this.onMouseLeave);
+        window.removeEventListener("mousedown", this.onGlobalMouseDown);
     }
 
-    onMouseEnter() {
-        this.hover = true;
-    }
+    onGlobalMouseDown = (evt: MouseEvent) => {
+        if (this.bubbleOpen && !evt.composedPath().includes(this.shadowRoot as any)) {
+            this.dispatchEvent(new Event("close"));
+        }
+    };
 
-    onMouseLeave() {
-        this.hover = false;
-    }
 
     render() {
         const { kind, hover, active, num, label } = this;


### PR DESCRIPTION
Closes #3165

- Open the settings bubble when the teacher clicks on a setting;
- Bubble stays open until the teacher clicks outside of it or presses the "enter" key

Note that I didn't add the "x" button because couldn't figure out how to make it look neat.


https://user-images.githubusercontent.com/4161106/189634738-e7492e28-cf2e-489b-9a2b-f59726043fc5.mov

