### PR TITLE
fix(fe/flashcards): increase card border radius

### DIFF
--- a/frontend/elements/src/module/_groups/cards/play/card/card.ts
+++ b/frontend/elements/src/module/_groups/cards/play/card/card.ts
@@ -36,6 +36,10 @@ export class _ extends LitElement {
                     z-index: 1001;
                 }
 
+                :host([side="left"][size="flashcards"]) .front.content {
+                    border-radius: 56px;
+                }
+
                 section {
                     transition: transform 0.8s;
                     transform-style: preserve-3d;
@@ -186,18 +190,18 @@ export class _ extends LitElement {
                 </div>
                 <div class="back">
                     ${doubleSided
-                        ? html`<div
+                ? html`<div
                               class="content"
                               style=${getContentStyle(
-                                  styleKind,
-                                  theme,
-                                  mode,
-                                  backSide
-                              )}
+                    styleKind,
+                    theme,
+                    mode,
+                    backSide
+                )}
                           >
                               <slot name="backSideContent"></slot>
                           </div>`
-                        : html`<img-ui
+                : html`<img-ui
                               path="${cardBackFullPath(theme)}"
                           ></img-ui>`}
                 </div>

--- a/frontend/elements/src/module/_groups/cards/play/card/card.ts
+++ b/frontend/elements/src/module/_groups/cards/play/card/card.ts
@@ -36,10 +36,6 @@ export class _ extends LitElement {
                     z-index: 1001;
                 }
 
-                :host([side="left"][size="flashcards"]) .front.content {
-                    border-radius: 56px;
-                }
-
                 section {
                     transition: transform 0.8s;
                     transform-style: preserve-3d;
@@ -190,18 +186,18 @@ export class _ extends LitElement {
                 </div>
                 <div class="back">
                     ${doubleSided
-                ? html`<div
+                        ? html`<div
                               class="content"
                               style=${getContentStyle(
-                    styleKind,
-                    theme,
-                    mode,
-                    backSide
-                )}
-                          >
-                              <slot name="backSideContent"></slot>
-                          </div>`
-                : html`<img-ui
+                                  styleKind,
+                                  theme,
+                                  mode,
+                                  backSide
+                            )}
+                    >
+                            <slot name="backSideContent"></slot>
+                      </div>`
+                    : html`<img-ui
                               path="${cardBackFullPath(theme)}"
                           ></img-ui>`}
                 </div>

--- a/frontend/elements/src/module/_groups/cards/play/card/styles.ts
+++ b/frontend/elements/src/module/_groups/cards/play/card/styles.ts
@@ -10,6 +10,7 @@ export const cardStyles = [
     css`
         :host {
             --img-padding: 10rem;
+            --border-radius: 16px;
         }
 
         :host([size="matching"]),
@@ -43,7 +44,7 @@ export const cardStyles = [
         }
 
         .content {
-            border-radius: 16px;
+            border-radius: var(--border-radius);
             border-style: solid;
             border-width: var(--border-size);
             background-color: white;

--- a/frontend/elements/src/module/_groups/cards/play/card/styles.ts
+++ b/frontend/elements/src/module/_groups/cards/play/card/styles.ts
@@ -22,6 +22,7 @@ export const cardStyles = [
         :host([size="flashcards"]) {
             --card-size: 500rem;
             --border-size: 16rem;
+            --border-radius: 16%;
         }
 
         :host([size="memory"]) {


### PR DESCRIPTION
https://github.com/ji-devs/ji-cloud/issues/3230

## What?
Increases the border radius of the frontside of the flipped card

## Added
- selected element `.front.content`, and initialized `border-radius: 56px` for attributes `side="left"` and `size="flashcards`
- assigned variable `--border-radius: 16px` in `:host` to `border-radius` in `.content` element