### PR TITLE
chore(fe/settings): Use a builder to construct instances of SettingsButton

### DIFF
--- a/frontend/apps/crates/entry/module/card-quiz/edit/src/settings/sidebar/dom.rs
+++ b/frontend/apps/crates/entry/module/card-quiz/edit/src/settings/sidebar/dom.rs
@@ -12,102 +12,107 @@ pub fn render(state: Rc<SidebarSettings>) -> Dom {
             ModuleSettingsLine::new(
                 LineKind::GameDisplay,
                 vec![
-                    Some(SettingsButton::new_value(
-                        SettingsButtonKind::NumChoices,
-                        || always(true),
-                        SettingsValue::new(
-                            state.settings().n_choices.get(),
-                            clone!(state => move |value| {
-                                state.set_n_choices(value);
+                    Some(
+                        SettingsButtonBuilder::new(SettingsButtonKind::NumChoices, || always(true))
+                            .value(SettingsValue::new(
+                                state.settings().n_choices.get(),
+                                clone!(state => move |value| {
+                                    state.set_n_choices(value);
+                                }),
+                            ))
+                            .build(),
+                    ),
+                    Some(
+                        SettingsButtonBuilder::new(
+                            SettingsButtonKind::Swap,
+                            clone!(state => move || {
+                                state.base.extra.settings.swap.signal()
                             }),
-                        ),
-                    )),
-                    Some(SettingsButton::new_click(
-                        SettingsButtonKind::Swap,
-                        clone!(state => move || {
-                            state.base.extra.settings.swap.signal()
-                        }),
-                        clone!(state => move || {
-                            state.toggle_swap();
-                        }),
-                    )),
+                        )
+                        .on_click(clone!(state => move || state.toggle_swap()))
+                        .build(),
+                    ),
                 ],
             ),
             ModuleSettingsLine::new(
                 LineKind::Rounds,
-                vec![Some(SettingsButton::new_value(
-                    SettingsButtonKind::Rounds,
-                    || always(true),
-                    SettingsValue::new(
-                        state.settings().n_rounds.get(),
-                        clone!(state => move |value| {
-                            state.set_n_rounds(value);
-                        }),
-                    ),
-                ))],
+                vec![Some(
+                    SettingsButtonBuilder::new(SettingsButtonKind::Rounds, || always(true))
+                        .value(SettingsValue::new(
+                            state.settings().n_rounds.get(),
+                            clone!(state => move |value| {
+                                state.set_n_rounds(value);
+                            }),
+                        ))
+                        .build(),
+                )],
             ),
             ModuleSettingsLine::new(
                 LineKind::TimeLimit,
                 vec![
-                    Some(SettingsButton::new_click(
-                        SettingsButtonKind::TimeLimitOff,
-                        clone!(state => move || {
-                            state.base.extra.settings.has_time_limit
-                                .signal()
-                                .map(|flag| !flag)
-                        }),
-                        clone!(state => move || {
-                            state.set_has_time_limit(false);
-                        }),
-                    )),
-                    Some(SettingsButton::new_value_click(
-                        SettingsButtonKind::TimeLimit,
-                        clone!(state => move || {
-                            state.base.extra.settings.has_time_limit
-                                .signal()
-                        }),
-                        SettingsValue::new(
+                    Some(
+                        SettingsButtonBuilder::new(
+                            SettingsButtonKind::TimeLimitOff,
+                            clone!(state => move || {
+                                state.base.extra.settings.has_time_limit
+                                    .signal()
+                                    .map(|flag| !flag)
+                            }),
+                        )
+                        .on_click(clone!(state => move || state.set_has_time_limit(false)))
+                        .build(),
+                    ),
+                    Some(
+                        SettingsButtonBuilder::new(
+                            SettingsButtonKind::TimeLimit,
+                            clone!(state => move || {
+                                state.base.extra.settings.has_time_limit
+                                    .signal()
+                            }),
+                        )
+                        .value(SettingsValue::new(
                             state.settings().time_limit.get(),
                             clone!(state => move |value| {
                                 state.set_time_limit(value);
                             }),
-                        ),
-                        clone!(state => move || {
-                            state.set_has_time_limit(true);
-                        }),
-                    )),
+                        ))
+                        .on_click(clone!(state => move || state.set_has_time_limit(true)))
+                        .build(),
+                    ),
                 ],
             ),
             ModuleSettingsLine::new(
                 LineKind::Attempts,
                 vec![
-                    Some(SettingsButton::new_click(
-                        SettingsButtonKind::NoLimit,
-                        clone!(state => move || {
-                            state.base.extra.settings.has_attempts_limit
-                                .signal()
-                                .map(|flag| !flag)
-                        }),
-                        clone!(state => move || {
-                            state.set_has_attempts_limit(false);
-                        }),
-                    )),
-                    Some(SettingsButton::new_value_click(
-                        SettingsButtonKind::Attempts,
-                        clone!(state => move || {
-                            state.base.extra.settings.has_attempts_limit
-                                .signal()
-                        }),
-                        SettingsValue::new(
+                    Some(
+                        SettingsButtonBuilder::new(
+                            SettingsButtonKind::NoLimit,
+                            clone!(state => move || {
+                                state.base.extra.settings.has_attempts_limit
+                                    .signal()
+                                    .map(|flag| !flag)
+                            }),
+                        )
+                        .on_click(clone!(state => move || state.set_has_attempts_limit(false)))
+                        .build(),
+                    ),
+                    Some(
+                        SettingsButtonBuilder::new(
+                            SettingsButtonKind::Attempts,
+                            clone!(state => move || {
+                                state.base.extra.settings.has_attempts_limit
+                                    .signal()
+                            }),
+                        )
+                        .value(SettingsValue::new(
                             state.settings().attempts_limit.get(),
                             clone!(state => move |value| {
                                 state.set_attempts_limit(value);
                             }),
-                        ),
-                        clone!(state => move || {
-                            state.set_has_attempts_limit(true);
-                        }),
-                    )),
+                        ))
+                        .on_click(clone!(state => move || state.set_has_attempts_limit(true)))
+                        .build(),
+                    ),
                 ],
             ),
             // NOTE - not including score until player/jig story is resolved

--- a/frontend/apps/crates/entry/module/drag-drop/edit/src/base/sidebar/step_4/play_settings/dom.rs
+++ b/frontend/apps/crates/entry/module/drag-drop/edit/src/base/sidebar/step_4/play_settings/dom.rs
@@ -13,87 +13,93 @@ pub fn render(state: Rc<PlaySettingsState>) -> Dom {
             ModuleSettingsLine::new(
                 LineKind::Next,
                 vec![
-                    Some(SettingsButton::new_click(
-                        SettingsButtonKind::ContinueAll,
-                        clone!(state => move || {
-                            state.base.play_settings.next.signal_ref(|curr| {
-                                std::mem::discriminant(curr) == std::mem::discriminant(&Next::PlaceAll)
-                            })
-                        }),
-                        clone!(state => move || {
-                            state.set_next(Next::PlaceAll);
-                        }),
-                    )),
-                    Some(SettingsButton::new_click(
-                        SettingsButtonKind::ContinueClick,
-                        clone!(state => move || {
-                            state.base.play_settings.next.signal_ref(|curr| {
-                                std::mem::discriminant(curr) == std::mem::discriminant(&Next::ClickContinue)
-                            })
-                        }),
-                        clone!(state => move || {
-                            state.set_next(Next::ClickContinue);
-                        }),
-                    )),
+                    Some(
+                        SettingsButtonBuilder::new(
+                            SettingsButtonKind::ContinueAll,
+                            clone!(state => move || {
+                                state.base.play_settings.next.signal_ref(|curr| {
+                                    std::mem::discriminant(curr) == std::mem::discriminant(&Next::PlaceAll)
+                                })
+                            }),
+                        )
+                        .on_click(clone!(state => move || state.set_next(Next::PlaceAll)))
+                        .build()
+                    ),
+                    Some(
+                        SettingsButtonBuilder::new(
+                            SettingsButtonKind::ContinueClick,
+                            clone!(state => move || {
+                                state.base.play_settings.next.signal_ref(|curr| {
+                                    std::mem::discriminant(curr) == std::mem::discriminant(&Next::ClickContinue)
+                                })
+                            }),
+                        )
+                        .on_click(clone!(state => move || state.set_next(Next::ClickContinue)))
+                        .build()
+                    ),
                 ],
             ),
             ModuleSettingsLine::new(
                 LineKind::TimeLimit,
                 vec![
-                    Some(SettingsButton::new_click(
-                        SettingsButtonKind::TimeLimitOff,
-                        clone!(state => move || {
-                            state.base.play_settings.has_time_limit
-                                .signal()
-                                .map(|flag| !flag)
-                        }),
-                        clone!(state => move || {
-                            state.set_has_time_limit(false);
-                        }),
-                    )),
-                    Some(SettingsButton::new_value_click(
-                        SettingsButtonKind::TimeLimit,
-                        clone!(state => move || {
-                            state.base.play_settings.has_time_limit
-                                .signal()
-                        }),
-                        SettingsValue::new(
+                    Some(
+                        SettingsButtonBuilder::new(
+                            SettingsButtonKind::TimeLimitOff,
+                            clone!(state => move || {
+                                state.base.play_settings.has_time_limit
+                                    .signal()
+                                    .map(|flag| !flag)
+                            }),
+                        )
+                        .on_click(clone!(state => move || state.set_has_time_limit(false)))
+                        .build()
+                    ),
+                    Some(
+                        SettingsButtonBuilder::new(
+                            SettingsButtonKind::TimeLimit,
+                            clone!(state => move || {
+                                state.base.play_settings.has_time_limit
+                                    .signal()
+                            }),
+                        )
+                        .value(SettingsValue::new(
                             state.base.play_settings.time_limit.get(),
                             clone!(state => move |value| {
                                 state.set_time_limit(value);
                             }),
-                        ),
-                        clone!(state => move || {
-                            state.set_has_time_limit(true);
-                        }),
-                    )),
+                        ))
+                        .on_click(clone!(state => move || state.set_has_time_limit(true)))
+                        .build()
+                    ),
                 ],
             ),
             ModuleSettingsLine::new(
                 LineKind::Hint,
                 vec![
-                    Some(SettingsButton::new_click(
-                        SettingsButtonKind::HighlightOff,
-                        clone!(state => move || {
-                            state.base.play_settings.hint.signal_ref(|curr| {
-                                *curr == Hint::None
-                            })
-                        }),
-                        clone!(state => move || {
-                            state.set_hint(Hint::None);
-                        }),
-                    )),
-                    Some(SettingsButton::new_click(
-                        SettingsButtonKind::Highlight,
-                        clone!(state => move || {
-                            state.base.play_settings.hint.signal_ref(|curr| {
-                                *curr == Hint::Highlight
-                            })
-                        }),
-                        clone!(state => move || {
-                            state.set_hint(Hint::Highlight);
-                        }),
-                    )),
+                    Some(
+                        SettingsButtonBuilder::new(
+                            SettingsButtonKind::HighlightOff,
+                            clone!(state => move || {
+                                state.base.play_settings.hint.signal_ref(|curr| {
+                                    *curr == Hint::None
+                                })
+                            }),
+                        )
+                        .on_click(clone!(state => move || state.set_hint(Hint::None)))
+                        .build()
+                    ),
+                    Some(
+                        SettingsButtonBuilder::new(
+                            SettingsButtonKind::Highlight,
+                            clone!(state => move || {
+                                state.base.play_settings.hint.signal_ref(|curr| {
+                                    *curr == Hint::Highlight
+                                })
+                            }),
+                        )
+                        .on_click(clone!(state => move || state.set_hint(Hint::Highlight)))
+                        .build()
+                    ),
                 ],
             ),
             // Note - not including scoring until player settings is resolved

--- a/frontend/apps/crates/entry/module/find-answer/edit/src/base/sidebar/step_4/play_settings/dom.rs
+++ b/frontend/apps/crates/entry/module/find-answer/edit/src/base/sidebar/step_4/play_settings/dom.rs
@@ -11,28 +11,30 @@ pub fn render(state: Rc<State>) -> Dom {
             ModuleSettingsLine::new(
                 LineKind::Ordering,
                 vec![
-                    Some(SettingsButton::new_click(
-                        SettingsButtonKind::Randomize,
-                        clone!(state => move || {
-                            state.base.play_settings.ordering.signal_ref(|curr| {
-                                *curr == Ordering::Randomize
-                            })
-                        }),
-                        clone!(state => move || {
-                            state.set_ordering(Ordering::Randomize);
-                        }),
-                    )),
-                    Some(SettingsButton::new_click(
-                        SettingsButtonKind::Order,
-                        clone!(state => move || {
-                            state.base.play_settings.ordering.signal_ref(|curr| {
-                                *curr == Ordering::InOrder
-                            })
-                        }),
-                        clone!(state => move || {
-                            state.set_ordering(Ordering::InOrder);
-                        }),
-                    )),
+                    Some(
+                        SettingsButtonBuilder::new(
+                            SettingsButtonKind::Randomize,
+                            clone!(state => move || {
+                                state.base.play_settings.ordering.signal_ref(|curr| {
+                                    *curr == Ordering::Randomize
+                                })
+                            }),
+                        )
+                        .on_click(clone!(state => move || state.set_ordering(Ordering::Randomize)))
+                        .build()
+                    ),
+                    Some(
+                        SettingsButtonBuilder::new(
+                            SettingsButtonKind::Order,
+                            clone!(state => move || {
+                                state.base.play_settings.ordering.signal_ref(|curr| {
+                                    *curr == Ordering::InOrder
+                                })
+                            }),
+                        )
+                        .on_click(clone!(state => move || state.set_ordering(Ordering::InOrder)))
+                        .build()
+                    ),
                 ],
             ),
             // (
@@ -67,75 +69,80 @@ pub fn render(state: Rc<State>) -> Dom {
             ModuleSettingsLine::new(
                 LineKind::TimeLimit,
                 vec![
-                    Some(SettingsButton::new_click(
-                        SettingsButtonKind::TimeLimitOff,
-                        clone!(state => move || {
-                            state.base.play_settings.has_time_limit.signal_ref(|flag| !flag)
-                        }),
-                        clone!(state => move || {
-                            state.set_has_time_limit(false);
-                        }),
-                    )),
-                    Some(SettingsButton::new_value_click(
-                        SettingsButtonKind::TimeLimit,
-                        clone!(state => move || {
-                            state.base.play_settings.has_time_limit
-                                .signal()
-                        }),
-                        SettingsValue::new(
+                    Some(
+                        SettingsButtonBuilder::new(
+                            SettingsButtonKind::TimeLimitOff,
+                            clone!(state => move || {
+                                state.base.play_settings.has_time_limit.signal_ref(|flag| !flag)
+                            }),
+                        )
+                        .on_click(clone!(state => move || state.set_has_time_limit(false)))
+                        .build()
+                    ),
+                    Some(
+                        SettingsButtonBuilder::new(
+                            SettingsButtonKind::TimeLimit,
+                            clone!(state => move || {
+                                state.base.play_settings.has_time_limit
+                                    .signal()
+                            }),
+                        )
+                        .value(SettingsValue::new(
                             state.base.play_settings.time_limit.get(),
                             clone!(state => move |value| {
                                 state.set_time_limit(value);
                             }),
-                        ),
-                        clone!(state => move || {
-                            state.set_has_time_limit(true);
-                        }),
-                    )),
+                        ))
+                        .on_click(clone!(state => move || state.set_has_time_limit(true)))
+                        .build()
+                    ),
                 ],
             ),
             ModuleSettingsLine::new(
                 LineKind::Next,
                 vec![
-                    Some(SettingsButton::new_click(
-                        SettingsButtonKind::ContinueClick,
-                        clone!(state => move || {
-                            state.base.play_settings.next.signal_ref(|curr| {
-                                std::mem::discriminant(curr) == std::mem::discriminant(&Next::Continue)
-                            })
-                        }),
-                        clone!(state => move || {
-                            state.set_next(Next::Continue);
-                        }),
-                    )),
-                    Some(SettingsButton::new_click(
-                        SettingsButtonKind::ContinueAll,
-                        clone!(state => move || {
-                            state.base.play_settings.next.signal_ref(|curr| {
-                                std::mem::discriminant(curr) == std::mem::discriminant(&Next::SelectAll)
-                            })
-                        }),
-                        clone!(state => move || {
-                            state.set_next(Next::SelectAll);
-                        }),
-                    )),
-                    Some(SettingsButton::new_value_click(
-                        SettingsButtonKind::ContinueSome,
-                        clone!(state => move || {
-                            state.base.play_settings.next.signal_ref(|curr| {
-                                std::mem::discriminant(curr) == std::mem::discriminant(&Next::SelectSome(0))
-                            })
-                        }),
-                        SettingsValue::new(
+                    Some(
+                        SettingsButtonBuilder::new(
+                            SettingsButtonKind::ContinueClick,
+                            clone!(state => move || {
+                                state.base.play_settings.next.signal_ref(|curr| {
+                                    std::mem::discriminant(curr) == std::mem::discriminant(&Next::Continue)
+                                })
+                            }),
+                        )
+                        .on_click(clone!(state => move || state.set_next(Next::Continue)))
+                        .build()
+                    ),
+                    Some(
+                        SettingsButtonBuilder::new(
+                            SettingsButtonKind::ContinueAll,
+                            clone!(state => move || {
+                                state.base.play_settings.next.signal_ref(|curr| {
+                                    std::mem::discriminant(curr) == std::mem::discriminant(&Next::SelectAll)
+                                })
+                            }),
+                        )
+                        .on_click(clone!(state => move || state.set_next(Next::SelectAll)))
+                        .build()
+                    ),
+                    Some(
+                        SettingsButtonBuilder::new(
+                            SettingsButtonKind::ContinueSome,
+                            clone!(state => move || {
+                                state.base.play_settings.next.signal_ref(|curr| {
+                                    std::mem::discriminant(curr) == std::mem::discriminant(&Next::SelectSome(0))
+                                })
+                            }),
+                        )
+                        .value(SettingsValue::new(
                             state.base.play_settings.next_value.get(),
                             clone!(state => move |value| {
                                 state.set_next_value(value);
                             }),
-                        ),
-                        clone!(state => move || {
-                            state.set_next_some();
-                        }),
-                    )),
+                        ))
+                        .on_click(clone!(state => move || state.set_next_some()))
+                        .build()
+                    ),
                 ],
             ),
         ],

--- a/frontend/apps/crates/entry/module/flashcards/edit/src/settings/sidebar/dom.rs
+++ b/frontend/apps/crates/entry/module/flashcards/edit/src/settings/sidebar/dom.rs
@@ -29,46 +29,45 @@ pub fn render(state: Rc<SidebarSettings>) -> Dom {
                     ),
                     ModuleSettingsLine::new_with_label(
                         "Which card should be face-up?".to_string(),
-                        vec![Some(SettingsButton::new_click(
-                            SettingsButtonKind::custom_kind(SettingsButtonKind::Swap, "swap"),
-                            clone!(state => move || {
-                                state.base.extra.settings.swap.signal()
-                            }),
-                            clone!(state => move || {
-                                state.toggle_swap();
-                            }),
-                        ))],
+                        vec![
+                            Some(SettingsButtonBuilder::new(
+                                    SettingsButtonKind::custom_kind(SettingsButtonKind::Swap, "swap"),
+                                    clone!(state => move || {
+                                        state.base.extra.settings.swap.signal()
+                                    }),
+                                )
+                                .on_click(clone!(state => move || state.toggle_swap()))
+                                .build())
+                        ],
                     ),
                     ModuleSettingsLine::new_with_label(
                         "Should student view all pairs?".to_string(),
                         vec![
-                            Some(SettingsButton::new_click(
-                                SettingsButtonKind::CardsShowAll,
-                                clone!(state => move || {
-                                    state.base.extra.settings.view_all
-                                        .signal()
-                                }),
-                                clone!(state => move || {
-                                    state.set_view_all(true);
-                                }),
-                            )),
-                            Some(SettingsButton::new_value_click(
-                                SettingsButtonKind::CardsShowSome,
-                                clone!(state => move || {
-                                    state.base.extra.settings.view_all
-                                        .signal()
-                                        .map(|view_all| !view_all)
-                                }),
-                                SettingsValue::new_mutable(
+                            Some(SettingsButtonBuilder::new(
+                                    SettingsButtonKind::CardsShowAll,
+                                    clone!(state => move || {
+                                        state.base.extra.settings.view_all
+                                            .signal()
+                                    }),
+                                )
+                                .on_click(clone!(state => move || state.set_view_all(true)))
+                                .build()),
+                            Some(SettingsButtonBuilder::new(
+                                    SettingsButtonKind::CardsShowSome,
+                                    clone!(state => move || {
+                                        state.base.extra.settings.view_all
+                                            .signal()
+                                            .map(|view_all| !view_all)
+                                    }),
+                                )
+                                .value(SettingsValue::new_mutable(
                                     state.base.extra.settings.view_pairs.clone(),
                                     clone!(state => move |value| {
                                         state.set_view_pairs(value);
                                     }),
-                                ),
-                                clone!(state => move || {
-                                    state.set_view_all(false);
-                                }),
-                            )),
+                                ))
+                                .on_click(clone!(state => move || state.set_view_all(false)))
+                                .build()),
                         ],
                     ),
                 ],
@@ -81,7 +80,7 @@ pub fn make_display_mode_button(
     state: Rc<SidebarSettings>,
     display_mode: DisplayMode,
 ) -> Rc<SettingsButton> {
-    SettingsButton::new_click(
+    SettingsButtonBuilder::new(
         if display_mode == DisplayMode::Single {
             SettingsButtonKind::CardSingle
         } else {
@@ -92,8 +91,7 @@ pub fn make_display_mode_button(
                 *curr == display_mode
             })
         }),
-        clone!(state => move || {
-            state.set_display_mode(display_mode);
-        }),
     )
+    .on_click(clone!(state => move || state.set_display_mode(display_mode)))
+    .build()
 }

--- a/frontend/apps/crates/entry/module/matching/edit/src/settings/sidebar/dom.rs
+++ b/frontend/apps/crates/entry/module/matching/edit/src/settings/sidebar/dom.rs
@@ -12,70 +12,73 @@ pub fn render(state: Rc<SidebarSettings>) -> Dom {
             ModuleSettingsLine::new(
                 LineKind::GameDisplay,
                 vec![
-                    Some(SettingsButton::new_value(
-                        SettingsButtonKind::NumChoices,
-                        || always(true),
-                        SettingsValue::new(
-                            state.settings().n_choices.get(),
-                            clone!(state => move |value| {
-                                state.set_n_choices(value);
+                    Some(
+                        SettingsButtonBuilder::new(SettingsButtonKind::NumChoices, || always(true))
+                            .value(SettingsValue::new(
+                                state.settings().n_choices.get(),
+                                clone!(state => move |value| {
+                                    state.set_n_choices(value);
+                                }),
+                            ))
+                            .build(),
+                    ),
+                    Some(
+                        SettingsButtonBuilder::new(
+                            SettingsButtonKind::Swap,
+                            clone!(state => move || {
+                                state.base.extra.settings.swap.signal()
                             }),
-                        ),
-                    )),
-                    Some(SettingsButton::new_click(
-                        SettingsButtonKind::Swap,
-                        clone!(state => move || {
-                            state.base.extra.settings.swap.signal()
-                        }),
-                        clone!(state => move || {
-                            state.toggle_swap();
-                        }),
-                    )),
+                        )
+                        .on_click(clone!(state => move || state.toggle_swap()))
+                        .build(),
+                    ),
                 ],
             ),
             ModuleSettingsLine::new(
                 LineKind::Rounds,
-                vec![Some(SettingsButton::new_value(
-                    SettingsButtonKind::Rounds,
-                    || always(true),
-                    SettingsValue::new(
-                        state.settings().n_rounds.get(),
-                        clone!(state => move |value| {
-                            state.set_n_rounds(value);
-                        }),
-                    ),
-                ))],
+                vec![Some(
+                    SettingsButtonBuilder::new(SettingsButtonKind::Rounds, || always(true))
+                        .value(SettingsValue::new(
+                            state.settings().n_rounds.get(),
+                            clone!(state => move |value| {
+                                state.set_n_rounds(value);
+                            }),
+                        ))
+                        .build(),
+                )],
             ),
             ModuleSettingsLine::new(
                 LineKind::TimeLimit,
                 vec![
-                    Some(SettingsButton::new_click(
-                        SettingsButtonKind::TimeLimitOff,
-                        clone!(state => move || {
-                            state.base.extra.settings.has_time_limit
-                                .signal()
-                                .map(|flag| !flag)
-                        }),
-                        clone!(state => move || {
-                            state.set_has_time_limit(false);
-                        }),
-                    )),
-                    Some(SettingsButton::new_value_click(
-                        SettingsButtonKind::TimeLimit,
-                        clone!(state => move || {
-                            state.base.extra.settings.has_time_limit
-                                .signal()
-                        }),
-                        SettingsValue::new(
+                    Some(
+                        SettingsButtonBuilder::new(
+                            SettingsButtonKind::TimeLimitOff,
+                            clone!(state => move || {
+                                state.base.extra.settings.has_time_limit
+                                    .signal()
+                                    .map(|flag| !flag)
+                            }),
+                        )
+                        .on_click(clone!(state => move || state.set_has_time_limit(false)))
+                        .build(),
+                    ),
+                    Some(
+                        SettingsButtonBuilder::new(
+                            SettingsButtonKind::TimeLimit,
+                            clone!(state => move || {
+                                state.base.extra.settings.has_time_limit
+                                    .signal()
+                            }),
+                        )
+                        .value(SettingsValue::new(
                             state.settings().time_limit.get(),
                             clone!(state => move |value| {
                                 state.set_time_limit(value);
                             }),
-                        ),
-                        clone!(state => move || {
-                            state.set_has_time_limit(true);
-                        }),
-                    )),
+                        ))
+                        .on_click(clone!(state => move || state.set_has_time_limit(true)))
+                        .build(),
+                    ),
                 ],
             ),
             // NOTE - not including score until player/jig story is resolved

--- a/frontend/apps/crates/entry/module/memory/edit/src/settings/sidebar/dom.rs
+++ b/frontend/apps/crates/entry/module/memory/edit/src/settings/sidebar/dom.rs
@@ -14,52 +14,55 @@ pub fn render(state: Rc<SidebarSettings>) -> Dom {
         lines: vec![
             ModuleSettingsLine::new(
                 LineKind::GameDisplay,
-                vec![Some(SettingsButton::new_value_click(
-                    SettingsButtonKind::NumPairs,
-                    clone!(state => move || {
-                        state.base.extra.settings.use_default_pairs.signal().map(|v| !v)
-                    }),
-                    SettingsValue::new_mutable(
+                vec![Some(
+                    SettingsButtonBuilder::new(
+                        SettingsButtonKind::NumPairs,
+                        clone!(state => move || {
+                            state.base.extra.settings.use_default_pairs.signal().map(|v| !v)
+                        }),
+                    )
+                    .value(SettingsValue::new_mutable(
                         state.settings().pairs_to_display.clone(),
                         clone!(state => move |value| {
                             state.set_pairs_to_display(value);
                         }),
-                    ),
-                    clone!(state => move || {
-                        state.toggle_use_default_pairs();
-                    }),
-                ))],
+                    ))
+                    .on_click(clone!(state => move || state.toggle_use_default_pairs()))
+                    .build(),
+                )],
             ),
             ModuleSettingsLine::new(
                 LineKind::TimeLimit,
                 vec![
-                    Some(SettingsButton::new_click(
-                        SettingsButtonKind::TimeLimitOff,
-                        clone!(state => move || {
-                            state.base.extra.settings.has_time_limit
-                                .signal()
-                                .map(|flag| !flag)
-                        }),
-                        clone!(state => move || {
-                            state.set_has_time_limit(false);
-                        }),
-                    )),
-                    Some(SettingsButton::new_value_click(
-                        SettingsButtonKind::TimeLimit,
-                        clone!(state => move || {
-                            state.base.extra.settings.has_time_limit
-                                .signal()
-                        }),
-                        SettingsValue::new(
+                    Some(
+                        SettingsButtonBuilder::new(
+                            SettingsButtonKind::TimeLimitOff,
+                            clone!(state => move || {
+                                state.base.extra.settings.has_time_limit
+                                    .signal()
+                                    .map(|flag| !flag)
+                            }),
+                        )
+                        .on_click(clone!(state => move || state.set_has_time_limit(false)))
+                        .build(),
+                    ),
+                    Some(
+                        SettingsButtonBuilder::new(
+                            SettingsButtonKind::TimeLimit,
+                            clone!(state => move || {
+                                state.base.extra.settings.has_time_limit
+                                    .signal()
+                            }),
+                        )
+                        .value(SettingsValue::new(
                             state.settings().time_limit.get(),
                             clone!(state => move |value| {
                                 state.set_time_limit(value);
                             }),
-                        ),
-                        clone!(state => move || {
-                            state.set_has_time_limit(true);
-                        }),
-                    )),
+                        ))
+                        .on_click(clone!(state => move || state.set_has_time_limit(true)))
+                        .build(),
+                    ),
                 ],
             ),
             // NOTE - not including score until player/jig story is resolved

--- a/frontend/apps/crates/entry/module/tapping-board/edit/src/base/sidebar/step_4/play_settings/dom.rs
+++ b/frontend/apps/crates/entry/module/tapping-board/edit/src/base/sidebar/step_4/play_settings/dom.rs
@@ -11,178 +11,79 @@ pub fn render(state: Rc<State>) -> Dom {
             ModuleSettingsLine::new(
                 LineKind::Hint,
                 vec![
-                    Some(SettingsButton::new_click(
-                        SettingsButtonKind::HighlightOff,
-                        clone!(state => move || {
-                            state.base.play_settings.hint.signal_ref(|curr| {
-                                *curr == Hint::None
-                            })
-                        }),
-                        clone!(state => move || {
-                            state.set_hint(Hint::None);
-                        }),
-                    )),
-                    Some(SettingsButton::new_click(
-                        SettingsButtonKind::Highlight,
-                        clone!(state => move || {
-                            state.base.play_settings.hint.signal_ref(|curr| {
-                                *curr == Hint::Highlight
-                            })
-                        }),
-                        clone!(state => move || {
-                            state.set_hint(Hint::Highlight);
-                        }),
-                    )),
+                    Some(
+                        SettingsButtonBuilder::new(
+                            SettingsButtonKind::HighlightOff,
+                            clone!(state => move || {
+                                state.base.play_settings.hint.signal_ref(|curr| {
+                                    *curr == Hint::None
+                                })
+                            }),
+                        )
+                        .on_click(clone!(state => move || state.set_hint(Hint::None)))
+                        .build()
+                    ),
+                    Some(
+                        SettingsButtonBuilder::new(
+                            SettingsButtonKind::Highlight,
+                            clone!(state => move || {
+                                state.base.play_settings.hint.signal_ref(|curr| {
+                                    *curr == Hint::Highlight
+                                })
+                            }),
+                        )
+                        .on_click(clone!(state => move || state.set_hint(Hint::Highlight)))
+                        .build()
+                    ),
                 ],
             ),
             ModuleSettingsLine::new(
                 LineKind::Next,
                 vec![
-                    Some(SettingsButton::new_click(
-                        SettingsButtonKind::ContinueClick,
-                        clone!(state => move || {
-                            state.base.play_settings.next.signal_ref(|curr| {
-                                std::mem::discriminant(curr) == std::mem::discriminant(&Next::Continue)
-                            })
-                        }),
-                        clone!(state => move || {
-                            state.set_next(Next::Continue);
-                        }),
-                    )),
-                    Some(SettingsButton::new_click(
-                        SettingsButtonKind::ContinueAll,
-                        clone!(state => move || {
-                            state.base.play_settings.next.signal_ref(|curr| {
-                                std::mem::discriminant(curr) == std::mem::discriminant(&Next::SelectAll)
-                            })
-                        }),
-                        clone!(state => move || {
-                            state.set_next(Next::SelectAll);
-                        }),
-                    )),
-                    Some(SettingsButton::new_value_click(
-                        SettingsButtonKind::ContinueSome,
-                        clone!(state => move || {
-                            state.base.play_settings.next.signal_ref(|curr| {
-                                std::mem::discriminant(curr) == std::mem::discriminant(&Next::SelectSome(0))
-                            })
-                        }),
-                        SettingsValue::new(
+                    Some(
+                        SettingsButtonBuilder::new(
+                            SettingsButtonKind::ContinueClick,
+                            clone!(state => move || {
+                                state.base.play_settings.next.signal_ref(|curr| {
+                                    std::mem::discriminant(curr) == std::mem::discriminant(&Next::Continue)
+                                })
+                            }),
+                        )
+                        .on_click(clone!(state => move || state.set_next(Next::Continue)))
+                        .build()
+                    ),
+                    Some(
+                        SettingsButtonBuilder::new(
+                            SettingsButtonKind::ContinueAll,
+                            clone!(state => move || {
+                                state.base.play_settings.next.signal_ref(|curr| {
+                                    std::mem::discriminant(curr) == std::mem::discriminant(&Next::SelectAll)
+                                })
+                            }),
+                        )
+                        .on_click(clone!(state => move || state.set_next(Next::SelectAll)))
+                        .build()
+                    ),
+                    Some(
+                        SettingsButtonBuilder::new(
+                            SettingsButtonKind::ContinueSome,
+                            clone!(state => move || {
+                                state.base.play_settings.next.signal_ref(|curr| {
+                                    std::mem::discriminant(curr) == std::mem::discriminant(&Next::SelectSome(0))
+                                })
+                            }),
+                        )
+                        .value(SettingsValue::new(
                             state.base.play_settings.next_value.get(),
                             clone!(state => move |value| {
                                 state.set_next_value(value);
                             }),
-                        ),
-                        clone!(state => move || {
-                            state.set_next_some();
-                        }),
-                    )),
+                        ))
+                        .on_click(clone!(state => move || state.set_next_some()))
+                        .build()
+                    ),
                 ],
             ),
         ],
     }))
 }
-/*
-pub fn render(state: Rc<State>) -> Dom {
-    html!("section", {
-        .style("display", "flex")
-        .style("flex-direction", "column")
-        .children(&mut [
-            html!("div", {
-                .text(crate::strings::step_4::STR_HEADER_HINT)
-            }),
-            render_hint_choice(state.clone(), Hint::Highlight),
-            render_hint_choice(state.clone(), Hint::None),
-            html!("div", {
-                .text(crate::strings::step_4::STR_HEADER_NEXT)
-            }),
-            render_next_choice_simple(state.clone(), Next::Continue),
-            render_next_choice_simple(state.clone(), Next::SelectAll),
-            render_next_select_some(state.clone())
-        ])
-    })
-}
-
-fn render_hint_choice(state: Rc<State>, hint:Hint) -> Dom {
-    html!("label", {
-        .child(html!("input", {
-            .attr("type", "radio")
-            .attr("name", "hint")
-            .event(clone!(state, hint => move |evt:events::Change| {
-                if evt.checked().unwrap_or_default() {
-                    state.set_hint(hint.clone());
-                }
-            }))
-            .prop_signal("checked", state.base.play_settings.hint.signal_ref(clone!(hint => move |curr| *curr == hint)))
-        }))
-        .text(match hint {
-            Hint::None => crate::strings::step_4::STR_HINT_NONE,
-            Hint::Highlight => crate::strings::step_4::STR_HINT_HIGHLIGHT
-        })
-    })
-}
-
-
-fn render_next_choice_simple(state: Rc<State>, next:Next) -> Dom {
-    html!("label", {
-        .child(html!("input", {
-            .attr("type", "radio")
-            .attr("name", "next")
-            .event(clone!(state, next => move |evt:events::Change| {
-                if evt.checked().unwrap_or_default() {
-                    state.set_next(next.clone());
-                }
-            }))
-            .prop_signal("checked", state.base.play_settings.next.signal_ref(clone!(next => move |curr| {
-                std::mem::discriminant(curr) == std::mem::discriminant(&next)
-            })))
-        }))
-        .text(match next {
-            Next::Continue => crate::strings::step_4::STR_NEXT_CONTINUE,
-            Next::SelectAll => crate::strings::step_4::STR_NEXT_SELECT_ALL,
-            _ => ""
-        })
-    })
-}
-fn render_next_select_some(state: Rc<State>) -> Dom {
-    html!("label", {
-        .child(html!("input", {
-            .attr("type", "radio")
-            .attr("name", "next")
-            .event(clone!(state => move |evt:events::Change| {
-                if evt.checked().unwrap_or_default() {
-                    state.set_next_amount();
-                }
-            }))
-            .prop_signal("checked", state.base.play_settings.next.signal_ref(|curr| {
-                std::mem::discriminant(curr) == std::mem::discriminant(&Next::SelectSome(0))
-            }))
-        }))
-        .children(&mut [
-            html!("span", {
-                .text(crate::strings::step_4::STR_NEXT_SELECT_SOME_PREFIX)
-            }),
-            html!("input" => web_sys::HtmlInputElement, {
-                .prop("type", "text")
-                .prop("size", "3")
-                .prop("value", state.some_amount.borrow().to_string())
-                .with_node!(elem => {
-                    .event(clone!(state => move |evt:events::Input| {
-                        let value = evt.value().and_then(|value| value.parse::<usize>().ok());
-
-                        if let Some(value) = value {
-                            state.on_next_amount_value(value);
-                        }
-
-                    }))
-                })
-            }),
-            html!("span", {
-                .text(crate::strings::step_4::STR_NEXT_SELECT_SOME_SUFFIX)
-            }),
-        ])
-    })
-}
-//<input @change=${this.onRadioChange} type="radio" name="img_kind" value="sticker" .checked=${imageKind === "sticker"} />
-//
-*/

--- a/frontend/apps/crates/entry/module/video/edit/src/base/sidebar/step_3/play_settings/dom.rs
+++ b/frontend/apps/crates/entry/module/video/edit/src/base/sidebar/step_3/play_settings/dom.rs
@@ -10,15 +10,14 @@ pub fn render(state: Rc<State>) -> Dom {
             ModuleSettingsLine::new(
                 LineKind::VideoPlay,
                 vec![
-                    Some(SettingsButton::new_click(
-                        SettingsButtonKind::Autoplay,
-                        clone!(state => move || {
-                            state.base.play_settings.autoplay.signal()
-                        }),
-                        clone!(state => move || {
-                            state.toggle_autoplay();
-                        }),
-                    )),
+                    Some(
+                        SettingsButtonBuilder::new(
+                            SettingsButtonKind::Autoplay,
+                            clone!(state => move || state.base.play_settings.autoplay.signal()),
+                        )
+                        .on_click(clone!(state => move || state.toggle_autoplay()))
+                        .build()
+                    ),
                     // Some(SettingsButton::new_click(
                     //     SettingsButtonKind::Loop,
                     //     clone!(state => move || {
@@ -30,51 +29,51 @@ pub fn render(state: Rc<State>) -> Dom {
                     //         state.set_unset_next_action(Some(DoneAction::Loop));
                     //     }),
                     // )),
-                    Some(SettingsButton::new_click(
-                        SettingsButtonKind::VideoCaptions,
-                        clone!(state => move || {
-                            state.base.play_settings.captions.signal()
-                        }),
-                        clone!(state => move || {
-                            state.toggle_captions();
-                        }),
-                    )),
-                    Some(SettingsButton::new_click(
-                        SettingsButtonKind::Mute,
-                        clone!(state => move || {
-                            state.base.play_settings.muted.signal()
-                        }),
-                        clone!(state => move || {
-                            state.toggle_muted();
-                        }),
-                    )),
+                    Some(
+                        SettingsButtonBuilder::new(
+                            SettingsButtonKind::VideoCaptions,
+                            clone!(state => move || state.base.play_settings.captions.signal()),
+                        )
+                        .on_click(clone!(state => move || state.toggle_captions()))
+                        .build()
+                    ),
+                    Some(
+                        SettingsButtonBuilder::new(
+                            SettingsButtonKind::Mute,
+                            clone!(state => move || state.base.play_settings.muted.signal()),
+                        )
+                        .on_click(clone!(state => move || state.toggle_muted()))
+                        .build()
+                    ),
                 ],
             ),
             ModuleSettingsLine::new(
                 LineKind::Next,
                 vec![
-                    Some(SettingsButton::new_click(
-                        SettingsButtonKind::ContinueClick,
-                        clone!(state => move || {
-                            state.base.play_settings.done_action.signal_ref(|done_action| {
-                                matches!(done_action, None)
-                            })
-                        }),
-                        clone!(state => move || {
-                            state.set_unset_next_action(None);
-                        }),
-                    )),
-                    Some(SettingsButton::new_click(
-                        SettingsButtonKind::ContinueAutomatically,
-                        clone!(state => move || {
-                            state.base.play_settings.done_action.signal_ref(|done_action| {
-                                matches!(done_action, Some(DoneAction::Next))
-                            })
-                        }),
-                        clone!(state => move || {
-                            state.set_unset_next_action(Some(DoneAction::Next));
-                        }),
-                    )),
+                    Some(
+                        SettingsButtonBuilder::new(
+                            SettingsButtonKind::ContinueClick,
+                            clone!(state => move || {
+                                state.base.play_settings.done_action.signal_ref(|done_action| {
+                                    matches!(done_action, None)
+                                })
+                            }),
+                        )
+                        .on_click(clone!(state => move || state.set_unset_next_action(None)))
+                        .build()
+                    ),
+                    Some(
+                        SettingsButtonBuilder::new(
+                            SettingsButtonKind::ContinueAutomatically,
+                            clone!(state => move || {
+                                state.base.play_settings.done_action.signal_ref(|done_action| {
+                                    matches!(done_action, Some(DoneAction::Next))
+                                })
+                            }),
+                        )
+                        .on_click(clone!(state => move || state.set_unset_next_action(Some(DoneAction::Next))))
+                        .build()
+                    ),
                 ],
             ),
         ],


### PR DESCRIPTION
Part of #3284

- Lays groundwork for enhancements required by #3284, #3285, #3279, etc.
- `new`, `new_none`, `new_value`, `new_click`, `new_value_click` and replaces them with a `SettingsButtonBuilder` struct to make SettingsButton construction more flexible and less messy;
- Updates all activity settings to use the new builder.