### PR TITLE
fix(fe/instructions): Prevent overlapping instructions audio with activity audio

### DIFF
--- a/frontend/apps/crates/components/src/module/_common/play/entry/state.rs
+++ b/frontend/apps/crates/components/src/module/_common/play/entry/state.rs
@@ -4,7 +4,7 @@ use dominator_helpers::futures::AsyncLoader;
 use futures_signals::signal::{Mutable, ReadOnlyMutable};
 use shared::domain::asset::{Asset, AssetId, AssetType, DraftOrLive, PrivacyLevel};
 use shared::domain::course::CourseGetDraftPath;
-use shared::domain::module::body::Instructions;
+use shared::domain::module::body::{Instructions, InstructionsType};
 use shared::domain::resource::ResourceGetDraftPath;
 use shared::{
     api::endpoints::{self, module::*},
@@ -325,6 +325,7 @@ pub enum InitSource {
 pub enum ModulePlayPhase {
     Preload,
     Init,
+    PreStart,
     Playing,
     Ending(Option<ModuleEnding>),
 }
@@ -404,7 +405,7 @@ pub trait BaseExt: DomRenderable {
         Mutable::new(None).read_only()
     }
 
-    fn handle_instructions_ended(&self) {
+    fn handle_instructions_ended(&self, _instructions_type: InstructionsType) {
         // Do nothing. Activities which have custom ended logic/rules should implement this.
     }
 

--- a/frontend/apps/crates/entry/asset/play/src/jig/dom.rs
+++ b/frontend/apps/crates/entry/asset/play/src/jig/dom.rs
@@ -45,7 +45,7 @@ impl JigPlayer {
             let timer = state.timer.signal_cloned(),
             let started = state.started.signal_cloned().dedupe()
             => {
-                let result = if *started {
+                if *started {
                     if let Some(instructions) = instructions {
                         if timer.is_some() || instructions.text.is_some() {
                             let is_instructions = instructions.instructions_type.is_instructions();
@@ -71,9 +71,7 @@ impl JigPlayer {
                     }
                 } else {
                     None
-                };
-
-                result
+                }
             }
         };
 

--- a/frontend/apps/crates/entry/module/card-quiz/play/src/base/state.rs
+++ b/frontend/apps/crates/entry/module/card-quiz/play/src/base/state.rs
@@ -5,6 +5,7 @@ use shared::domain::{
             Background, Instructions,
             _groups::cards::{CardPair, Mode, Step},
             card_quiz::{ModuleData as RawData, PlayerSettings},
+            InstructionsType,
         },
         ModuleId,
     },
@@ -83,9 +84,11 @@ impl BaseExt for Base {
         self.feedback_signal.read_only()
     }
 
-    fn handle_instructions_ended(&self) {
-        self.phase.set(Phase::Ending);
-        self.set_play_phase(ModulePlayPhase::Ending(Some(ModuleEnding::Positive)));
+    fn handle_instructions_ended(&self, instructions_type: InstructionsType) {
+        if let InstructionsType::Feedback = instructions_type {
+            self.phase.set(Phase::Ending);
+            self.set_play_phase(ModulePlayPhase::Ending(Some(ModuleEnding::Positive)));
+        }
     }
 
     fn get_timer_minutes(&self) -> Option<u32> {

--- a/frontend/apps/crates/entry/module/drag-drop/play/src/base/state.rs
+++ b/frontend/apps/crates/entry/module/drag-drop/play/src/base/state.rs
@@ -9,6 +9,7 @@ use shared::domain::{
                 Item, Mode, ModuleData as RawData, Next, PlaySettings, Step, TargetArea,
                 TargetTransform,
             },
+            InstructionsType,
         },
         ModuleId,
     },
@@ -74,9 +75,11 @@ impl BaseExt for Base {
         self.feedback_signal.read_only()
     }
 
-    fn handle_instructions_ended(&self) {
-        if let Next::PlaceAll = self.settings.next {
-            self.set_play_phase(ModulePlayPhase::Ending(Some(ModuleEnding::Next)));
+    fn handle_instructions_ended(&self, instructions_type: InstructionsType) {
+        if let InstructionsType::Feedback = instructions_type {
+            if let Next::PlaceAll = self.settings.next {
+                self.set_play_phase(ModulePlayPhase::Ending(Some(ModuleEnding::Next)));
+            }
         }
     }
 

--- a/frontend/apps/crates/entry/module/find-answer/play/src/base/state.rs
+++ b/frontend/apps/crates/entry/module/find-answer/play/src/base/state.rs
@@ -10,7 +10,7 @@ use shared::domain::{
                 Mode, ModuleData as RawData, Next, Ordering, PlaySettings, Question, QuestionField,
                 Step,
             },
-            Instructions,
+            Instructions, InstructionsType,
         },
         ModuleId,
     },
@@ -108,12 +108,14 @@ impl BaseExt for Base {
         self.feedback_signal.read_only()
     }
 
-    fn handle_instructions_ended(&self) {
-        match self.settings.next {
-            Next::SelectAll | Next::SelectSome(_) => {
-                self.set_play_phase(ModulePlayPhase::Ending(Some(ModuleEnding::Next)));
+    fn handle_instructions_ended(&self, instructions_type: InstructionsType) {
+        if let InstructionsType::Feedback = instructions_type {
+            match self.settings.next {
+                Next::SelectAll | Next::SelectSome(_) => {
+                    self.set_play_phase(ModulePlayPhase::Ending(Some(ModuleEnding::Next)));
+                }
+                _ => {}
             }
-            _ => {}
         }
     }
 

--- a/frontend/apps/crates/entry/module/matching/play/src/base/state.rs
+++ b/frontend/apps/crates/entry/module/matching/play/src/base/state.rs
@@ -5,6 +5,7 @@ use shared::domain::{
             Background, Instructions,
             _groups::cards::{CardPair, Mode, Step},
             matching::{ModuleData as RawData, PlayerSettings},
+            InstructionsType,
         },
         ModuleId,
     },
@@ -83,9 +84,11 @@ impl BaseExt for Base {
         self.feedback_signal.read_only()
     }
 
-    fn handle_instructions_ended(&self) {
-        self.phase.set(Phase::Ending);
-        self.set_play_phase(ModulePlayPhase::Ending(Some(ModuleEnding::Positive)));
+    fn handle_instructions_ended(&self, instructions_type: InstructionsType) {
+        if let InstructionsType::Feedback = instructions_type {
+            self.phase.set(Phase::Ending);
+            self.set_play_phase(ModulePlayPhase::Ending(Some(ModuleEnding::Positive)));
+        }
     }
 
     fn get_timer_minutes(&self) -> Option<u32> {

--- a/frontend/apps/crates/entry/module/memory/play/src/base/state.rs
+++ b/frontend/apps/crates/entry/module/memory/play/src/base/state.rs
@@ -7,6 +7,7 @@ use shared::{
                 Background, Instructions,
                 _groups::cards::{CardPair as RawCardPair, Mode, Step},
                 memory::{ModuleData as RawData, PlayerSettings},
+                InstructionsType,
             },
             ModuleId,
         },
@@ -168,8 +169,10 @@ impl BaseExt for Base {
         self.feedback_signal.read_only()
     }
 
-    fn handle_instructions_ended(&self) {
-        self.set_play_phase(ModulePlayPhase::Ending(Some(ModuleEnding::Positive)));
+    fn handle_instructions_ended(&self, instructions_type: InstructionsType) {
+        if let InstructionsType::Feedback = instructions_type {
+            self.set_play_phase(ModulePlayPhase::Ending(Some(ModuleEnding::Positive)));
+        }
     }
 
     fn get_timer_minutes(&self) -> Option<u32> {

--- a/frontend/apps/crates/utils/src/iframe.rs
+++ b/frontend/apps/crates/utils/src/iframe.rs
@@ -175,7 +175,7 @@ pub enum JigToModulePlayerMessage {
     // remove play and pause? might need for video
     Play,
     Pause,
-    InstructionsDone,
+    InstructionsDone(InstructionsType),
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
Resolves #3317

- Adds an extra `PreStart` phase so that instructions can be played/shown.