### PR TITLE
feat(fe/find-answer): Make question field dynamic

### DIFF
--- a/frontend/apps/crates/components/src/stickers/dom.rs
+++ b/frontend/apps/crates/components/src/stickers/dom.rs
@@ -233,7 +233,7 @@ pub fn render_sticker<T: AsSticker>(
                 if let Some(selected) = stickers.selected_index.get_cloned() {
                     if Some(selected) == index.get_cloned() {
                         let can_delete = if let Some(text) = stickers.get_as_text(selected) {
-                            !text.is_editing.get()
+                            !text.is_editing.get() && text.can_delete.get()
                         } else {
                             true
                         };

--- a/frontend/apps/crates/components/src/stickers/text/state.rs
+++ b/frontend/apps/crates/components/src/stickers/text/state.rs
@@ -22,6 +22,8 @@ pub struct Text {
     /// Optional reference to the wysiwyg-output-renderer
     pub renderer_ref: Mutable<Option<HtmlElement>>,
     pub is_editing: Mutable<bool>,
+    pub is_editable: Mutable<bool>,
+    pub can_delete: Mutable<bool>,
 }
 
 impl Text {
@@ -33,12 +35,15 @@ impl Text {
     ) -> Self {
         let text = text.clone();
         let is_editing = Mutable::new(false);
+        let is_editable = Mutable::new(true);
 
         let transform_callbacks = TransformCallbacks::new(
             on_transform_finished,
             //transform double-click
-            Some(clone!(is_editing => move || {
-                is_editing.set_neq(true)
+            Some(clone!(is_editable, is_editing => move || {
+                if is_editable.get() {
+                    is_editing.set_neq(true)
+                }
             })),
             on_blur.map(clone!(is_editing => move|on_blur| {
                 move || {
@@ -59,6 +64,8 @@ impl Text {
             editor,
             renderer_ref: Mutable::new(None),
             is_editing,
+            is_editable,
+            can_delete: Mutable::new(true),
         }
     }
 

--- a/frontend/apps/crates/entry/module/find-answer/edit/src/base/actions.rs
+++ b/frontend/apps/crates/entry/module/find-answer/edit/src/base/actions.rs
@@ -9,6 +9,7 @@ use shared::domain::module::body::{
     find_answer::{Mode, ModuleData as RawData, Question as RawQuestion, QuestionField, Step},
 };
 use std::rc::Rc;
+use utils::unwrap::UnwrapJiExt;
 
 pub enum Direction {
     Up,
@@ -114,6 +115,14 @@ impl Base {
     pub fn delete_question(&self, index: usize) {
         self.questions.lock_mut().remove(index);
         if self.questions.lock_ref().is_empty() {
+            if let QuestionField::Text(index) = self.question_field.get_cloned() {
+                self.stickers
+                    .get_as_text(index)
+                    .unwrap_ji()
+                    .can_delete
+                    .set_neq(true);
+            }
+
             self.question_field.set(QuestionField::Dynamic(None));
         }
 


### PR DESCRIPTION
Closes #3085 

- If a teacher adds a new question without selecting a text sticker, one will be added with the text "Your question box";
  - They are not able to delete that sticker unless all questions are deleted;
- On step 3, the question sticker will not be editable except to move it around;
- Existing activities that didn't have a text sticker will still work - there is no clean way to update those to include a sticker without potentially ruining the activity layout. 
  - I need to check how many activities exist that don't have a sticker selected. 