### PR TITLE
chore(fe/play): Update instructions popup to grow with text, respect newlines and center content

### DIFF
--- a/frontend/apps/crates/entry/asset/play/src/jig/dom.rs
+++ b/frontend/apps/crates/entry/asset/play/src/jig/dom.rs
@@ -240,6 +240,7 @@ impl JigPlayer {
                                         .apply(OverlayHandle::lifecycle(
                                             clone!(state, instructions => move || {
                                                 html!("overlay-tooltip-info", {
+                                                    .property("centeredContent", true)
                                                     .property("marginX", -16)
                                                     .property("target", &elem)
                                                     .attribute("targetAnchor", "br")

--- a/frontend/elements/src/core/overlays/tooltip/info.ts
+++ b/frontend/elements/src/core/overlays/tooltip/info.ts
@@ -78,12 +78,14 @@ export class _ extends LitElement {
                     color: #ffffff;
                     width: 304px;
                     margin: 8px 0 36px 0;
+                    white-space: pre-wrap;
+                    overflow-wrap: break-word;
                 }
                 :host([size="large"]) .body {
                     font-size: 22px;
-                    width: auto;
+                    width: max-content;
+                    max-width: 504px;
                     min-width: 304px;
-                    max-width: 500px;
                 }
 
                 :host([color="dark-blue"]) .body {
@@ -96,6 +98,11 @@ export class _ extends LitElement {
                 :host([color="light-orange"]) .body {
                     color: var(--dark-gray-6);
                 }
+
+                :host([centeredContent]) .body {
+                    text-align: center;
+                }
+
                 .actions {
                     display: flex;
                     flex-direction: row;
@@ -195,6 +202,9 @@ export class _ extends LitElement {
 
     @property({ type: Boolean, reflect: true })
     removeMargins: boolean = false;
+
+    @property({ type: Boolean, reflect: true })
+    centeredContent: boolean = false;
 
     renderClose() {
         if (!this.closeable) {

--- a/frontend/elements/src/module/_common/edit/post-preview/post-preview.ts
+++ b/frontend/elements/src/module/_common/edit/post-preview/post-preview.ts
@@ -53,8 +53,15 @@ export class _ extends LitElement {
                     padding: 30px 0;
                 }
                 .bottom-section .actions {
+                    display: flex;
+                    flex-direction: column;
+                    justify-content: center;
+                    grid-gap: 48px;
+                }
+
+                .bottom-section .actions > div {
                     display: grid;
-                    grid-template-columns: repeat(3, 116px) 1px repeat(auto-fit, 116px);
+                    grid-template-columns: repeat(auto-fit, 116px);
                     justify-content: center;
                     column-gap: 48px;
                 }
@@ -165,17 +172,20 @@ function renderConvertable(module: ModuleKind) {
             ${renderMessage(module)}
             <h3 class="action-header">${STR_ACTION_HEADER}</h3>
             <div class="actions">
-                <h4 class="action-use-in-header">
-                    ${STR_USE_IN_PREFIX} ${STR_MODULE_DISPLAY_NAME[module]}
-                    ${STR_USE_IN_SUFFIX}
-                </h4>
-                <slot class="module-1" name="module-1"></slot>
-                <slot class="module-2" name="module-2"></slot>
-                <slot class="module-3" name="module-3"></slot>
-                <div class="divider"></div>
-                <slot class="action-print" name="action-print"></slot>
-                <slot class="action-publish" name="action-publish"></slot>
-                <slot class="action-continue" name="action-continue"></slot>
+                <div>
+                    <slot class="action-print" name="action-print"></slot>
+                    <slot class="action-publish" name="action-publish"></slot>
+                    <slot class="action-continue" name="action-continue"></slot>
+                </div>
+                <div>
+                    <h4 class="action-use-in-header">
+                        ${STR_USE_IN_PREFIX} ${STR_MODULE_DISPLAY_NAME[module]}
+                        ${STR_USE_IN_SUFFIX}
+                    </h4>
+                    <slot class="module-1" name="module-1"></slot>
+                    <slot class="module-2" name="module-2"></slot>
+                    <slot class="module-3" name="module-3"></slot>
+                </div>
             </div>
         </div>
     `;


### PR DESCRIPTION
Closes #3308.

- Instructions popup has centered text, expands wider with more text and respects newlines in copy;
- Post preview screen has conversion actions on a new row.
