### PR TITLE
style(fe/edit/post-preview): reformat and remove headers on post preview page

### DIFF
--- a/frontend/elements/src/module/_common/edit/post-preview/post-preview-action.ts
+++ b/frontend/elements/src/module/_common/edit/post-preview/post-preview-action.ts
@@ -27,7 +27,7 @@ export class _ extends LitElement {
                 }
                 .circle {
                     height: 116px;
-                    width: 140px;
+                    width: 130px;
                     border-radius: 50%;
                     transition: background-color 0.3s;
                     display: grid;
@@ -44,9 +44,9 @@ export class _ extends LitElement {
                 .label {
                     text-align: center;
                     transition: color 0.3s;
-                    line-height: 1.5;
+                    line-height: 1.2;
                     font-weight: 600;
-                    width: 140px;
+                    width: 130px;
                     font-size: 16px;
                 }
                 :host(:hover) .label {

--- a/frontend/elements/src/module/_common/edit/post-preview/post-preview-action.ts
+++ b/frontend/elements/src/module/_common/edit/post-preview/post-preview-action.ts
@@ -27,7 +27,7 @@ export class _ extends LitElement {
                 }
                 .circle {
                     height: 116px;
-                    width: 116px;
+                    width: 140px;
                     border-radius: 50%;
                     transition: background-color 0.3s;
                     display: grid;
@@ -46,7 +46,7 @@ export class _ extends LitElement {
                     transition: color 0.3s;
                     line-height: 1.5;
                     font-weight: 600;
-                    width: 116px;
+                    width: 140px;
                     font-size: 16px;
                 }
                 :host(:hover) .label {

--- a/frontend/elements/src/module/_common/edit/post-preview/post-preview.ts
+++ b/frontend/elements/src/module/_common/edit/post-preview/post-preview.ts
@@ -37,7 +37,7 @@ export class _ extends LitElement {
                 .message {
                     text-align: center;
                     line-height: 1.18;
-                    font-size: 24px;
+                    font-size: 22px;
                     font-weight: 500;
                     color: #fd7076;
                     margin: 0;
@@ -53,9 +53,13 @@ export class _ extends LitElement {
                     display: flex;
                     flex-direction: column;
                     justify-content: center;
-                    grid-gap: 48px;
+                    grid-gap: 15px;
                 }
-
+                .bottom-section .actions .middle-plane {
+                    background-color: var(--light-orange-1);
+                    height: 220px;
+                    padding-bottom: 12px;
+                }
                 .bottom-section .actions > div {
                     display: grid;
                     grid-template-columns: repeat(auto-fit, 116px);
@@ -71,14 +75,13 @@ export class _ extends LitElement {
                 .bottom-section-centered {
                     background-color: var(--white);
                     display: grid;
-                    grid-gap: 16px;
                     justify-content: center;
                     align-items: center;
-                    padding: 46px 0;
+                    padding: 50px 0;
                 }
                 .action-header {
                     color: #fd7076;
-                    font-size: 32px;
+                    font-size: 22px;
                     grid-column: 1 / -1;
                     text-align: center;
                     margin: 0;
@@ -89,8 +92,8 @@ export class _ extends LitElement {
                     grid-column: 1 / span 3;
                     text-align: center;
                     color: #4a4a4a;
-                    margin: 0;
-                    margin-bottom: 12px;
+                    margin: auto;
+                    margin-bottom: 10px;
                     font-weight: 500;
                 }
                 .bottom-section .actions ::slotted([slot="module-1"]) {
@@ -154,9 +157,9 @@ function renderNonConvertable(module: ModuleKind) {
             ${renderMessage(module)}
             <h3 class="action-header">${STR_ACTION_HEADER}</h3>
             <div class="actions">
+                <slot class="action-continue" name="action-continue"></slot>
                 <slot class="action-print" name="action-print"></slot>
                 <slot class="action-publish" name="action-publish"></slot>
-                <slot class="action-continue" name="action-continue"></slot>
             </div>
         </div>
     `;
@@ -167,7 +170,7 @@ function renderConvertable(module: ModuleKind) {
             ${renderMessage(module)}
             <h3 class="action-header">${STR_ACTION_HEADER}</h3>
             <div class="actions">
-                <div>
+                <div class= "middle-plane">
                     <h4 class="action-use-in-header">
                         ${STR_USE_IN}
                     </h4>

--- a/frontend/elements/src/module/_common/edit/post-preview/post-preview.ts
+++ b/frontend/elements/src/module/_common/edit/post-preview/post-preview.ts
@@ -6,12 +6,10 @@ import {
 } from "@elements/module/_common/types";
 
 const STR_ACTION_HEADER = "What do you want to do next?";
-const STR_USE_IN_PREFIX = "Use the content from this";
-const STR_USE_IN_SUFFIX = "activity in:";
+const STR_USE_IN= "Use this content in:";
 
 const STR_HEADER_LINE_1_PREFIX = "Your";
 const STR_HEADER_LINE_1_SUFFIX = "activity is ready!";
-const STR_HEADER_LINE_2 = "It’s now part of your JIG.";
 
 @customElement("post-preview")
 export class _ extends LitElement {
@@ -85,7 +83,7 @@ export class _ extends LitElement {
                     grid-column: 1 / -1;
                     text-align: center;
                     margin: 0;
-                    margin-bottom: 24px;
+                    margin-bottom: 30px;
                     font-weight: 900;
                 }
                 .action-use-in-header {
@@ -147,8 +145,6 @@ function renderMessage(module: ModuleKind) {
             ${STR_HEADER_LINE_1_PREFIX}
             ${STR_MODULE_DISPLAY_NAME[module]}
             ${STR_HEADER_LINE_1_SUFFIX}
-            <br />
-            ${STR_HEADER_LINE_2}
         </div>
     `;
 }
@@ -173,18 +169,17 @@ function renderConvertable(module: ModuleKind) {
             <h3 class="action-header">${STR_ACTION_HEADER}</h3>
             <div class="actions">
                 <div>
-                    <slot class="action-print" name="action-print"></slot>
-                    <slot class="action-publish" name="action-publish"></slot>
-                    <slot class="action-continue" name="action-continue"></slot>
-                </div>
-                <div>
                     <h4 class="action-use-in-header">
-                        ${STR_USE_IN_PREFIX} ${STR_MODULE_DISPLAY_NAME[module]}
-                        ${STR_USE_IN_SUFFIX}
+                        ${STR_USE_IN}
                     </h4>
                     <slot class="module-1" name="module-1"></slot>
                     <slot class="module-2" name="module-2"></slot>
                     <slot class="module-3" name="module-3"></slot>
+                </div>
+                <div>
+                    <slot class="action-continue" name="action-continue"></slot>
+                    <slot class="action-print" name="action-print"></slot>
+                    <slot class="action-publish" name="action-publish"></slot>
                 </div>
             </div>
         </div>

--- a/frontend/elements/src/module/_common/edit/post-preview/post-preview.ts
+++ b/frontend/elements/src/module/_common/edit/post-preview/post-preview.ts
@@ -45,10 +45,9 @@ export class _ extends LitElement {
                 .bottom-section {
                     background-color: var(--white);
                     display: grid;
-                    grid-gap: 16px;
                     align-items: center;
                     align-content: center;
-                    padding: 30px 0;
+                    padding: 40px 0;
                 }
                 .bottom-section .actions {
                     display: flex;


### PR DESCRIPTION
https://github.com/ji-devs/ji-cloud/issues/3326

## Changes 
- changed the order of actions
- apply orange background
- adjust grid box dimensions
- decrease font size of top headers
- removed "Its now a part of your JIG"
- make text shorter: "Use this content in:"
- make activity texts single-line
- decrease line height for text, "Add new activity"

<img width="500" alt="Screenshot 2022-12-06 at 3 22 56 PM" src="https://user-images.githubusercontent.com/76449893/206046728-b122121a-9057-49b3-a4f7-e09e70ca1f49.png">

<img width="500" alt="Screenshot 2022-12-06 at 3 23 47 PM" src="https://user-images.githubusercontent.com/76449893/206046798-759f2a40-897d-4429-99c0-a7309c6a0ad5.png">


