### PR TITLE
feat(fe/stickers): Implement undo and redo during activity editing

### DIFF
--- a/frontend/apps/Cargo.toml
+++ b/frontend/apps/Cargo.toml
@@ -138,6 +138,7 @@ web-sys = { version = "0.3.55", features = [
     'console',
     'DomParser',
     'SupportedType',
+    'Navigator',
 ] }
 
 [profile.release]

--- a/frontend/apps/crates/components/src/module/_common/edit/header/controller/dom.rs
+++ b/frontend/apps/crates/components/src/module/_common/edit/header/controller/dom.rs
@@ -1,7 +1,10 @@
 use dominator::{clone, html, Dom};
 
 use std::{fmt::Debug, rc::Rc};
-use utils::events;
+use utils::{
+    events,
+    keyboard::{Key, KeyEvent},
+};
 
 use crate::module::_common::edit::history::state::HistoryState;
 
@@ -37,6 +40,25 @@ impl ControllerDom {
                     }
                     _ => {}
                 };
+            }))
+            .global_event(clone!(history => move |evt: events::KeyDown| {
+                let key_event = KeyEvent::from(evt);
+                let key = &key_event.key;
+
+                if let Key::Other(other) = key {
+                    let other = other.to_uppercase();
+                    let other: &str = other.as_ref();
+                    if key_event.ctrl_cmd && !key_event.shift && other == "Z" {
+                        history.undo();
+                    } else {
+                        let is_osx_redo = key_event.is_osx && key_event.ctrl_cmd && key_event.shift && other == "Z";
+                        let is_regular_redo = !key_event.is_osx && key_event.ctrl_cmd && other == "Y";
+
+                        if is_osx_redo || is_regular_redo {
+                            history.redo();
+                        }
+                    }
+                }
             }))
         })
     }

--- a/frontend/apps/crates/components/src/stickers/dom.rs
+++ b/frontend/apps/crates/components/src/stickers/dom.rs
@@ -19,7 +19,10 @@ use futures_signals::{
 };
 use shared::domain::module::body::{Transform, _groups::design::Sticker as RawSticker};
 use std::rc::Rc;
