### PR TITLE
feat(fe/flashcards): Make view pairs setting dynamic so it's capped at current amount of pairs

### DIFF
--- a/frontend/apps/crates/entry/module/flashcards/edit/src/settings/sidebar/dom.rs
+++ b/frontend/apps/crates/entry/module/flashcards/edit/src/settings/sidebar/dom.rs
@@ -1,5 +1,5 @@
-use dominator::{clone, Dom};
-use futures_signals::signal::SignalExt;
+use dominator::{clone, html, Dom};
+use futures_signals::{signal::SignalExt, signal_vec::SignalVecExt};
 use std::rc::Rc;
 
 use super::state::*;
@@ -8,61 +8,73 @@ use components::module::_common::edit::settings::prelude::*;
 use shared::domain::module::body::flashcards::DisplayMode;
 
 pub fn render(state: Rc<SidebarSettings>) -> Dom {
-    render_settings(Rc::new(ModuleSettings {
-        lines: vec![
-            ModuleSettingsLine::new_with_label(
-                "How should card pairs be displayed?".to_string(),
-                vec![
-                    Some(make_display_mode_button(state.clone(), DisplayMode::Double)),
-                    Some(make_display_mode_button(state.clone(), DisplayMode::Single)),
-                ],
-            ),
-            ModuleSettingsLine::new_with_label(
-                "Which card should be face-up?".to_string(),
-                vec![Some(SettingsButton::new_click(
-                    SettingsButtonKind::custom_kind(SettingsButtonKind::Swap, "swap"),
-                    clone!(state => move || {
-                        state.base.extra.settings.swap.signal()
-                    }),
-                    clone!(state => move || {
-                        state.toggle_swap();
-                    }),
-                ))],
-            ),
-            ModuleSettingsLine::new_with_label(
-                "Should student view all pairs?".to_string(),
-                vec![
-                    Some(SettingsButton::new_click(
-                        SettingsButtonKind::CardsShowAll,
-                        clone!(state => move || {
-                            state.base.extra.settings.view_all
-                                .signal()
-                        }),
-                        clone!(state => move || {
-                            state.set_view_all(true);
-                        }),
-                    )),
-                    Some(SettingsButton::new_value_click(
-                        SettingsButtonKind::CardsShowSome,
-                        clone!(state => move || {
-                            state.base.extra.settings.view_all
-                                .signal()
-                                .map(|view_all| !view_all)
-                        }),
-                        SettingsValue::new_mutable(
-                            state.base.extra.settings.view_pairs.clone(),
-                            clone!(state => move |value| {
-                                state.set_view_pairs(value);
+    html!("empty-fragment", {
+        .future(state.base.pairs.signal_vec_cloned().to_signal_cloned().for_each(clone!(state => move |pairs| {
+            let view_pairs = state.base.extra.settings.view_pairs.get_cloned();
+
+            if view_pairs > pairs.len() as u32 {
+                state.set_view_pairs(pairs.len() as u32);
+            }
+            async {}
+        })))
+        .child(
+            render_settings(Rc::new(ModuleSettings {
+                lines: vec![
+                    ModuleSettingsLine::new_with_label(
+                        "How should card pairs be displayed?".to_string(),
+                        vec![
+                            Some(make_display_mode_button(state.clone(), DisplayMode::Double)),
+                            Some(make_display_mode_button(state.clone(), DisplayMode::Single)),
+                        ],
+                    ),
+                    ModuleSettingsLine::new_with_label(
+                        "Which card should be face-up?".to_string(),
+                        vec![Some(SettingsButton::new_click(
+                            SettingsButtonKind::custom_kind(SettingsButtonKind::Swap, "swap"),
+                            clone!(state => move || {
+                                state.base.extra.settings.swap.signal()
                             }),
-                        ),
-                        clone!(state => move || {
-                            state.set_view_all(false);
-                        }),
-                    )),
+                            clone!(state => move || {
+                                state.toggle_swap();
+                            }),
+                        ))],
+                    ),
+                    ModuleSettingsLine::new_with_label(
+                        "Should student view all pairs?".to_string(),
+                        vec![
+                            Some(SettingsButton::new_click(
+                                SettingsButtonKind::CardsShowAll,
+                                clone!(state => move || {
+                                    state.base.extra.settings.view_all
+                                        .signal()
+                                }),
+                                clone!(state => move || {
+                                    state.set_view_all(true);
+                                }),
+                            )),
+                            Some(SettingsButton::new_value_click(
+                                SettingsButtonKind::CardsShowSome,
+                                clone!(state => move || {
+                                    state.base.extra.settings.view_all
+                                        .signal()
+                                        .map(|view_all| !view_all)
+                                }),
+                                SettingsValue::new_mutable(
+                                    state.base.extra.settings.view_pairs.clone(),
+                                    clone!(state => move |value| {
+                                        state.set_view_pairs(value);
+                                    }),
+                                ),
+                                clone!(state => move || {
+                                    state.set_view_all(false);
+                                }),
+                            )),
+                        ],
+                    ),
                 ],
-            ),
-        ],
-    }))
+            }))
+        )
+    })
 }
 
 pub fn make_display_mode_button(

--- a/frontend/apps/crates/entry/module/flashcards/play/src/base/game/actions.rs
+++ b/frontend/apps/crates/entry/module/flashcards/play/src/base/game/actions.rs
@@ -28,7 +28,9 @@ impl Game {
             .base
             .settings
             .view_pairs
-            .unwrap_or_else(|| self.base.raw_pairs.len() as u32);
+            .unwrap_or_else(|| self.base.raw_pairs.len() as u32)
+            .min(self.base.raw_pairs.len() as u32);
+
         let has_ended = rounds_played >= max_rounds as usize;
 
         log::info!("{:?}", self.base.settings.view_pairs);


### PR DESCRIPTION
Actually part of #3284 - I was working out simplest way to update settings based on content.

- Caps the "view pairs" setting at the total number of cards currently in in the deck;
- Caps the number of rounds at the minimum of view pairs setting or number of cards in deck.