### PR TITLE
fix(fe/module): Ensure activities end correctly when no feedback config is set

### DIFF
--- a/frontend/apps/crates/components/src/module/_common/play/entry/dom.rs
+++ b/frontend/apps/crates/components/src/module/_common/play/entry/dom.rs
@@ -12,7 +12,7 @@ use crate::{
     audio::mixer::AUDIO_MIXER, module::_common::play::prelude::*,
     overlay::container::OverlayContainer,
 };
-use shared::domain::module::body::{BodyExt, ModeExt, StepExt};
+use shared::domain::module::body::{BodyExt, InstructionsType, ModeExt, StepExt};
 
 pub fn render_page_body<RawData, Mode, Step, Base>(
     state: Rc<GenericState<RawData, Mode, Step, Base>>,
@@ -140,7 +140,7 @@ where
         .property("slot", "main")
         .child(Base::render(base.clone()))
         .future(feedback.signal_cloned().for_each(move |feedback| async move {
-            let msg = IframeAction::new(ModuleToJigPlayerMessage::instructions_once(feedback.clone()));
+            let msg = IframeAction::new(ModuleToJigPlayerMessage::Instructions(feedback.map(|feedback| (feedback, InstructionsType::Feedback))));
             let _ = msg.try_post_message_to_player();
         }))
         .apply_if(jig_player, |dom| {
@@ -195,7 +195,7 @@ where
 
                     ModulePlayPhase::Playing => {
                         if jig_player {
-                            let msg = IframeAction::new(ModuleToJigPlayerMessage::instructions(instructions.clone()));
+                            let msg = IframeAction::new(ModuleToJigPlayerMessage::Instructions(instructions.clone().map(|instructions| (instructions, InstructionsType::Instructions))));
                             let _ = msg.try_post_message_to_player();
 
                             let timer_seconds = base.get_timer_minutes().map(|minutes| minutes * 60);

--- a/frontend/apps/crates/entry/asset/play/src/jig/state.rs
+++ b/frontend/apps/crates/entry/asset/play/src/jig/state.rs
@@ -8,7 +8,7 @@ use shared::domain::{
     jig::{JigId, JigPlayerSettings, JigResponse},
     meta::ResourceType,
     module::{
-        body::{Audio, Instructions as ModuleInstructions},
+        body::{Audio, Instructions as ModuleInstructions, InstructionsType},
         ModuleId,
     },
 };
@@ -104,19 +104,22 @@ pub fn can_load_liked_status(jig: &JigResponse) -> bool {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Instructions {
     pub text: Option<String>,
     pub audio: Option<Audio>,
-    pub persisted: bool,
+    pub instructions_type: InstructionsType,
 }
 
 impl Instructions {
-    pub fn from_instructions(instructions: ModuleInstructions, persisted: bool) -> Self {
+    pub fn from_instructions(
+        instructions: ModuleInstructions,
+        instructions_type: InstructionsType,
+    ) -> Self {
         Self {
             text: instructions.text,
             audio: instructions.audio,
-            persisted,
+            instructions_type,
         }
     }
 }

--- a/frontend/apps/crates/entry/module/card-quiz/play/src/base/game/actions.rs
+++ b/frontend/apps/crates/entry/module/card-quiz/play/src/base/game/actions.rs
@@ -1,10 +1,15 @@
+use crate::base::state::Phase;
+
 use super::state::*;
 
 use std::sync::atomic::Ordering;
 
 use components::{
     audio::mixer::{AudioMixer, AudioPath, AUDIO_MIXER},
-    module::_groups::cards::play::card::dom::FLIPPED_AUDIO_EFFECT,
+    module::{
+        _common::play::prelude::{BaseExt, ModuleEnding, ModulePlayPhase},
+        _groups::cards::play::card::dom::FLIPPED_AUDIO_EFFECT,
+    },
 };
 
 use dominator::clone;
@@ -43,10 +48,15 @@ impl Game {
                 state.base.settings.n_rounds
             );
         } else {
-            state
-                .base
-                .feedback_signal
-                .set(Some(state.base.feedback.clone()));
+            let feedback = &state.base.feedback;
+            if feedback.has_content() {
+                state.base.feedback_signal.set(Some(feedback.clone()));
+            } else {
+                state.base.phase.set(Phase::Ending);
+                state
+                    .base
+                    .set_play_phase(ModulePlayPhase::Ending(Some(ModuleEnding::Positive)));
+            }
         }
     }
 

--- a/frontend/apps/crates/entry/module/drag-drop/play/src/base/game/playing/actions.rs
+++ b/frontend/apps/crates/entry/module/drag-drop/play/src/base/game/playing/actions.rs
@@ -1,7 +1,9 @@
 use std::rc::Rc;
 
 use super::state::*;
+use components::module::_common::play::prelude::{BaseExt, ModuleEnding, ModulePlayPhase};
 use shared::domain::module::body::_groups::design::Trace;
+use shared::domain::module::body::drag_drop::Next;
 use utils::{drag::Drag, prelude::*, resize::get_resize_info};
 
 use crate::debug::*;
@@ -109,11 +111,16 @@ impl PlayState {
                             // feedback for the activity. If we played this at the same time, it
                             // we could have two audio clips playing simultaneously which would be
                             // noisy and distracting from the intent of the feedbacks.
-                            state
-                                .game
-                                .base
-                                .feedback_signal
-                                .set(Some(state.game.base.feedback.clone()));
+                            let feedback = &state.game.base.feedback;
+                            if feedback.has_content() {
+                                state.game.base.feedback_signal.set(Some(feedback.clone()));
+                            } else {
+                                if let Next::PlaceAll = state.game.base.settings.next {
+                                    state.game.base.set_play_phase(ModulePlayPhase::Ending(Some(
+                                        ModuleEnding::Next,
+                                    )));
+                                }
+                            }
                         });
                     });
                 }

--- a/frontend/apps/crates/entry/module/matching/play/src/base/game/actions.rs
+++ b/frontend/apps/crates/entry/module/matching/play/src/base/game/actions.rs
@@ -1,7 +1,10 @@
+use crate::base::state::Phase;
+
 use super::state::*;
 
 use std::sync::atomic::Ordering;
 
+use components::module::_common::play::prelude::{BaseExt, ModuleEnding, ModulePlayPhase};
 use rand::prelude::*;
 use std::convert::TryInto;
 use std::rc::Rc;
@@ -34,10 +37,15 @@ impl Game {
                 state.base.settings.n_rounds
             );
         } else {
-            state
-                .base
-                .feedback_signal
-                .set(Some(state.base.feedback.clone()));
+            let feedback = &state.base.feedback;
+            if feedback.has_content() {
+                state.base.feedback_signal.set(Some(feedback.clone()));
+            } else {
+                state.base.phase.set(Phase::Ending);
+                state
+                    .base
+                    .set_play_phase(ModulePlayPhase::Ending(Some(ModuleEnding::Positive)));
+            }
         }
     }
 

