### PR TITLE
feat(fe/find-answer): Add ability to replay question audio from instructions button

### DIFF
--- a/frontend/apps/crates/entry/asset/play/src/jig/dom.rs
+++ b/frontend/apps/crates/entry/asset/play/src/jig/dom.rs
@@ -257,7 +257,8 @@ impl JigPlayer {
                                 let instructions = state.instructions.get_cloned();
                                 let timer = state.timer.get_cloned();
                                 if let Some(instructions) = instructions {
-                                    if timer.is_some() || instructions.text.is_some() {
+                                    if (timer.is_some() && instructions.instructions_type.is_instructions()) || instructions.text.is_some() {
+                                        // If there is a timer and the type is `Instructions`, or if there is text, show the popup
                                         actions::show_instructions(state.clone(), true);
                                     } else if instructions.audio.is_some() {
                                         actions::play_instructions_audio(state.clone());
@@ -284,7 +285,7 @@ impl JigPlayer {
                                                             InstructionsType::Instructions => {
                                                                 dom.prop("body", &instructions.text.unwrap_or(DEFAULT_INSTRUCTIONS_TEXT.to_owned()))
                                                             }
-                                                            InstructionsType::Feedback => {
+                                                            InstructionsType::Feedback | InstructionsType::InActivity => {
                                                                 if let Some(text) = &instructions.text {
                                                                     dom.prop("body", text)
                                                                 } else {
@@ -576,6 +577,9 @@ fn render_time_up_popup(state: Rc<JigPlayer>) -> impl Signal<Item = Option<Dom>>
                                         .prop("slot", "actions")
                                         .prop("kind", "replay")
                                         .event(clone!(state => move |_: events::Click| {
+                                            // Clear the instructions so that they don't play/show once the
+                                            // activity is reloaded.
+                                            actions::set_instructions(state.clone(), None);
                                             actions::reload_iframe(Rc::clone(&state));
                                         }))
                                     })

--- a/shared/rust/src/domain/module/body.rs
+++ b/shared/rust/src/domain/module/body.rs
@@ -445,6 +445,8 @@ pub enum InstructionsType {
     Instructions,
     /// Feedback is shown at the end of an activity
     Feedback,
+    /// Replayable activity-specific audio or text
+    InActivity,
 }
 
 impl InstructionsType {
@@ -456,6 +458,11 @@ impl InstructionsType {
     /// Whether this variant is `Feedback`
     pub fn is_feedback(&self) -> bool {
         matches!(self, Self::Feedback)
+    }
+
+    /// Whether this variant is `InActivity`
+    pub fn is_in_activity(&self) -> bool {
+        matches!(self, Self::InActivity)
     }
 }
 


### PR DESCRIPTION
Closes #3333 

- Replaces instructions text/audio with question audio once activity has started so that a student can press the button to replay the question;
  - Added a new `InstructionType` variant `InActivity` which allows activities to set new text/audio that can be played.
- Fixes issue where replaying an activity would replay the last instruction audio;