### PR TITLE
feat(be): remove users with expired verification emails

### DIFF
--- a/backend/api/sqlx-data.json
+++ b/backend/api/sqlx-data.json
@@ -4513,6 +4513,18 @@
     },
     "query": "\n    update jig_curation_data\n    set description = $2\n    where jig_id = $1 and $2 is distinct from description\n                "
   },
+  "608570654b76fe283fddb937731c721ebfee382fd9004821681ba0ebaaa953f6": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Int2"
+        ]
+      }
+    },
+    "query": "\n        delete from \"user\" \n        using session\n        where \"user\".id = session.user_id \n        and (scope_mask & $1) = $1 \n        and expires_at <= now() \n     "
+  },
   "620638cd11c57d625c799e1d5ada2d57161cb59e06559bc3bd7ee3e3e3a8d5ee": {
     "describe": {
       "columns": [

--- a/backend/api/src/http/endpoints/scheduler/expired_emails.rs
+++ b/backend/api/src/http/endpoints/scheduler/expired_emails.rs
@@ -1,0 +1,21 @@
+use crate::token::SessionMask;
+use sqlx::PgPool;
+
+pub(crate) async fn delete_expired_emails(db: &PgPool) -> anyhow::Result<()> {
+    log::debug!("reached delete expired emails");
+
+    sqlx::query!(
+        r#"
+        delete from "user" 
+        using session
+        where "user".id = session.user_id 
+        and (scope_mask & $1) = $1 
+        and expires_at <= now() 
+     "#,
+        SessionMask::VERIFY_EMAIL.bits(),
+    )
+    .execute(db)
+    .await?;
+
+    Ok(())
+}


### PR DESCRIPTION
resolves https://github.com/ji-devs/ji-cloud/issues/3295

## Added:
- api endpoint that checks for unverified sign-up sessions, and deletes the expired `user_id` from the database.
- added endpoint to google cloud scheduler  