--- a/frontend/apps/crates/entry/module/memory/play/src/base/stage/dom.rs
+++ b/frontend/apps/crates/entry/module/memory/play/src/base/stage/dom.rs
@@ -1,4 +1,5 @@
 use super::game::dom::render as render_game;
+use components::module::_common::play::prelude::{BaseExt, ModuleEnding, ModulePlayPhase};
 use dominator::{clone, html, Dom};
 use futures_signals::signal::SignalExt;
 use std::rc::Rc;
@@ -9,9 +10,13 @@ pub fn render(state: Rc<Base>) -> Dom {
     html!("empty-fragment", {
         .future(state.all_cards_ended_signal().dedupe().for_each(clone!(state => move |ended| {
             if ended {
-                state
-                    .feedback_signal
-                    .set(Some(state.feedback.clone()));
+                if state.feedback.has_content() {
+                    state
+                        .feedback_signal
+                        .set(Some(state.feedback.clone()));
+                } else {
+                    state.set_play_phase(ModulePlayPhase::Ending(Some(ModuleEnding::Positive)));
+                }
             }
             async {}
         })))

--- a/frontend/apps/crates/utils/src/iframe.rs
+++ b/frontend/apps/crates/utils/src/iframe.rs
@@ -1,6 +1,9 @@
 use crate::unwrap::UnwrapJiExt;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use shared::domain::module::{body::Instructions, LiteModule, ModuleId};
+use shared::domain::module::{
+    body::{Instructions, InstructionsType},
+    LiteModule, ModuleId,
+};
 use std::cell::Cell;
 use wasm_bindgen::prelude::*;
 
@@ -183,21 +186,8 @@ pub enum ModuleToJigPlayerMessage {
     Next,
     JumpToIndex(usize),
     JumpToId(ModuleId),
-    /// Optional instructions, and whether they should be always available
-    Instructions(Option<Instructions>, bool),
-}
-
-impl ModuleToJigPlayerMessage {
-    /// Instructions which will be available until new instructions are sent, or the activity ends
-    pub fn instructions(instructions: Option<Instructions>) -> Self {
-        Self::Instructions(instructions, true)
-    }
-
-    /// Instructions which will be available only once until audio has played, or the student has
-    /// clicked OK
-    pub fn instructions_once(instructions: Option<Instructions>) -> Self {
-        Self::Instructions(instructions, false)
-    }
+    /// Optional instructions, and their type
+    Instructions(Option<(Instructions, InstructionsType)>),
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/shared/rust/src/domain/module/body.rs
+++ b/shared/rust/src/domain/module/body.rs
@@ -438,6 +438,27 @@ impl Instructions {
     }
 }
 
+/// Type of Instructions to be shown
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub enum InstructionsType {
+    /// Instructions are shown when an activity starts
+    Instructions,
+    /// Feedback is shown at the end of an activity
+    Feedback,
+}
+
+impl InstructionsType {
+    /// Whether this variant is `Instructions`
+    pub fn is_instructions(&self) -> bool {
+        matches!(self, Self::Instructions)
+    }
+
+    /// Whether this variant is `Feedback`
+    pub fn is_feedback(&self) -> bool {
+        matches!(self, Self::Feedback)
+    }
+}
+
 #[derive(Clone, Serialize, Deserialize, Debug)]
 /// Background
 pub enum Background {


### PR DESCRIPTION
Closes #3307

- Fixes issue where activities wouldn't end correctly if no feedback config was set;
- Updates instruction/feedback logic to only show popup if there is a timer or if there is text set.