### PR TITLE
feat(fe/asset/jig/play): Arrow key navigation respects JIG direction setting

### DIFF
--- a/frontend/apps/crates/entry/asset/play/src/jig/dom.rs
+++ b/frontend/apps/crates/entry/asset/play/src/jig/dom.rs
@@ -15,6 +15,7 @@ use utils::events;
 use utils::iframe::{AssetPlayerToPlayerPopup, IframeMessageExt};
 use utils::init::analytics;
 use utils::js_wrappers::is_iframe;
+use utils::keyboard::KeyEvent;
 use utils::prelude::is_in_iframe;
 use utils::{
     iframe::{IframeAction, ModuleToJigPlayerMessage},
@@ -380,9 +381,7 @@ impl JigPlayer {
                         actions::navigate_back(Rc::clone(&state));
                     }))
                     .global_event(clone!(state => move |e: events::KeyUp| {
-                        if &e.key() == "ArrowLeft" {
-                            actions::navigate_back(Rc::clone(&state));
-                        }
+                        actions::navigate_from_keyboard_event(state.clone(), KeyEvent::from(e));
                     }))
                 }),
                 html!("jig-play-progress-bar", {
@@ -396,9 +395,7 @@ impl JigPlayer {
                         actions::navigate_forward(Rc::clone(&state));
                     }))
                     .global_event(clone!(state => move |e: events::KeyUp| {
-                        if &e.key() == "ArrowRight" {
-                            actions::navigate_forward(Rc::clone(&state));
-                        }
+                        actions::navigate_from_keyboard_event(state.clone(), KeyEvent::from(e));
                     }))
                 }),
             ])

--- a/frontend/apps/crates/utils/src/iframe.rs
+++ b/frontend/apps/crates/utils/src/iframe.rs
@@ -1,4 +1,4 @@
-use crate::unwrap::UnwrapJiExt;
+use crate::{keyboard::KeyEvent, unwrap::UnwrapJiExt};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use shared::domain::module::{
     body::{Instructions, InstructionsType},
@@ -187,6 +187,9 @@ pub enum ModuleToJigPlayerMessage {
     Next,
     JumpToIndex(usize),
     JumpToId(ModuleId),
+    /// Useful for acting on key press events such as arrow keys for navigating between activities
+    KeyEvent(KeyEvent),
+
     /// Optional instructions, and their type
     Instructions(Option<(Instructions, InstructionsType)>),
 }

--- a/frontend/apps/crates/utils/src/keyboard.rs
+++ b/frontend/apps/crates/utils/src/keyboard.rs
@@ -1,4 +1,5 @@
 use dominator::events::{KeyDown, KeyUp};
+use serde::{Deserialize, Serialize};
 
 use crate::{resize::get_resize_info, unwrap::UnwrapJiExt};
 
@@ -6,7 +7,7 @@ pub const MOVE_MULTIPLIER: f64 = 10.0;
 pub const MOVE_AMOUNT_PX: f64 = 1.0;
 
 /// Map of keyboard keys used to perform various actions in the system.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum Key {
     ArrowLeft,
@@ -17,7 +18,7 @@ pub enum Key {
     Other(String),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct KeyEvent {
     pub is_osx: bool,
     pub shift: bool,


### PR DESCRIPTION
- Also includes update to use the `KeyEvent` struct to figure out which key was pressed.