### PR TITLE
fix(fe/play): Prevent feedback advancing to next activity automatically when there is text and audio

### DIFF
--- a/frontend/apps/crates/entry/asset/play/src/jig/actions.rs
+++ b/frontend/apps/crates/entry/asset/play/src/jig/actions.rs
@@ -167,7 +167,7 @@ pub fn play_instructions_audio(state: Rc<JigPlayer>) {
     if let Some(instructions) = state.instructions.get_cloned() {
         if let Some(audio) = &instructions.audio {
             AUDIO_MIXER.with(clone!(state, instructions => move |mixer| mixer.play_oneshot_on_ended(audio.into(), clone!(state => move || {
-                if instructions.instructions_type.is_feedback() {
+                if instructions.instructions_type.is_feedback() && instructions.text.is_none() {
                     set_instructions(state.clone(), None);
                     send_iframe_message(Rc::clone(&state), JigToModulePlayerMessage::InstructionsDone);
                 }


### PR DESCRIPTION
- Fixes issue when an activity has feedback configured with both text and audio, once the audio completed, the JIG would be advanced to the next activity.