### PR TITLE
fix(fe/find-answer): Prevent audio playback from overlapping across selections/questions

### DIFF
--- a/frontend/apps/crates/entry/module/find-answer/play/src/base/game/playing/state.rs
+++ b/frontend/apps/crates/entry/module/find-answer/play/src/base/game/playing/state.rs
@@ -89,14 +89,13 @@ impl PlayTrace {
     pub fn select(&self, play_state: Rc<PlayState>) {
         if self.audio.is_none() && self.text.is_none() {
             self.phase.set(PlayPhase::IdleSelected);
-            play_state.evaluate_end();
         } else if let Some(bounds) = self.inner.calc_bounds(true) {
             let bubble = TraceBubble::new(
                 bounds,
                 self.audio.clone(),
                 self.text.clone(),
                 Some(clone!(play_state => move || {
-                    play_state.clone().evaluate_end();
+                    play_state.clone().remove_incorrect_highlights();
                 })),
             );
             self.phase.set(PlayPhase::Playing(bubble));


### PR DESCRIPTION
Part of #2658 