### PR TITLE
fix(fe/instructions): Prevent playing multiple instructions audio simultaneously

### DIFF
--- a/frontend/apps/crates/components/src/audio/mixer/mixer_top.rs
+++ b/frontend/apps/crates/components/src/audio/mixer/mixer_top.rs
@@ -93,6 +93,10 @@ impl AudioMixerTop {
         let el = active.remove(&handle_id);
         if let Some(el) = &el {
             spawn_local(clone!(el => async move {
+                // We need to make sure that the audio has stopped playing once the handle was "dropped"
+                // otherwise it'll keep playing even while in the inactive queue.
+                // Alternatively, set_url("") might be better than pausing it.
+                let _ = el.pause();
                 // wait for next cycle as ended_callbacks is currently locked because handle_dropped is called from within a callback
                 TimeoutFuture::new(0).await;
                 ENDED_CALLBACKS.with(clone!(el => move |ended_callbacks| {

--- a/frontend/apps/crates/entry/asset/play/src/jig/actions.rs
+++ b/frontend/apps/crates/entry/asset/play/src/jig/actions.rs
@@ -166,12 +166,12 @@ pub fn show_instructions(state: Rc<JigPlayer>, visible: bool) {
 pub fn play_instructions_audio(state: Rc<JigPlayer>) {
     if let Some(instructions) = state.instructions.get_cloned() {
         if let Some(audio) = &instructions.audio {
-            AUDIO_MIXER.with(clone!(state, instructions => move |mixer| mixer.play_oneshot_on_ended(audio.into(), clone!(state => move || {
+            *instructions.audio_handle.borrow_mut() = Some(AUDIO_MIXER.with(clone!(state, instructions => move |mixer| mixer.play_on_ended(audio.into(), false, clone!(state => move || {
                 if instructions.instructions_type.is_feedback() && instructions.text.is_none() {
                     set_instructions(state.clone(), None);
                     send_iframe_message(Rc::clone(&state), JigToModulePlayerMessage::InstructionsDone);
                 }
-            }))));
+            })))));
         }
     }
 }

--- a/frontend/apps/crates/entry/asset/play/src/jig/state.rs
+++ b/frontend/apps/crates/entry/asset/play/src/jig/state.rs
@@ -109,6 +109,7 @@ pub struct Instructions {
     pub text: Option<String>,
     pub audio: Option<Audio>,
     pub instructions_type: InstructionsType,
+    pub audio_handle: Rc<RefCell<Option<AudioHandle>>>,
 }
 
 impl Instructions {
@@ -120,6 +121,7 @@ impl Instructions {
             text: instructions.text,
             audio: instructions.audio,
             instructions_type,
+            audio_handle: Rc::new(RefCell::new(None)),
         }
     }
 }


### PR DESCRIPTION
- Fixes issue where clicking "Repeat" in instruction popup multiple times could play the audio multiple times simultaneously.