### PR TITLE
fix(fe/instructions): Drop instructions audio when popup is closed

### DIFF
--- a/frontend/apps/crates/entry/asset/play/src/jig/actions.rs
+++ b/frontend/apps/crates/entry/asset/play/src/jig/actions.rs
@@ -175,6 +175,9 @@ pub fn show_instructions(state: Rc<JigPlayer>, visible: bool) {
         if visible {
             play_instructions_audio(state);
         } else {
+            // Always drop the audio handle whenever the popup is hidden
+            *state.instructions_audio_handle.borrow_mut() = None;
+
             if instructions.instructions_type.is_feedback() {
                 // Clear the instructions to prevent any audio possibly playing again.
                 set_instructions(state.clone(), None);


### PR DESCRIPTION
Fix regression caused by #3372 which removed the code to drop the audio handle whenever the popup closes.