### PR TITLE
feat(fe/find-answer): Update settings; Keep attempts setting hidden for now

### DIFF
--- a/frontend/apps/crates/entry/module/find-answer/edit/src/base/sidebar/step_4/play_settings/actions.rs
+++ b/frontend/apps/crates/entry/module/find-answer/edit/src/base/sidebar/step_4/play_settings/actions.rs
@@ -1,5 +1,5 @@
 use super::state::State;
-use shared::domain::module::body::find_answer::{Next, Ordering};
+use shared::domain::module::body::find_answer::Ordering;
 
 impl State {
     pub fn set_ordering(&self, ordering: Ordering) {
@@ -31,7 +31,7 @@ impl State {
 
     // TODO: Once attempt limits functionality has been implemented, remove this `allow`
     #[allow(dead_code)]
-    pub fn set_attempts_limit(&self, n_attempts: u8) {
+    pub fn set_attempts_limit(&self, n_attempts: u32) {
         self.base.play_settings.n_attempts.set_neq(n_attempts);
 
         if self.base.play_settings.has_attempts_limit.get() {
@@ -67,29 +67,5 @@ impl State {
                 }
             })
         }
-    }
-
-    pub fn set_next(&self, next: Next) {
-        self.base.play_settings.next.set(next.clone());
-
-        self.base.history.push_modify(move |raw| {
-            if let Some(content) = &mut raw.content {
-                content.play_settings.next = next;
-            }
-        })
-    }
-
-    pub fn set_next_value(&self, amount: usize) {
-        self.base.play_settings.next_value.set(amount);
-
-        if std::mem::discriminant(&*self.base.play_settings.next.lock_ref())
-            == std::mem::discriminant(&Next::SelectSome(0))
-        {
-            self.set_next_some();
-        }
-    }
-
-    pub fn set_next_some(&self) {
-        self.set_next(Next::SelectSome(self.base.play_settings.next_value.get()));
     }
 }

--- a/frontend/apps/crates/entry/module/find-answer/edit/src/base/sidebar/step_4/play_settings/dom.rs
+++ b/frontend/apps/crates/entry/module/find-answer/edit/src/base/sidebar/step_4/play_settings/dom.rs
@@ -2,7 +2,7 @@ use dominator::{clone, Dom};
 use std::rc::Rc;
 
 use super::state::State;
-use shared::domain::module::body::find_answer::{Next, Ordering};
+use shared::domain::module::body::find_answer::Ordering;
 
 use components::module::_common::edit::settings::prelude::*;
 pub fn render(state: Rc<State>) -> Dom {
@@ -13,18 +13,6 @@ pub fn render(state: Rc<State>) -> Dom {
                 vec![
                     Some(
                         SettingsButtonBuilder::new(
-                            SettingsButtonKind::Randomize,
-                            clone!(state => move || {
-                                state.base.play_settings.ordering.signal_ref(|curr| {
-                                    *curr == Ordering::Randomize
-                                })
-                            }),
-                        )
-                        .on_click(clone!(state => move || state.set_ordering(Ordering::Randomize)))
-                        .build()
-                    ),
-                    Some(
-                        SettingsButtonBuilder::new(
                             SettingsButtonKind::Order,
                             clone!(state => move || {
                                 state.base.play_settings.ordering.signal_ref(|curr| {
@@ -33,41 +21,64 @@ pub fn render(state: Rc<State>) -> Dom {
                             }),
                         )
                         .on_click(clone!(state => move || state.set_ordering(Ordering::InOrder)))
-                        .build()
+                        .build(),
+                    ),
+                    Some(
+                        SettingsButtonBuilder::new(
+                            SettingsButtonKind::Randomize,
+                            clone!(state => move || {
+                                state.base.play_settings.ordering.signal_ref(|curr| {
+                                    *curr == Ordering::Randomize
+                                })
+                            }),
+                        )
+                        .on_click(clone!(state => move || state.set_ordering(Ordering::Randomize)))
+                        .build(),
                     ),
                 ],
             ),
-            // (
-            //     LineKind::Attempts,
+            // ModuleSettingsLine::new_with_label(
+            //     "Highlight correct answer...".into(),
             //     vec![
-            //         Some(SettingsButton::new_click(
-            //             SettingsButtonKind::NoLimit,
-            //             clone!(state => move || {
-            //                 state.base.play_settings.has_attempts_limit.signal_ref(|flag| !flag)
-            //             }),
-            //             clone!(state => move || {
-            //                 state.set_has_attempts_limit(false);
-            //             }),
-            //         )),
-            //         Some(SettingsButton::new_value_click(
-            //             SettingsButtonKind::Attempts,
-            //             clone!(state => move || {
-            //                 state.base.play_settings.has_attempts_limit.signal()
-            //             }),
-            //             SettingsValue::new(
-            //                 state.base.play_settings.n_attempts.get(),
-            //                 clone!(state => move |value| {
-            //                     state.set_attempts_limit(value);
+            //         Some(
+            //             SettingsButtonBuilder::new(
+            //                 SettingsButtonKind::custom_kind(
+            //                     SettingsButtonKind::Highlight,
+            //                     "after tries",
+            //                 ),
+            //                 clone!(state => move || {
+            //                     state.base.play_settings.has_attempts_limit.signal()
             //                 }),
-            //             ),
-            //             clone!(state => move || {
-            //                 state.set_has_attempts_limit(true);
-            //             }),
-            //         )),
+            //             )
+            //             .value(
+            //                 SettingsValue::new(
+            //                     state.base.play_settings.n_attempts.get(),
+            //                     clone!(state => move |value| {
+            //                         state.set_attempts_limit(value);
+            //                     }),
+            //                 )
+            //                 .value_label_template(ValueLabelTemplate::from((
+            //                     "after", "try", "tries",
+            //                 )))
+            //                 .value_input_kind(InputKind::Field),
+            //             )
+            //             .on_click(clone!(state => move || state.set_has_attempts_limit(true)))
+            //             .build(),
+            //         ),
+            //         Some(
+            //             SettingsButtonBuilder::new(
+            //                 SettingsButtonKind::HighlightOff,
+            //                 clone!(state => move || {
+            //                     state.base.play_settings.has_attempts_limit.signal_ref(|flag| !flag)
+            //                 }),
+            //             )
+            //             .on_click(clone!(state => move || state.set_has_attempts_limit(false)))
+            //             .build(),
+            //         ),
             //     ],
             // ),
-            ModuleSettingsLine::new(
-                LineKind::TimeLimit,
+            ModuleSettingsLine::new_with_label(
+                "Would you like to set a time limit?".into(), //  per question?
                 vec![
                     Some(
                         SettingsButtonBuilder::new(
@@ -77,11 +88,14 @@ pub fn render(state: Rc<State>) -> Dom {
                             }),
                         )
                         .on_click(clone!(state => move || state.set_has_time_limit(false)))
-                        .build()
+                        .build(),
                     ),
                     Some(
                         SettingsButtonBuilder::new(
-                            SettingsButtonKind::TimeLimit,
+                            SettingsButtonKind::custom_kind(
+                                SettingsButtonKind::TimeLimit,
+                                "Time limit (seconds)", // per question
+                            ),
                             clone!(state => move || {
                                 state.base.play_settings.has_time_limit
                                     .signal()
@@ -94,54 +108,7 @@ pub fn render(state: Rc<State>) -> Dom {
                             }),
                         ))
                         .on_click(clone!(state => move || state.set_has_time_limit(true)))
-                        .build()
-                    ),
-                ],
-            ),
-            ModuleSettingsLine::new(
-                LineKind::Next,
-                vec![
-                    Some(
-                        SettingsButtonBuilder::new(
-                            SettingsButtonKind::ContinueClick,
-                            clone!(state => move || {
-                                state.base.play_settings.next.signal_ref(|curr| {
-                                    std::mem::discriminant(curr) == std::mem::discriminant(&Next::Continue)
-                                })
-                            }),
-                        )
-                        .on_click(clone!(state => move || state.set_next(Next::Continue)))
-                        .build()
-                    ),
-                    Some(
-                        SettingsButtonBuilder::new(
-                            SettingsButtonKind::ContinueAll,
-                            clone!(state => move || {
-                                state.base.play_settings.next.signal_ref(|curr| {
-                                    std::mem::discriminant(curr) == std::mem::discriminant(&Next::SelectAll)
-                                })
-                            }),
-                        )
-                        .on_click(clone!(state => move || state.set_next(Next::SelectAll)))
-                        .build()
-                    ),
-                    Some(
-                        SettingsButtonBuilder::new(
-                            SettingsButtonKind::ContinueSome,
-                            clone!(state => move || {
-                                state.base.play_settings.next.signal_ref(|curr| {
-                                    std::mem::discriminant(curr) == std::mem::discriminant(&Next::SelectSome(0))
-                                })
-                            }),
-                        )
-                        .value(SettingsValue::new(
-                            state.base.play_settings.next_value.get(),
-                            clone!(state => move |value| {
-                                state.set_next_value(value);
-                            }),
-                        ))
-                        .on_click(clone!(state => move || state.set_next_some()))
-                        .build()
+                        .build(),
                     ),
                 ],
             ),

--- a/frontend/apps/crates/entry/module/find-answer/edit/src/base/state.rs
+++ b/frontend/apps/crates/entry/module/find-answer/edit/src/base/state.rs
@@ -20,16 +20,16 @@ use futures_signals::{
 use shared::domain::asset::AssetId;
 use shared::domain::module::body::Audio;
 use shared::domain::module::body::_groups::design::Trace;
-use shared::domain::module::body::find_answer::{Ordering, Question as RawQuestion, QuestionField};
+use shared::domain::module::body::find_answer::{
+    Ordering, Question as RawQuestion, QuestionField, DEFAULT_ATTEMPTS_LIMIT,
+};
 use shared::domain::{
     jig::JigId,
     module::{
         body::{
             BodyExt, Instructions,
             _groups::design::TraceKind,
-            find_answer::{
-                Mode, ModuleData as RawData, Next, PlaySettings as RawPlaySettings, Step,
-            },
+            find_answer::{Mode, ModuleData as RawData, PlaySettings as RawPlaySettings, Step},
         },
         ModuleId,
     },
@@ -61,30 +61,21 @@ pub struct Base {
 pub struct PlaySettings {
     pub ordering: Mutable<Ordering>,
     pub has_attempts_limit: Mutable<bool>,
-    pub n_attempts: Mutable<u8>,
+    pub n_attempts: Mutable<u32>,
     pub has_time_limit: Mutable<bool>,
     pub time_limit: Mutable<u32>,
-    pub next: Mutable<Next>,
-    pub next_value: Mutable<usize>,
 }
 
-const DEFAULT_ATTEMPTS_LIMIT: u8 = 2;
 const DEFAULT_TIME_LIMIT: u32 = 10;
 
 impl PlaySettings {
     pub fn new(settings: RawPlaySettings) -> Self {
-        let next_value = Mutable::new(match &settings.next {
-            Next::SelectSome(value) => *value,
-            _ => crate::config::DEFAULT_SELECT_AMOUNT,
-        });
         Self {
             ordering: Mutable::new(settings.ordering),
             has_attempts_limit: Mutable::new(settings.n_attempts.is_some()),
             n_attempts: Mutable::new(settings.n_attempts.unwrap_or(DEFAULT_ATTEMPTS_LIMIT)),
             has_time_limit: Mutable::new(settings.time_limit.is_some()),
             time_limit: Mutable::new(settings.time_limit.unwrap_or(DEFAULT_TIME_LIMIT)),
-            next: Mutable::new(settings.next),
-            next_value,
         }
     }
 }

--- a/frontend/apps/crates/entry/module/find-answer/edit/src/config.rs
+++ b/frontend/apps/crates/entry/module/find-answer/edit/src/config.rs
@@ -1,1 +1,0 @@
-pub const DEFAULT_SELECT_AMOUNT: usize = 3;

--- a/frontend/apps/crates/entry/module/find-answer/edit/src/lib.rs
+++ b/frontend/apps/crates/entry/module/find-answer/edit/src/lib.rs
@@ -6,7 +6,6 @@
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
 mod base;
-mod config;
 mod debug;
 mod router;
 mod state;

--- a/frontend/apps/crates/utils/src/unwrap.rs
+++ b/frontend/apps/crates/utils/src/unwrap.rs
@@ -1,5 +1,4 @@
 use cfg_if::cfg_if;
-use wasm_bindgen::prelude::*;
 
 /*
  * debug switching between unwrap_ji() and unwrap_ji()

--- a/frontend/elements/src/module/_common/edit/widgets/settings/bubble-content.ts
+++ b/frontend/elements/src/module/_common/edit/widgets/settings/bubble-content.ts
@@ -9,6 +9,13 @@ import { nothing } from "lit-html";
 import "@elements/core/images/ui";
 import { Kind } from "./button";
 
+// TS copy of ValueLabelTemplate
+interface ValueLabelTemplate {
+    prefix: string,
+    postfix_singular: string,
+    postfix_plural: string,
+}
+
 const STR_LABEL: Partial<Record<Kind, string>> = {
     attempts: "Player gets",
     "continue-some": "of",
@@ -56,22 +63,42 @@ export class _ extends LitElement {
     kind: Kind = "attempts";
 
     @property()
+    private valueLabelTemplate?: ValueLabelTemplate;
+
+    @property()
     value?: any;
 
+    public set valueLabelTemplateFromString(template: string) {
+        this.valueLabelTemplate = JSON.parse(template);
+    }
+
     renderLabelSuffix() {
-        const suffix = STR_LABEL_SUFFIX[this.kind];
+        if (this.valueLabelTemplate) {
+            return html`<span>${
+                this.value > 1
+                ? this.valueLabelTemplate.postfix_plural
+                : this.valueLabelTemplate.postfix_singular
+            }</span>`;
+        } else {
+            const suffix = STR_LABEL_SUFFIX[this.kind];
 
-        if (!suffix) {
-            return nothing;
+            if (!suffix) {
+                return nothing;
+            }
+
+            return html`<span>${this.value > 1 ? suffix[1] : suffix[0]}</span>`;
         }
-
-        return html`<span>${this.value > 1 ? suffix[1] : suffix[0]}</span>`;
     }
 
     render() {
         const { kind } = this;
 
-        const label = STR_LABEL[kind];
+        let label = null;
+        if (this.valueLabelTemplate) {
+            label = this.valueLabelTemplate.prefix;
+        } else {
+            label = STR_LABEL[kind];
+        }
 
         return html`
             ${label ? html`<span>${label}</span>` : nothing}

--- a/shared/rust/src/domain/module/body/find_answer/play_settings.rs
+++ b/shared/rust/src/domain/module/body/find_answer/play_settings.rs
@@ -1,19 +1,30 @@
 use serde::{Deserialize, Serialize};
 
+/// Default limit for attempts a student can make on an answer before a trace
+/// is highlighted.
+pub const DEFAULT_ATTEMPTS_LIMIT: u32 = 3;
+
 /// Play settings
-#[derive(Clone, Default, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct PlaySettings {
     /// Question ordering
     pub ordering: Ordering,
 
     /// number of attempts
-    pub n_attempts: Option<u8>,
+    pub n_attempts: Option<u32>,
 
     /// time limit in minutes
     pub time_limit: Option<u32>,
+}
 
-    /// Next style
-    pub next: Next,
+impl Default for PlaySettings {
+    fn default() -> Self {
+        Self {
+            n_attempts: Some(DEFAULT_ATTEMPTS_LIMIT),
+            ordering: Default::default(),
+            time_limit: Default::default(),
+        }
+    }
 }
 
 /// Ordering of questions
@@ -28,25 +39,6 @@ pub enum Ordering {
 
 impl Default for Ordering {
     fn default() -> Self {
-        Self::Randomize
-    }
-}
-
-/// Next
-#[derive(Clone, Serialize, Deserialize, Debug)]
-pub enum Next {
-    /// Continue
-    Continue,
-
-    /// SelectAll
-    SelectAll,
-
-    /// Select Some
-    SelectSome(usize),
-}
-
-impl Default for Next {
-    fn default() -> Self {
-        Self::Continue
+        Self::InOrder
     }
 }


### PR DESCRIPTION
Part of #3291 

- Removes "Student finishes this activity by...";
- Updates "ask in order" to be default and moves to the first position;
- Updates logic so that we can customize setting bubble labels - for the highlight correct answer setting;
	- Setting has been added and hidden until the play logic is updated.
- Moves the timer settings to be on the last row;
- Updates text of the timer settings 
	- Hidden until the play logic is updated;