### PR TITLE
fix(fe/play/cards): resize oversized images in flashcards

### DIFF
--- a/frontend/elements/src/module/_groups/cards/play/card/styles.ts
+++ b/frontend/elements/src/module/_groups/cards/play/card/styles.ts
@@ -57,6 +57,7 @@ export const cardStyles = [
             display: flex;
             justify-content: center;
             align-items: center;
+            overflow: hidden;
         }
     `,
 ];


### PR DESCRIPTION
resolves https://github.com/ji-devs/ji-cloud/issues/3397

## Added
- `overflow` property, set to `hidden` to clip borders of oversized images