### PR TITLE
feat(shared/macros): Add proc macro for testing the backend services

### DIFF
--- a/backend/api/Cargo.lock
+++ b/backend/api/Cargo.lock
@@ -145,7 +145,7 @@ dependencies = [
  "actix-utils",
  "futures-core",
  "log",
- "mio",
+ "mio 0.7.13",
  "num_cpus",
  "slab",
  "tokio",
@@ -391,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
@@ -1259,7 +1259,7 @@ checksum = "62007592ac46aa7c2b6416f7deb9a8a8f63a01e0f1d6e1787d5630170db2b63e"
 dependencies = [
  "futures-core",
  "lock_api",
- "parking_lot",
+ "parking_lot 0.11.2",
 ]
 
 [[package]]
@@ -1342,7 +1342,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -1696,6 +1696,7 @@ dependencies = [
  "jsonwebtoken",
  "listenfd",
  "log",
+ "macros",
  "mp3-metadata",
  "once_cell",
  "openssl",
@@ -1784,9 +1785,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.119"
+version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
+checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "linked-hash-map"
@@ -1825,10 +1826,11 @@ checksum = "84f9a2d3e27ce99ce2c3aad0b09b1a7b916293ea9b2bf624c13fe646fadd8da4"
 
 [[package]]
 name = "lock_api"
-version = "0.4.5"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
+ "autocfg",
  "scopeguard",
 ]
 
@@ -1958,6 +1960,18 @@ dependencies = [
  "miow",
  "ntapi",
  "winapi",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2162,7 +2176,17 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.5",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.4",
 ]
 
 [[package]]
@@ -2177,6 +2201,19 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2402,9 +2439,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
 ]
@@ -2983,7 +3020,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "time 0.3.7",
+ "time 0.3.16",
  "url",
  "uuid",
 ]
