### PR TITLE
feat(fe/player): Allow modules to opt-in to controlling player navigation; Allow modules to update the timer

### DIFF
--- a/frontend/apps/crates/components/src/module/_common/play/entry/dom.rs
+++ b/frontend/apps/crates/components/src/module/_common/play/entry/dom.rs
@@ -177,6 +177,11 @@ where
                                     }
                                 }
                             },
+                            message => {
+                                if let InitPhase::Ready(base) = &*state.phase.get_cloned() {
+                                    base.base.handle_navigation(message);
+                                }
+                            }
                         }
                     } else {
                         log::info!("hmmm got other iframe message...");
@@ -216,14 +221,7 @@ where
                         // This will mark the activity as started in the player, but the activity itself would
                         // only start playing once it's in the Playing phase.
                         if jig_player {
-                            let timer_seconds = base.get_timer_seconds();
-
-                            let msg = IframeAction::new(ModuleToJigPlayerMessage::Start(timer_seconds));
-
-                            match timer_seconds {
-                                Some(x) => log::info!("Starting with a {} seconds timer", x),
-                                None => log::info!("Starting without a timer")
-                            }
+                            let msg = IframeAction::new(ModuleToJigPlayerMessage::Start(base.get_module_config()));
 
                             //let the player know we're starting
                             msg.try_post_message_to_player().unwrap_ji();

--- a/frontend/apps/crates/components/src/module/_common/play/entry/ending/dom.rs
+++ b/frontend/apps/crates/components/src/module/_common/play/entry/ending/dom.rs
@@ -9,8 +9,7 @@ use gloo_timers::future::TimeoutFuture;
 
 impl Ending {
     pub fn render(state: Rc<Self>) -> Dom {
-        log::info!("MODULE ENDED");
-        let msg = IframeAction::new(ModuleToJigPlayerMessage::Stop);
+        let msg = IframeAction::new(ModuleToJigPlayerMessage::PauseTimer);
 
         if msg.try_post_message_to_player().is_err() {
             log::info!("Couldn't post message to player!");

--- a/frontend/apps/crates/components/src/module/_common/play/entry/state.rs
+++ b/frontend/apps/crates/components/src/module/_common/play/entry/state.rs
@@ -4,6 +4,7 @@ use dominator_helpers::futures::AsyncLoader;
 use futures_signals::signal::{Mutable, ReadOnlyMutable};
 use shared::domain::asset::{Asset, AssetId, AssetType, DraftOrLive, PrivacyLevel};
 use shared::domain::course::CourseGetDraftPath;
+use shared::domain::jig::player::ModuleConfig;
 use shared::domain::module::body::{Instructions, InstructionsType};
 use shared::domain::resource::ResourceGetDraftPath;
 use shared::{
@@ -416,8 +417,12 @@ pub trait BaseExt: DomRenderable {
         // Do nothing. Activities which have custom ended logic/rules should implement this.
     }
 
-    fn get_timer_seconds(&self) -> Option<u32> {
-        None
+    fn handle_navigation(&self, _message: JigToModulePlayerMessage) {
+        // Do nothing. Acitivities which control navigation should implement this.
+    }
+
+    fn get_module_config(&self) -> ModuleConfig {
+        ModuleConfig::default()
     }
 
     fn set_play_phase(&self, phase: ModulePlayPhase) {

--- a/frontend/apps/crates/entry/asset/play/src/jig/dom.rs
+++ b/frontend/apps/crates/entry/asset/play/src/jig/dom.rs
@@ -390,7 +390,7 @@ impl JigPlayer {
                         }
                     }))
                     .event(clone!(state => move |_: events::Click| {
-                        actions::navigate_back(Rc::clone(&state));
+                        actions::navigate_back_or_handle(Rc::clone(&state));
                     }))
                     .global_event(clone!(state => move |e: events::KeyUp| {
                         actions::navigate_from_keyboard_event(state.clone(), KeyEvent::from(e));
@@ -404,7 +404,7 @@ impl JigPlayer {
                     .prop("slot", "forward")
                     .prop("kind", "forward")
                     .event(clone!(state => move |_: events::Click| {
-                        actions::navigate_forward(Rc::clone(&state));
+                        actions::navigate_forward_or_handle(Rc::clone(&state));
                     }))
                     .global_event(clone!(state => move |e: events::KeyUp| {
                         actions::navigate_from_keyboard_event(state.clone(), KeyEvent::from(e));
@@ -610,7 +610,6 @@ fn render_time_indicator(state: Rc<JigPlayer>) -> impl Signal<Item = Option<Dom>
                                     &JsValue::from_str("buzz")
                                 )
                                     .unwrap_ji();
-                                log::info!("{:?}", buzz_method);
                                 let buzz_method = buzz_method.dyn_ref::<js_sys::Function>().unwrap_ji();
                                 let _ = buzz_method.call0(&elem);
                             }

--- a/frontend/apps/crates/entry/asset/play/src/jig/state.rs
+++ b/frontend/apps/crates/entry/asset/play/src/jig/state.rs
@@ -5,7 +5,7 @@ use components::audio::mixer::AudioHandle;
 use futures_signals::signal::Mutable;
 use serde::{Deserialize, Serialize};
 use shared::domain::{
-    jig::{JigId, JigPlayerSettings, JigResponse},
+    jig::{player::PlayerNavigationHandler, JigId, JigPlayerSettings, JigResponse},
     meta::ResourceType,
     module::{
         body::{Audio, Instructions as ModuleInstructions, InstructionsType},
@@ -28,6 +28,7 @@ pub struct JigPlayer {
     pub played_modules: RefCell<usize>,
     pub play_tracked: RefCell<bool>,
     pub start_module_id: Option<ModuleId>,
+    pub navigation_handler: Mutable<Option<PlayerNavigationHandler>>,
     pub timer: Mutable<Option<Timer>>,
     pub points: Mutable<u32>,
     pub iframe: Rc<RefCell<Option<HtmlIFrameElement>>>,
@@ -70,6 +71,7 @@ impl JigPlayer {
             play_tracked: RefCell::new(false),
             start_module_id: module_id,
             timer: Mutable::new(None),
+            navigation_handler: Mutable::new(None),
             points: Mutable::new(0),
             iframe: Rc::new(RefCell::new(None)),
             started: Mutable::new(false),

--- a/frontend/apps/crates/entry/module/card-quiz/play/src/base/state.rs
+++ b/frontend/apps/crates/entry/module/card-quiz/play/src/base/state.rs
@@ -1,5 +1,6 @@
 use shared::domain::{
     asset::AssetId,
+    jig::player::{ModuleConfig, Seconds},
     module::{
         body::{
             Background, Instructions,
@@ -91,8 +92,11 @@ impl BaseExt for Base {
         }
     }
 
-    fn get_timer_seconds(&self) -> Option<u32> {
-        self.settings.time_limit
+    fn get_module_config(&self) -> ModuleConfig {
+        ModuleConfig {
+            timer: self.settings.time_limit.map(|t| Seconds(t)),
+            ..Default::default()
+        }
     }
 
     fn play_phase(&self) -> Mutable<ModulePlayPhase> {

--- a/frontend/apps/crates/entry/module/drag-drop/play/src/base/state.rs
+++ b/frontend/apps/crates/entry/module/drag-drop/play/src/base/state.rs
@@ -1,6 +1,7 @@
 use components::module::_common::play::prelude::*;
 use shared::domain::{
     asset::{Asset, AssetId},
+    jig::player::{ModuleConfig, Seconds},
     module::{
         body::{
             Instructions,
@@ -80,8 +81,11 @@ impl BaseExt for Base {
         }
     }
 
-    fn get_timer_seconds(&self) -> Option<u32> {
-        self.settings.time_limit
+    fn get_module_config(&self) -> ModuleConfig {
+        ModuleConfig {
+            timer: self.settings.time_limit.map(|t| Seconds(t)),
+            ..Default::default()
+        }
     }
 
     fn play_phase(&self) -> Mutable<ModulePlayPhase> {

--- a/frontend/apps/crates/entry/module/find-answer/edit/src/base/sidebar/step_4/play_settings/dom.rs
+++ b/frontend/apps/crates/entry/module/find-answer/edit/src/base/sidebar/step_4/play_settings/dom.rs
@@ -78,7 +78,7 @@ pub fn render(state: Rc<State>) -> Dom {
             //     ],
             // ),
             ModuleSettingsLine::new_with_label(
-                "Would you like to set a time limit?".into(), //  per question?
+                "Would you like to set a time limit per question?".into(),
                 vec![
                     Some(
                         SettingsButtonBuilder::new(
@@ -94,7 +94,7 @@ pub fn render(state: Rc<State>) -> Dom {
                         SettingsButtonBuilder::new(
                             SettingsButtonKind::custom_kind(
                                 SettingsButtonKind::TimeLimit,
-                                "Time limit (seconds)", // per question
+                                "Time limit (seconds) per question",
                             ),
                             clone!(state => move || {
                                 state.base.play_settings.has_time_limit

--- a/frontend/apps/crates/entry/module/find-answer/play/src/base/game/playing/state.rs
+++ b/frontend/apps/crates/entry/module/find-answer/play/src/base/game/playing/state.rs
@@ -68,21 +68,19 @@ impl PlayTrace {
     }
 
     pub fn select(&self, play_state: Rc<PlayState>) {
-        if !play_state.ended.get() {
-            if self.audio.is_none() && self.text.is_none() {
-                self.phase.set(PlayPhase::IdleSelected);
-                play_state.evaluate_end();
-            } else if let Some(bounds) = self.inner.calc_bounds(true) {
-                let bubble = TraceBubble::new(
-                    bounds,
-                    self.audio.clone(),
-                    self.text.clone(),
-                    Some(clone!(play_state => move || {
-                        play_state.clone().evaluate_end();
-                    })),
-                );
-                self.phase.set(PlayPhase::Playing(bubble));
-            }
+        if self.audio.is_none() && self.text.is_none() {
+            self.phase.set(PlayPhase::IdleSelected);
+            play_state.evaluate_end();
+        } else if let Some(bounds) = self.inner.calc_bounds(true) {
+            let bubble = TraceBubble::new(
+                bounds,
+                self.audio.clone(),
+                self.text.clone(),
+                Some(clone!(play_state => move || {
+                    play_state.clone().evaluate_end();
+                })),
+            );
+            self.phase.set(PlayPhase::Playing(bubble));
         }
     }
 

--- a/frontend/apps/crates/entry/module/find-answer/play/src/base/game/state.rs
+++ b/frontend/apps/crates/entry/module/find-answer/play/src/base/game/state.rs
@@ -3,6 +3,7 @@ use std::rc::Rc;
 
 use futures_signals::signal::Mutable;
 use shared::domain::module::body::find_answer::Question;
+use utils::prelude::*;
 
 pub struct Game {
     pub base: Rc<Base>,
@@ -18,7 +19,6 @@ impl Game {
         //     Hint::None => Phase::Playing,
         // });
 
-        // TODO We need to choose random questions if that setting is enabled for the activity.
         // Fetch the first question. It should be guaranteed that at least one question always exists when playing.
         // However, there is always the possibility that a teacher wants to preview an incomplete activity which has
         // no questions yet, so we leave this value as optional.
@@ -29,10 +29,12 @@ impl Game {
             .cloned()
             .map(|question| (0, question));
 
+        base.current_question.set(first_question);
+
         Rc::new(Self {
+            question: base.current_question.clone(),
             base,
             phase: Mutable::new(Phase::Playing),
-            question: Mutable::new(first_question),
         })
     }
 
@@ -45,12 +47,6 @@ impl Game {
         }
 
         None
-    }
-
-    pub fn move_next_question(self: &Rc<Game>, index: usize) {
-        if let Some(next_question) = self.base.questions.get(index) {
-            self.question.set(Some((index, next_question.clone())));
-        }
     }
 }
 

--- a/frontend/apps/crates/entry/module/matching/play/src/base/state.rs
+++ b/frontend/apps/crates/entry/module/matching/play/src/base/state.rs
@@ -1,5 +1,6 @@
 use shared::domain::{
     asset::AssetId,
+    jig::player::{ModuleConfig, Seconds},
     module::{
         body::{
             Background, Instructions,
@@ -91,8 +92,11 @@ impl BaseExt for Base {
         }
     }
 
-    fn get_timer_seconds(&self) -> Option<u32> {
-        self.settings.time_limit
+    fn get_module_config(&self) -> ModuleConfig {
+        ModuleConfig {
+            timer: self.settings.time_limit.map(|t| Seconds(t)),
+            ..Default::default()
+        }
     }
 
     fn play_phase(&self) -> Mutable<ModulePlayPhase> {

--- a/frontend/apps/crates/entry/module/memory/play/src/base/state.rs
+++ b/frontend/apps/crates/entry/module/memory/play/src/base/state.rs
@@ -2,6 +2,7 @@ use shared::{
     config::MAX_LIST_WORDS,
     domain::{
         asset::AssetId,
+        jig::player::{ModuleConfig, Seconds},
         module::{
             body::{
                 Background, Instructions,
@@ -175,8 +176,11 @@ impl BaseExt for Base {
         }
     }
 
-    fn get_timer_seconds(&self) -> Option<u32> {
-        self.settings.time_limit
+    fn get_module_config(&self) -> ModuleConfig {
+        ModuleConfig {
+            timer: self.settings.time_limit.map(|t| Seconds(t)),
+            ..Default::default()
+        }
     }
 
     fn play_phase(&self) -> Mutable<ModulePlayPhase> {

--- a/frontend/apps/crates/utils/src/iframe.rs
+++ b/frontend/apps/crates/utils/src/iframe.rs
@@ -1,8 +1,11 @@
 use crate::{keyboard::KeyEvent, unwrap::UnwrapJiExt};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use shared::domain::module::{
-    body::{Instructions, InstructionsType},
-    LiteModule, ModuleId,
+use shared::domain::{
+    jig::player::{ModuleConfig, Seconds},
+    module::{
+        body::{Instructions, InstructionsType},
+        LiteModule, ModuleId,
+    },
 };
 use std::cell::Cell;
 use wasm_bindgen::prelude::*;
@@ -175,14 +178,22 @@ pub enum JigToModulePlayerMessage {
     // remove play and pause? might need for video
     Play,
     Pause,
+    /// Sent if the player is configured to forward navigation events to
+    /// the module
+    Previous,
+    /// Sent if the player is configured to forward navigation events to
+    /// the module
+    Next,
     InstructionsDone(InstructionsType),
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum ModuleToJigPlayerMessage {
     AddPoints(u32),
-    Start(Option<u32>),
-    Stop,
+    Start(ModuleConfig),
+    ResetTimer(Seconds),
+    PauseTimer,
+    UnpauseTimer,
     Previous,
     Next,
     JumpToIndex(usize),

--- a/shared/rust/src/domain/jig/player.rs
+++ b/shared/rust/src/domain/jig/player.rs
@@ -1,5 +1,7 @@
 //! Types for Jig short codes for sharing
 
+use std::ops::Deref;
+
 use chrono::{DateTime, Utc};
 use macros::make_path_parts;
 use serde::{Deserialize, Serialize};
@@ -166,5 +168,41 @@ pub mod instance {
     pub struct PlayerSessionInstanceCompleteRequest {
         /// Token that will be passed to confirm a JIG was played all the way through
         pub token: String,
+    }
+}
+
+#[derive(Clone, Default, Serialize, Deserialize, Debug, Eq, PartialEq)]
+/// Module config passed to the JIG player when a module starts
+pub struct ModuleConfig {
+    /// How player navigation should be handled
+    pub navigation_handler: PlayerNavigationHandler,
+    /// Optional timer to use for the module
+    pub timer: Option<Seconds>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+/// How JIG player navigation should be handled
+pub enum PlayerNavigationHandler {
+    /// The JIG player handles the navigation
+    Player,
+    /// The module handles navigation
+    Module,
+}
+
+impl Default for PlayerNavigationHandler {
+    fn default() -> Self {
+        Self::Player
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
+/// Newtype for timer seconds
+pub struct Seconds(pub u32);
+
+impl Deref for Seconds {
+    type Target = u32;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }


### PR DESCRIPTION
Part of #3291

- Timer:
  - Timer restarts at the start of each question. Default is 10 seconds.
  - Stop timer when a question is completed correctly.
- If there are multiple questions, then the NEXT in the player should go to the next question and not the next module.
 - If the student is on the last question, the next button goes to the next module; If they're on the first question, the back button goes to the previous module.
