### PR TITLE
fix(fe/instructions): increase gap between instruction and audio/upload texts

### DIFF
--- a/frontend/apps/crates/components/src/instructions/editor/dom.rs
+++ b/frontend/apps/crates/components/src/instructions/editor/dom.rs
@@ -18,7 +18,7 @@ pub fn render(state: Rc<State>) -> Dom {
     html!("div", {
         .style("display", "grid")
         .style("grid-template-rows", "auto auto")
-        .style("row-gap", "16px")
+        .style("row-gap", "20px")
 
         .children(&mut [
             render_text(state.clone()),

--- a/frontend/apps/crates/components/src/instructions/editor/dom.rs
+++ b/frontend/apps/crates/components/src/instructions/editor/dom.rs
@@ -16,6 +16,10 @@ const MAX_INSTRUCTION_TEXT_LEN: usize = 250;
 
 pub fn render(state: Rc<State>) -> Dom {
     html!("div", {
+        .style("display", "grid")
+        .style("grid-template-rows", "auto auto")
+        .style("row-gap", "16px")
+
         .children(&mut [
             render_text(state.clone()),
             render_audio(state)

--- a/frontend/elements/src/module/_common/edit/widgets/audio-input/audio-input.ts
+++ b/frontend/elements/src/module/_common/edit/widgets/audio-input/audio-input.ts
@@ -9,7 +9,7 @@ export class _ extends LitElement {
             css`
                 :host {
                     display: grid;
-                    row-gap: 20px;
+                    row-gap: 10px;
                     grid-template-rows: 24px 220px auto;
                 }
                 @media (min-width: 1920px) {

--- a/frontend/elements/src/module/_common/edit/widgets/audio-input/audio-input.ts
+++ b/frontend/elements/src/module/_common/edit/widgets/audio-input/audio-input.ts
@@ -9,7 +9,7 @@ export class _ extends LitElement {
             css`
                 :host {
                     display: grid;
-                    row-gap: 10px;
+                    row-gap: 4px;
                     grid-template-rows: 24px 220px auto;
                 }
                 @media (min-width: 1920px) {


### PR DESCRIPTION
https://github.com/ji-devs/ji-cloud/issues/3113

## Added 
- `div` has a styled grid
-  `row-gap` for `div` was increased to `16px`