### PR TITLE
fix(fe/stickers): Remove 's' from forward/backward menu items

### DIFF
--- a/frontend/elements/src/core/menu/menu-line.ts
+++ b/frontend/elements/src/core/menu/menu-line.ts
@@ -32,8 +32,8 @@ const STR_LABEL_LOOKUP: any = {
     ["reuse"]: "Reuse",
     //all stickers
     ["move-to-front"]: "Bring to front",
-    ["move-forward"]: "Bring forwards",
-    ["move-backward"]: "Send backwards",
+    ["move-forward"]: "Bring forward",
+    ["move-backward"]: "Send backward",
     ["move-to-back"]: "Send to back",
     ["flip-horizontal"]: "Flip right-left",
     ["flip-vertical"]: "Flip up-down",


### PR DESCRIPTION
Closes #3341