### PR TITLE
fix(fe/instructions): Pause timer to prevent instructions from showing at the end of an activity; Correctly ends the Answer This activity

### DIFF
--- a/frontend/apps/crates/components/src/module/_common/play/entry/state.rs
+++ b/frontend/apps/crates/components/src/module/_common/play/entry/state.rs
@@ -331,8 +331,13 @@ pub enum ModulePlayPhase {
 }
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum ModuleEnding {
+    // [Ty] I'm not 100% sure about these endings, but afaict they are not implemented except
+    // for Next.
+    /// The student completed the module correctly
     Positive,
+    /// The student completed the module, but there were mistakes
     Negative,
+    /// Move on to the next module
     Next,
 }
 

--- a/frontend/apps/crates/entry/asset/play/src/jig/actions.rs
+++ b/frontend/apps/crates/entry/asset/play/src/jig/actions.rs
@@ -372,7 +372,8 @@ pub fn on_iframe_message(state: Rc<JigPlayer>, message: ModuleToJigPlayerMessage
             navigate_forward(state);
         }
         ModuleToJigPlayerMessage::Stop => {
-            state.timer.set(None);
+            // Instead of stopping the timer altogether, we pause it
+            set_timer_paused(&state, true);
         }
         ModuleToJigPlayerMessage::JumpToIndex(index) => {
             navigate_to_index(state, index);

--- a/frontend/apps/crates/entry/module/find-answer/play/src/base/game/playing/actions.rs
+++ b/frontend/apps/crates/entry/module/find-answer/play/src/base/game/playing/actions.rs
@@ -110,7 +110,10 @@ impl PlayState {
                                 .base
                                 .set_play_phase(ModulePlayPhase::Ending(Some(ModuleEnding::Next)));
                         }
-                        _ => {}
+                        _ => state
+                            .game
+                            .base
+                            .set_play_phase(ModulePlayPhase::Ending(Some(ModuleEnding::Positive))),
                     }
                 }
             }

--- a/frontend/apps/crates/entry/module/find-answer/play/src/base/state.rs
+++ b/frontend/apps/crates/entry/module/find-answer/play/src/base/state.rs
@@ -114,7 +114,7 @@ impl BaseExt for Base {
                 Next::SelectAll | Next::SelectSome(_) => {
                     self.set_play_phase(ModulePlayPhase::Ending(Some(ModuleEnding::Next)));
                 }
-                _ => {}
+                _ => self.set_play_phase(ModulePlayPhase::Ending(Some(ModuleEnding::Positive))),
             }
         }
     }


### PR DESCRIPTION
- Resolves #3095;
- Resolves issue where instructions would show up at the end of an activity.