@@ -3243,9 +3280,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.2"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
+checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
 dependencies = [
  "libc",
  "winapi",
@@ -3311,7 +3348,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.11.2",
  "percent-encoding",
  "rand",
  "serde",
@@ -3463,13 +3500,13 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.93"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04066589568b72ec65f42d65a1a52436e954b168773148893c020269563decf2"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -3564,7 +3601,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
@@ -3578,21 +3615,30 @@ dependencies = [
  "libc",
  "standback",
  "stdweb",
- "time-macros",
+ "time-macros 0.1.1",
  "version_check",
  "winapi",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.7"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d"
+checksum = "0fab5c8b9980850e06d92ddbe3ab839c062c801f3927c0fb8abd6fc8e918fbca"
 dependencies = [
  "itoa 1.0.1",
  "libc",
  "num_threads",
+ "serde",
+ "time-core",
+ "time-macros 0.2.5",
 ]
+
+[[package]]
+name = "time-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
@@ -3602,6 +3648,15 @@ checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
 dependencies = [
  "proc-macro-hack",
  "time-macros-impl",
+]
+
+[[package]]
+name = "time-macros"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bb801831d812c562ae7d2bfb531f26e66e4e1f6b17307ba4149c5064710e5b"
+dependencies = [
+ "time-core",
 ]
 
 [[package]]
@@ -3634,29 +3689,29 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.12.0"
+version = "1.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
+checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
 dependencies = [
  "autocfg",
  "bytes",
  "libc",
  "memchr",
- "mio",
+ "mio 0.8.5",
  "num_cpus",
- "once_cell",
- "parking_lot",
+ "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros",
  "winapi",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.3.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
+checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3958,6 +4013,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4089,6 +4150,63 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
 name = "winreg"

--- a/backend/api/Cargo.toml
+++ b/backend/api/Cargo.toml
@@ -52,7 +52,7 @@ serde_json = { version = "1.0.68", features = ["preserve_order"] }
 serde_urlencoded = "0.7.0"
 sha2 = "0.9.8"
 time = "0.2.27"
-tokio = "1.12.0"
+tokio = { version = "1.12.0", default-features = false, features = ["full"] }
 tracing = "0.1.31"
 url = { version = "2.2.2", features = ["serde"] }
 uuid = "0.8.2"
@@ -62,6 +62,7 @@ hashfn = "0.2.0"
 # project deps
 core = { path = "../core", features = ["db"] }
 shared = { path = "../../shared/rust", features = ["backend"] }
+macros = { path = "../../shared/macros" }
 csv = "1.1.6"
 
 [dependencies.sendgrid]

--- a/backend/pages/Cargo.lock
+++ b/backend/pages/Cargo.lock
@@ -1797,9 +1797,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
 ]
@@ -2619,13 +2619,13 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.80"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d010a1623fbd906d51d650a9916aaefc05ffa0e4053ff7fe601167f3e715d194"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2947,12 +2947,6 @@ name = "unicode-segmentation"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "unicode_categories"

--- a/frontend/apps/Cargo.lock
+++ b/frontend/apps/Cargo.lock
@@ -2054,9 +2054,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
 ]
@@ -2350,9 +2350,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.99"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/shared/macros/Cargo.toml
+++ b/shared/macros/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 proc-macro = true
 
 [dependencies]
-syn = "1.0"
 quote = "1.0"
 convert_case = "0.5.0"
 anyhow = "1.0.58"
 proc-macro2 = "1.0.40"
 itertools = "0.10.3"
+syn = { version = "1.0.103", default-features = false, features = ["full"] }

--- a/shared/macros/src/lib.rs
+++ b/shared/macros/src/lib.rs
@@ -2,11 +2,12 @@ extern crate proc_macro;
 
 use make_path_parts_proc::PathPartsInput;
 use proc_macro::TokenStream;
-use syn;
-use syn::{parse_macro_input, DeriveInput};
+use syn::{self, parse_macro_input, DeriveInput, ExprArray, Lit, MetaList, NestedMeta, Result};
 
 mod make_path_parts_proc;
 mod path_part_derive;
+
+use quote::{format_ident, quote};
 
 #[proc_macro]
 pub fn make_path_parts(input: TokenStream) -> TokenStream {
@@ -30,4 +31,132 @@ pub fn path_part(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
 
     path_part_derive::impl_path_part(&ast)
+}
+
+fn parse_list(list: &MetaList) -> Result<ExprArray> {
+    let mut items = vec![];
+    for nested in &list.nested {
+        match nested {
+            syn::NestedMeta::Lit(syn::Lit::Str(value)) => {
+                items.push(value.value());
+            }
+            other => {
+                return Err(syn::Error::new_spanned(other, "expected string literal"));
+            }
+        }
+    }
+
+    let mut concatenated = items
+        .into_iter()
+        .reduce(|acc, value| acc + "," + &value)
+        .unwrap_or_default();
+    concatenated = format!("[{concatenated}]");
+
+    let concatenated = match concatenated.parse::<TokenStream>() {
+        Err(error) => {
+            return Err(syn::Error::new_spanned(list, error));
+        }
+        Ok(concatenated) => concatenated,
+    };
+
+    Ok(syn::parse::<syn::ExprArray>(concatenated)?)
+}
+
+type SetupFn = syn::Ident;
+type Fixtures = ExprArray;
+type Services = ExprArray;
+
+fn parse_args(args: Vec<NestedMeta>) -> Result<(SetupFn, Fixtures, Services)> {
+    let mut setup_fn = None;
+    let mut fixtures = None;
+    let mut services = None;
+
+    for arg in args.iter() {
+        match arg {
+            NestedMeta::Meta(syn::Meta::List(list)) => {
+                if list.path.is_ident("fixtures") {
+                    fixtures = Some(parse_list(list)?);
+                } else if list.path.is_ident("services") {
+                    services = Some(parse_list(list)?);
+                }
+            }
+            NestedMeta::Meta(syn::Meta::NameValue(namevalue)) => {
+                if namevalue.path.is_ident("setup") {
+                    if let Lit::Str(value) = &namevalue.lit {
+                        setup_fn = Some(format_ident!("{}", value.value()));
+                    } else {
+                        return Err(syn::Error::new_spanned(
+                            namevalue,
+                            "expected string literal",
+                        ));
+                    }
+                }
+            }
+            other => {
+                return Err(syn::Error::new_spanned(other, "unexpected argument"));
+            }
+        }
+    }
+
+    let setup_fn = match setup_fn {
+        None => {
+            let args = args.iter();
+            return Err(syn::Error::new_spanned(quote!({#(#args)*}), "foo"));
+        }
+        Some(setup_fn) => setup_fn,
+    };
+
+    let default_expr_array =
+        || syn::parse::<syn::ExprArray>("[]".parse::<TokenStream>().unwrap()).unwrap();
+
+    Ok((
+        setup_fn,
+        fixtures.unwrap_or_else(default_expr_array),
+        services.unwrap_or_else(default_expr_array),
+    ))
+}
+
+#[proc_macro_attribute]
+pub fn test_service(args: TokenStream, input: TokenStream) -> TokenStream {
+    let args = syn::parse_macro_input!(args as syn::AttributeArgs);
+
+    let input = syn::parse_macro_input!(input as syn::ItemFn);
+
+    let ret = &input.sig.output;
+    let name = &input.sig.ident;
+    let body = &input.block;
+
+    match parse_args(args) {
+        Ok((setup_fn, fixtures, services)) => {
+            quote! {
+                #[sqlx::test]
+                pub async fn #name(
+                    pool_opts: PgPoolOptions,
+                    conn_opts: PgConnectOptions,
+                ) #ret {
+                    async fn wrapped(port: u16) #ret {
+                        #body
+                    }
+
+                    let (server_handle, port) = #setup_fn(&#fixtures, &#services, pool_opts, conn_opts).await;
+
+                    use futures::FutureExt;
+                    use std::panic::AssertUnwindSafe;
+                    let result = AssertUnwindSafe(wrapped(port)).catch_unwind().await;
+
+                    server_handle.stop(true).await;
+
+                    match result {
+                        Ok(result) => result,
+                        Err(error) => std::panic::resume_unwind(error),
+                    }
+                }
+            }
+            .into()
+        }
+        Err(error) => {
+            let error = error.to_compile_error();
+            return quote!(#error).into();
+        }
+    }
 }


### PR DESCRIPTION
NB: this will only work with a version of sqlx that includes the ::test macro (i.e. this branch I think: https://github.com/RickyLB/ji-cloud/tree/chore/update_actix)

Adds a new proc macro which wraps sqlx::test so that we can test our actix services and shut them down correctly without holding the db pools farmed out by sqlx::test.

- Test fns only have a single argument, `port: u16`, so that requests to the service can use the correct port.
- A service setup function needs to be provided with the following signature: `async fn setup_service(fixtures: &[T], services: &[T], pool_opts: PgPoolOptions, conn_opts: PgConnectOptions) -> (ServerHandle, u16)`
  - This setup function replaces the service setup logic that is used in every test.
- Uses catch_unwind to handle a panic so that the service can be shutdown correctly and release the db pool.

Note: Doesn't use sqlx::tests fixtures since we're already using a Fixture enum and its a ton of work to update that. But it would be easy enough to switch to using fixtures paths instead of enum variants- we'd only have to use `&[&'static str]` for the fixtures argument in the setup fn.

The Application struct should be updated to include a `server_handle` field, and _the `Drop` implementation needs to be removed_. I couldn't get it to call stop correctly/reliably.

```
pub struct Application {
    port: u16,
    server: Option<Server>,
    server_handle: actix_web::dev::ServerHandle, // <-- New
}

impl Application {
    pub fn new(port: u16, server: Server) -> Self {
        Self {
            port,
            server_handle: server.handle(),
            server: Some(server),
        }
    }

    pub fn port(&self) -> u16 {
        self.port
    }

    pub fn handle(&self) -> ServerHandle {
        self.server_handle.clone()
    }
    
    // ...
}
```

Example setup function:

```rust
async fn setup_service(
	fixtures: &[Fixture], 
	services: &[Service], 
	pool_opts: PgPoolOptions, 
	conn_opts: PgConnectOptions
) -> (ServerHandle, u16) {
    let app = initialize_server(fixtures, services, pool_opts, conn_opts).await;

    let handle = app.handle();
    let port = app.port();

    let _join_handle = tokio::spawn(app.run_until_stopped());

    (handle, port)
}
```

The macro takes three arguments:

- `setup` **Required**: The setup function, for example `setup = "my_service_setup"`;
- `fixtures` **Optional**: A list of `T` - Passed as the `fixtures` argument to the setup fn;
- `services` **Optional**: A list of `T` - Passed as the `services` argument to the setup fn.

```rust
#[test_service(
	setup = "setup_service", 
	fixtures("Fixture::User", "Fixture::Jig"), 
	services("Service::S3", "Service::Email"),
)
```

Example test case:

```rust
use macros::test_service;
use crate::{fixture::Fixture, service::Service};

//...

async fn setup_service(
    fixtures: &[Fixture], 
    services: &[Service], 
    pool_opts: PgPoolOptions, 
    conn_opts: PgConnectOptions
) -> (ServerHandle, u16) {
    // ... do setup

    (handle, port)
}

#[test_service(setup = "setup_service", fixtures("Fixture::User"))]
async fn create_default(
    port: u16, // <-- NB
) -> anyhow::Result<()> {
    let settings = insta::Settings::clone_current();

    let client = reqwest::Client::new();

    let resp = client
        .post(&format!("http://0.0.0.0:{}/v1/resource", port))
        .login()
        .send()
        .await?
        .error_for_status()?;

    assert_eq!(resp.status(), StatusCode::CREATED);

    let body: CreateResponse<ResourceId> = resp.json().await?;

    settings
        .bind_async(async {
            assert_json_snapshot!(body, {".id" => "[id]"});
        })
        .await;

    let resource_id = body.id.0;

    let resp = client
        .get(&format!(
            "http://0.0.0.0:{}/v1/resource/{}/draft",
            port, resource_id
        ))
        .login()
        .send()
        .await?
        .error_for_status()?;

    let body: serde_json::Value = resp.json().await?;

    insta::assert_json_snapshot!(
        body, {
            ".**.id" => "[id]",
            ".**.createdAt" => "[created_at]",
            ".**.lastEdited" => "[last_edited]"});

    Ok(())
}
```