### PR TITLE
feat(fe/stickers): Implement move keys and delete key on all stickers

### DIFF
--- a/frontend/apps/crates/components/src/stickers/dom.rs
+++ b/frontend/apps/crates/components/src/stickers/dom.rs
@@ -227,26 +227,43 @@ pub fn render_sticker<T: AsSticker>(
     sticker: T,
     opts: Option<StickerRenderOptions>,
 ) -> Dom {
-    match sticker.as_ref() {
-        Sticker::Sprite(sprite) => render_sticker_sprite(
-            stickers,
-            index,
-            sprite.clone(),
-            opts.map(|opts| opts.into_sprite_unchecked()),
-        ),
-        Sticker::Text(text) => render_sticker_text(
-            stickers,
-            index,
-            text.clone(),
-            opts.map(|opts| opts.into_text_unchecked()),
-        ),
-        Sticker::Video(video) => render_sticker_video(
-            stickers,
-            index,
-            video.clone(),
-            opts.map(|opts| opts.into_video_unchecked()),
-        ),
-    }
+    html!("empty-fragment", {
+        .global_event(clone!(stickers, index => move |evt:events::KeyDown| {
+            if evt.key() == "Delete" && !evt.repeat() {
+                if let Some(selected) = stickers.selected_index.get_cloned() {
+                    if Some(selected) == index.get_cloned() {
+                        // If we don't deselect the currently selected sticker, then this event will
+                        // trigger on each sticker which moves into this index after the current one is
+                        // deleted.
+                        stickers.selected_index.set(None);
+                        stickers.delete_index(selected);
+                    }
+                }
+            }
+        }))
+        .child(
+            match sticker.as_ref() {
+                Sticker::Sprite(sprite) => render_sticker_sprite(
+                    stickers,
+                    index,
+                    sprite.clone(),
+                    opts.map(|opts| opts.into_sprite_unchecked()),
+                ),
+                Sticker::Text(text) => render_sticker_text(
+                    stickers,
+                    index,
+                    text.clone(),
+                    opts.map(|opts| opts.into_text_unchecked()),
+                ),
+                Sticker::Video(video) => render_sticker_video(
+                    stickers,
+                    index,
+                    video.clone(),
+                    opts.map(|opts| opts.into_video_unchecked()),
+                ),
+            }
+        )
+    })
 }
 
 pub fn render_stickers_raw(stickers: &[RawSticker], theme_id: ThemeId) -> Dom {

--- a/frontend/apps/crates/components/src/transform/state.rs
+++ b/frontend/apps/crates/components/src/transform/state.rs
@@ -12,6 +12,9 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use web_sys::{DomRect, HtmlElement};
 
+pub const MOVE_MULTIPLIER: f64 = 10.0;
+pub const MOVE_AMOUNT_PX: f64 = 1.0;
+
 pub struct TransformState {
     pub size: Mutable<Option<(f64, f64)>>,
     pub menu_pos: Mutable<Option<(f64, f64)>>,
@@ -22,6 +25,7 @@ pub struct TransformState {
     pub(super) action: RefCell<Option<Action>>,
     pub(super) rot_stash: RefCell<Option<InitRotation>>,
     pub(super) scale_stash: RefCell<Option<InitScale>>,
+    pub(super) shift_pressed: RefCell<bool>,
     pub(super) alt_pressed: RefCell<bool>,
     pub(super) dom_ref: RefCell<Option<TransformBoxElement>>,
     pub(super) callbacks: TransformCallbacks,
@@ -81,6 +85,7 @@ impl TransformState {
             action: RefCell::new(None),
             rot_stash: RefCell::new(None),
             scale_stash: RefCell::new(None),
+            shift_pressed: RefCell::new(false),
             alt_pressed: RefCell::new(false),
             is_transforming: Mutable::new(false),
             menu_pos: Mutable::new(None),
@@ -297,6 +302,51 @@ pub enum Action {
     Move,
     Rotate,
     Scale(ScaleFrom, LockAspect),
+}
+
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum Key {
+    ArrowLeft,
+    ArrowUp,
+    ArrowRight,
+    ArrowDown,
+    Shift,
+    Alt,
+    Other,
+}
+
+impl Key {
+    pub fn is_move_key(&self) -> bool {
+        match self {
+            Self::ArrowLeft | Self::ArrowRight | Self::ArrowUp | Self::ArrowDown => true,
+            _ => false,
+        }
+    }
+    pub fn translation_from_key(&self) -> (f64, f64) {
+        let resize_info = get_resize_info();
+        match self {
+            Self::ArrowLeft => resize_info.get_px_normalized(-MOVE_AMOUNT_PX, 0.0),
+            Self::ArrowRight => resize_info.get_px_normalized(MOVE_AMOUNT_PX, 0.0),
+            Self::ArrowUp => resize_info.get_px_normalized(0.0, -MOVE_AMOUNT_PX),
+            Self::ArrowDown => resize_info.get_px_normalized(0.0, MOVE_AMOUNT_PX),
+            _ => (0.0, 0.0),
+        }
+    }
+}
+
+impl From<String> for Key {
+    fn from(value: String) -> Self {
+        match value.as_str() {
+            "ArrowLeft" => Self::ArrowLeft,
+            "ArrowUp" => Self::ArrowUp,
+            "ArrowRight" => Self::ArrowRight,
+            "ArrowDown" => Self::ArrowDown,
+            "Shift" => Self::Shift,
+            "Alt" => Self::Alt,
+            _ => Self::Other,
+        }
+    }
 }
 
 pub type LockAspect = bool;


### PR DESCRIPTION
Part of #1837

- Adds arrow keys to move stickers, with Shift key for moving faster;
- Adds delete key for deleting a selected sticker.