### PR TITLE
fix(fe/legacy): Ensure legacy json slides can correctly deserialize when activity contains a video sticker

### DIFF
--- a/frontend/apps/crates/entry/module/legacy/play/src/base/activities/video/dom.rs
+++ b/frontend/apps/crates/entry/module/legacy/play/src/base/activities/video/dom.rs
@@ -2,7 +2,7 @@ use super::state::Video;
 use crate::base::styles;
 use components::stickers::video::ext::*;
 use dominator::{clone, html, with_node, Dom};
-use shared::domain::module::body::{_groups::design::YoutubeVideo, legacy::activity::VideoSource};
+use shared::domain::module::body::{_groups::design::YoutubeUrl, legacy::activity::VideoSource};
 use std::rc::Rc;
 use utils::prelude::*;
 
@@ -94,7 +94,7 @@ impl Video {
         })
     }
 
-    pub fn render_youtube(self: Rc<Self>, yt: &YoutubeVideo) -> Dom {
+    pub fn render_youtube(self: Rc<Self>, yt: &YoutubeUrl) -> Dom {
         let state = self;
 
         html!("video-youtube-player" => HtmlElement, {

--- a/shared/rust/src/domain/module/body/legacy/activity.rs
+++ b/shared/rust/src/domain/module/body/legacy/activity.rs
@@ -1,4 +1,4 @@
-use crate::domain::module::body::_groups::design::{TraceShape, YoutubeVideo};
+use crate::domain::module::body::_groups::design::{TraceShape, YoutubeUrl};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -68,7 +68,7 @@ pub struct Video {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum VideoSource {
-    Youtube(YoutubeVideo),
+    Youtube(YoutubeUrl),
     Direct(String),
 }
 


### PR DESCRIPTION
Resolves #3240

- The legacy player uses JSON files to load data of legacy JIGs. The JSON files were not updated as part of the migration for the Youtube data model changes prevented slides with youtube URLs to break on the frontend when being deserialized.