### PR TITLE
fix(fe/post_preview): add word activity to message

### DIFF
--- a/frontend/elements/src/module/_common/edit/post-preview/post-preview.ts
+++ b/frontend/elements/src/module/_common/edit/post-preview/post-preview.ts
@@ -10,7 +10,7 @@ const STR_USE_IN_PREFIX = "Use the content from this";
 const STR_USE_IN_SUFFIX = "activity in:";
 
 const STR_HEADER_LINE_1_PREFIX = "Your";
-const STR_HEADER_LINE_1_SUFFIX = "is ready!";
+const STR_HEADER_LINE_1_SUFFIX = "activity is ready!";
 const STR_HEADER_LINE_2 = "It’s now part of your JIG.";
 
 @customElement("post-preview")


### PR DESCRIPTION
resolves https://github.com/ji-devs/ji-cloud/issues/3394

## What 
1. All activity "done" pages have "activity" included in the "Your [activity] is ready!" message

## Added
1. In `post-preview.ts`, "activity" was prepended onto the existing `STR_HEADER_LINE_1_SUFFIX` value