-use utils::prelude::*;
+use utils::{
+    keyboard::{Key, KeyEvent},
+    prelude::*,
+};
 use web_sys::HtmlElement;
 
 pub fn mixin_sticker_button_signal(
@@ -229,7 +232,7 @@ pub fn render_sticker<T: AsSticker>(
 ) -> Dom {
     html!("empty-fragment", {
         .global_event(clone!(stickers, index => move |evt:events::KeyDown| {
-            if evt.key() == "Delete" && !evt.repeat() {
+            if let Key::Delete = KeyEvent::from(evt).key {
                 if let Some(selected) = stickers.selected_index.get_cloned() {
                     if Some(selected) == index.get_cloned() {
                         // If we don't deselect the currently selected sticker, then this event will

--- a/frontend/apps/crates/components/src/transform/state.rs
+++ b/frontend/apps/crates/components/src/transform/state.rs
@@ -12,9 +12,6 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use web_sys::{DomRect, HtmlElement};
 
-pub const MOVE_MULTIPLIER: f64 = 10.0;
-pub const MOVE_AMOUNT_PX: f64 = 1.0;
-
 pub struct TransformState {
     pub size: Mutable<Option<(f64, f64)>>,
     pub menu_pos: Mutable<Option<(f64, f64)>>,
@@ -25,7 +22,6 @@ pub struct TransformState {
     pub(super) action: RefCell<Option<Action>>,
     pub(super) rot_stash: RefCell<Option<InitRotation>>,
     pub(super) scale_stash: RefCell<Option<InitScale>>,
-    pub(super) shift_pressed: RefCell<bool>,
     pub(super) alt_pressed: RefCell<bool>,
     pub(super) dom_ref: RefCell<Option<TransformBoxElement>>,
     pub(super) callbacks: TransformCallbacks,
@@ -85,7 +81,6 @@ impl TransformState {
             action: RefCell::new(None),
             rot_stash: RefCell::new(None),
             scale_stash: RefCell::new(None),
-            shift_pressed: RefCell::new(false),
             alt_pressed: RefCell::new(false),
             is_transforming: Mutable::new(false),
             menu_pos: Mutable::new(None),
@@ -302,51 +297,6 @@ pub enum Action {
     Move,
     Rotate,
     Scale(ScaleFrom, LockAspect),
-}
-
-#[derive(Debug)]
-#[non_exhaustive]
-pub enum Key {
-    ArrowLeft,
-    ArrowUp,
-    ArrowRight,
-    ArrowDown,
-    Shift,
-    Alt,
-    Other,
-}
-
-impl Key {
-    pub fn is_move_key(&self) -> bool {
-        match self {
-            Self::ArrowLeft | Self::ArrowRight | Self::ArrowUp | Self::ArrowDown => true,
-            _ => false,
-        }
-    }
-    pub fn translation_from_key(&self) -> (f64, f64) {
-        let resize_info = get_resize_info();
-        match self {
-            Self::ArrowLeft => resize_info.get_px_normalized(-MOVE_AMOUNT_PX, 0.0),
-            Self::ArrowRight => resize_info.get_px_normalized(MOVE_AMOUNT_PX, 0.0),
-            Self::ArrowUp => resize_info.get_px_normalized(0.0, -MOVE_AMOUNT_PX),
-            Self::ArrowDown => resize_info.get_px_normalized(0.0, MOVE_AMOUNT_PX),
-            _ => (0.0, 0.0),
-        }
-    }
-}
-
-impl From<String> for Key {
-    fn from(value: String) -> Self {
-        match value.as_str() {
-            "ArrowLeft" => Self::ArrowLeft,
-            "ArrowUp" => Self::ArrowUp,
-            "ArrowRight" => Self::ArrowRight,
-            "ArrowDown" => Self::ArrowDown,
-            "Shift" => Self::Shift,
-            "Alt" => Self::Alt,
-            _ => Self::Other,
-        }
-    }
 }
 
 pub type LockAspect = bool;

--- a/frontend/apps/crates/utils/src/keyboard.rs
+++ b/frontend/apps/crates/utils/src/keyboard.rs
@@ -1,0 +1,85 @@
+use dominator::events::{KeyDown, KeyUp};
+
+use crate::{resize::get_resize_info, unwrap::UnwrapJiExt};
+
+pub const MOVE_MULTIPLIER: f64 = 10.0;
+pub const MOVE_AMOUNT_PX: f64 = 1.0;
+
+/// Map of keyboard keys used to perform various actions in the system.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub enum Key {
+    ArrowLeft,
+    ArrowUp,
+    ArrowRight,
+    ArrowDown,
+    Delete,
+    Other(String),
+}
+
+#[derive(Clone, Debug)]
+pub struct KeyEvent {
+    pub is_osx: bool,
+    pub shift: bool,
+    pub alt: bool,
+    pub ctrl_cmd: bool,
+    pub key: Key,
+}
+
+impl Key {
+    pub fn is_move_key(&self) -> bool {
+        match self {
+            Self::ArrowLeft | Self::ArrowRight | Self::ArrowUp | Self::ArrowDown => true,
+            _ => false,
+        }
+    }
+    pub fn translation_from_key(&self) -> (f64, f64) {
+        let resize_info = get_resize_info();
+        match self {
+            Self::ArrowLeft => resize_info.get_px_normalized(-MOVE_AMOUNT_PX, 0.0),
+            Self::ArrowRight => resize_info.get_px_normalized(MOVE_AMOUNT_PX, 0.0),
+            Self::ArrowUp => resize_info.get_px_normalized(0.0, -MOVE_AMOUNT_PX),
+            Self::ArrowDown => resize_info.get_px_normalized(0.0, MOVE_AMOUNT_PX),
+            _ => (0.0, 0.0),
+        }
+    }
+}
+
+impl From<String> for Key {
+    fn from(value: String) -> Self {
+        match value.as_str() {
+            "ArrowLeft" => Self::ArrowLeft,
+            "ArrowUp" => Self::ArrowUp,
+            "ArrowRight" => Self::ArrowRight,
+            "ArrowDown" => Self::ArrowDown,
+            "Delete" => Self::Delete,
+            other => Self::Other(other.into()),
+        }
+    }
+}
+
+/// Helper to implement `KeyUp` and `KeyDown` events.
+macro_rules! impl_from_key_event {
+    ($event_type:ident) => {
+        impl From<$event_type> for KeyEvent {
+            fn from(value: $event_type) -> Self {
+                let user_agent: String = web_sys::window()
+                    .unwrap_ji()
+                    .navigator()
+                    .user_agent()
+                    .unwrap_ji();
+
+                Self {
+                    is_osx: user_agent.contains("Mac OS X"),
+                    shift: value.shift_key(),
+                    alt: value.alt_key(),
+                    ctrl_cmd: value.ctrl_key(),
+                    key: Key::from(value.key()),
+                }
+            }
+        }
+    };
+}
+
+impl_from_key_event!(KeyDown);
+impl_from_key_event!(KeyUp);

--- a/frontend/apps/crates/utils/src/lib.rs
+++ b/frontend/apps/crates/utils/src/lib.rs
@@ -17,6 +17,7 @@ pub mod image;
 pub mod image_effects;
 pub mod init;
 pub mod js_wrappers;
+pub mod keyboard;
 pub mod languages;
 pub mod logging;
 pub mod math;


### PR DESCRIPTION
Part of #1837

- Adds undo/redo shortcut keys:
  - On Mac: Cmd + Z to undo, Cmd + Shift + Z to redo;
  - On Linux/Win: Ctrl + Z to undo, Ctrl + Y to redo.