### PR TITLE
feat(be/asset): add is_liked flag

### DIFF
--- a/backend/api/fixtures/20_course.sql
+++ b/backend/api/fixtures/20_course.sql
@@ -23,6 +23,8 @@ values ('3a6a3660-f3ec-11ec-b8ef-071747fa2a0d', '1f241e1b-b537-493f-a230-075cb16
        ('ef0c4d42-f3ec-11ec-b8ef-af940a9cfba5', '7b96a41c-e406-11eb-8176-efd86dd7f444', '7b96a41c-e406-11eb-8176-efd86dd7f444',
         'f393863c-f3ec-11ec-b8ef-43660dc59560', 'f9d0133a-f3ec-11ec-b8ef-3323861c2ef0', '2022-06-22 18:35:33.636556+00');
 
+insert into course_like (course_id, user_id, created_at)
+values ('ef0c4d42-f3ec-11ec-b8ef-af940a9cfba5', '1f241e1b-b537-493f-a230-075cb16315be', '2021-03-04 00:47:26.134651+00');
 
 insert into course_data_jig (course_data_id, jig_id)
 values ('566ed564-f3ec-11ec-b8ef-93b44835e7e4', '0cc084bc-7c83-11eb-9f77-e3218dffb008'),
@@ -41,5 +43,3 @@ values ('ce6e6eb0-0ea6-11ed-9785-2712225b9473',
         'e1aa3b64-f3ec-11ec-b8ef-2f4e066962a2', 0, 0, true, '{}', '2021-03-04 00:47:26.134651+00'), -- draft 
        ('266cbba8-0ea7-11ed-9785-0b828c5e915c', 
         'f9d0133a-f3ec-11ec-b8ef-3323861c2ef0', 0, 0, true, '{}', '2021-03-04 00:47:26.134651+00'); -- draft
-
-

--- a/backend/api/fixtures/21_resource.sql
+++ b/backend/api/fixtures/21_resource.sql
@@ -21,8 +21,8 @@ values ('d8067526-1518-11ed-87fa-ebaf880b6d9c', '1f241e1b-b537-493f-a230-075cb16
        ('2f8d91d0-1519-11ed-87fa-eb1826fcf343', '1f241e1b-b537-493f-a230-075cb16315be',
         '1f241e1b-b537-493f-a230-075cb16315be', '2f8d92d4-1519-11ed-87fa-63728884fdd0',
         '2f8d937e-1519-11ed-87fa-033ee1e7150d', '2022-06-23 17:57:33.149359+00'),
-       ('af827e00-1519-11ed-87fa-7b1aa26c85a8', '1f241e1b-b537-493f-a230-075cb16315be',
-        '1f241e1b-b537-493f-a230-075cb16315be', 'af827edc-1519-11ed-87fa-a7fcfabe535d',
+       ('af827e00-1519-11ed-87fa-7b1aa26c85a8', '7b96a41c-e406-11eb-8176-efd86dd7f444',
+        '7b96a41c-e406-11eb-8176-efd86dd7f444', 'af827edc-1519-11ed-87fa-a7fcfabe535d',
         'af827f86-1519-11ed-87fa-0f83dd32ae96', '2022-06-22 17:57:33.149359+00');
 
 insert into resource_data_module (id, resource_data_id, index, kind, is_complete, contents, created_at)
@@ -45,3 +45,6 @@ values ('d806771a-1518-11ed-87fa-4785946384aa', '286b828c-1dd9-11ec-8426-571b03b
        ('d8067634-1518-11ed-87fa-cb90cc4fa07d', '286b834a-1dd9-11ec-8426-6f641a50e23f',
         'link test', 'a91aca34-519e-11ec-ab46-175eaaf1ff23', '{ "link": "url://url.url.url/urls/s" }'),
        ('d8067634-1518-11ed-87fa-cb90cc4fa07d', '286b8390-1dd9-11ec-8426-fbeb80c504d9', 'link test', 'a91aca34-519e-11ec-ab46-175eaaf1ff23', '{ "link": "url://url.url.url/url/s" }');
+
+insert into resource_like (resource_id, user_id, created_at)
+values ('af827e00-1519-11ed-87fa-7b1aa26c85a8', '1f241e1b-b537-493f-a230-075cb16315be', '2021-03-04 00:47:26.134651+00');

--- a/backend/api/migrations/20230209004121_change-liked-count.sql
+++ b/backend/api/migrations/20230209004121_change-liked-count.sql
@@ -1,0 +1,39 @@
+--fix trigger "likes" variable
+drop function if exists update_course_unlike cascade;
+drop function if exists update_course_like cascade;
+
+create function update_course_like() returns trigger
+    language plpgsql
+as
+$$
+begin
+    update course
+    set likes = likes + 1
+    where id = NEW.course_id;
+    return NEW;
+end;
+$$;
+
+create trigger add_course_like
+    after insert
+    on course_like
+    for each row
+execute procedure update_course_like();
+
+create function update_course_unlike() returns trigger
+    language plpgsql
+as
+$$
+begin
+    update course
+    set likes = likes - 1
+    where id = OLD.course_id;
+    return NULL;
+end;
+$$;
+
+create trigger course_unlike
+    after delete
+    on course_like
+    for each row
+execute procedure update_course_unlike();

--- a/backend/api/sqlx-data.json
+++ b/backend/api/sqlx-data.json
@@ -153,6 +153,105 @@
     },
     "query": "\nupdate jig_data_module\nset\n    index = case when index = $2 then $3 else index - 1 end,\n    updated_at = now()\nwhere jig_data_id = $1 and index between $2 and $3\n"
   },
+  "035084fd2aec4252a82f4c4662721e09909ad682753ccab5b55781cebbae6e81": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id!: JigId",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "creator_id: UserId",
+          "ordinal": 1,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "author_id: UserId",
+          "ordinal": 2,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "author_name",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "live_id!",
+          "ordinal": 4,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "draft_id!",
+          "ordinal": 5,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "published_at",
+          "ordinal": 6,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "liked_count!",
+          "ordinal": 7,
+          "type_info": "Int8"
+        },
+        {
+          "name": "live_up_to_date!",
+          "ordinal": 8,
+          "type_info": "Bool"
+        },
+        {
+          "name": "is_liked!",
+          "ordinal": 9,
+          "type_info": "Bool"
+        },
+        {
+          "name": "play_count!",
+          "ordinal": 10,
+          "type_info": "Int8"
+        },
+        {
+          "name": "rating?: JigRating",
+          "ordinal": 11,
+          "type_info": "Int2"
+        },
+        {
+          "name": "blocked!",
+          "ordinal": 12,
+          "type_info": "Bool"
+        },
+        {
+          "name": "curated!",
+          "ordinal": 13,
+          "type_info": "Bool"
+        }
+      ],
+      "nullable": [
+        false,
+        true,
+        true,
+        null,
+        false,
+        false,
+        true,
+        false,
+        false,
+        null,
+        null,
+        true,
+        false,
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "UuidArray",
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\nselect jig.id                                       as \"id!: JigId\",\n       creator_id                               as \"creator_id: UserId\",\n       author_id                                as \"author_id: UserId\",\n       (select given_name || ' '::text || family_name\n        from user_profile\n        where user_profile.user_id = author_id) as \"author_name\",\n       live_id                                  as \"live_id!\",\n       draft_id                                 as \"draft_id!\",\n       published_at,\n       liked_count                              as \"liked_count!\",\n       live_up_to_date                          as \"live_up_to_date!\",\n       exists(select 1 from jig_like where jig_id = jig.id and user_id = $2) as \"is_liked!\",\n       (\n           select play_count\n           from jig_play_count\n           where jig_play_count.jig_id = jig.id\n       )                                        as \"play_count!\",\n       rating                                   as \"rating?: JigRating\",\n       blocked                                  as \"blocked!\",\n       curated                                  as \"curated!\"\nfrom jig\n         inner join unnest($1::uuid[])\n    with ordinality t(id, ord) using (id)\n    inner join jig_admin_data \"admin\" on admin.jig_id = jig.id\n    order by ord asc\n    "
+  },
   "0379e2a93becd328af1177045c2060becee6c16ff12487edf53446ceb7d9165d": {
     "describe": {
       "columns": [],
@@ -236,6 +335,196 @@
       }
     },
     "query": "\nupdate jig_play_count\nset play_count = play_count + 1\nwhere jig_id = $1;\n            "
+  },
+  "056d39e5cdfa3dc0aab02ae1ec2448e33172a3c9bc66a2658529d22758a6d103": {
+    "describe": {
+      "columns": [
+        {
+          "name": "resource_id: ResourceId",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "privacy_level: PrivacyLevel",
+          "ordinal": 1,
+          "type_info": "Int2"
+        },
+        {
+          "name": "creator_id?: UserId",
+          "ordinal": 2,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "author_id?: UserId",
+          "ordinal": 3,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "author_name",
+          "ordinal": 4,
+          "type_info": "Text"
+        },
+        {
+          "name": "created_at",
+          "ordinal": 5,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "updated_at",
+          "ordinal": 6,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "published_at",
+          "ordinal": 7,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "likes",
+          "ordinal": 8,
+          "type_info": "Int8"
+        },
+        {
+          "name": "views",
+          "ordinal": 9,
+          "type_info": "Int8"
+        },
+        {
+          "name": "live_up_to_date",
+          "ordinal": 10,
+          "type_info": "Bool"
+        },
+        {
+          "name": "is_liked!",
+          "ordinal": 11,
+          "type_info": "Bool"
+        },
+        {
+          "name": "display_name!",
+          "ordinal": 12,
+          "type_info": "Text"
+        },
+        {
+          "name": "language!",
+          "ordinal": 13,
+          "type_info": "Text"
+        },
+        {
+          "name": "description!",
+          "ordinal": 14,
+          "type_info": "Text"
+        },
+        {
+          "name": "translated_description!: Json<HashMap<String,String>>",
+          "ordinal": 15,
+          "type_info": "Jsonb"
+        },
+        {
+          "name": "draft_or_live!: DraftOrLive",
+          "ordinal": 16,
+          "type_info": "Int2"
+        },
+        {
+          "name": "cover?: (ModuleId, ModuleKind, bool)",
+          "ordinal": 17,
+          "type_info": "Record"
+        },
+        {
+          "name": "categories!: Vec<(CategoryId,)>",
+          "ordinal": 18,
+          "type_info": "RecordArray"
+        },
+        {
+          "name": "affiliations!: Vec<(AffiliationId,)>",
+          "ordinal": 19,
+          "type_info": "RecordArray"
+        },
+        {
+          "name": "age_ranges!: Vec<(AgeRangeId,)>",
+          "ordinal": 20,
+          "type_info": "RecordArray"
+        },
+        {
+          "name": "additional_resource!: Vec<(AddId, String, TypeId, Value)>",
+          "ordinal": 21,
+          "type_info": "RecordArray"
+        },
+        {
+          "name": "locked!",
+          "ordinal": 22,
+          "type_info": "Bool"
+        },
+        {
+          "name": "other_keywords!",
+          "ordinal": 23,
+          "type_info": "Text"
+        },
+        {
+          "name": "translated_keywords!",
+          "ordinal": 24,
+          "type_info": "Text"
+        },
+        {
+          "name": "rating!: Option<ResourceRating>",
+          "ordinal": 25,
+          "type_info": "Int2"
+        },
+        {
+          "name": "blocked!",
+          "ordinal": 26,
+          "type_info": "Bool"
+        },
+        {
+          "name": "curated!",
+          "ordinal": 27,
+          "type_info": "Bool"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        true,
+        true,
+        null,
+        false,
+        true,
+        true,
+        false,
+        false,
+        false,
+        null,
+        false,
+        false,
+        false,
+        false,
+        true,
+        null,
+        null,
+        null,
+        null,
+        null,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Bool",
+          "Int2Array",
+          "UuidArray",
+          "Int2",
+          "Int4",
+          "Int4",
+          "Int4",
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\nwith cte as (\n    select array_agg(rd.id)\n    from resource_data \"rd\"\n          inner join resource on (draft_id = rd.id or (live_id = rd.id and rd.last_synced_at is not null and published_at is not null))\n          left join resource_admin_data \"admin\" on admin.resource_id = resource.id\n          left join resource_data_resource \"rdr\" on rd.id = rdr.resource_data_id\n    where (author_id = $1 or $1 is null)\n        and (blocked = $2 or $2 is null)\n        and (rd.privacy_level = any($3) or $3 = array[]::smallint[])\n        and (rdr.resource_type_id = any($4) or $4 = array[]::uuid[])\n        and (draft_or_live = $5 or $5 is null)\n    group by updated_at, created_at, resource.published_at, admin.resource_id\n    order by case when $6 = 0 then created_at\n        when $6 = 1 then published_at\n        else coalesce(updated_at, created_at)\n  end desc, resource_id\n),\ncte1 as (\n    select * from unnest(array((select cte.array_agg[1] from cte))) with ordinality t(id\n   , ord) order by ord\n)\nselect resource.id                                              as \"resource_id: ResourceId\",\n    privacy_level                                       as \"privacy_level: PrivacyLevel\",\n    creator_id                                          as \"creator_id?: UserId\",\n    author_id                                           as \"author_id?: UserId\",\n    (select given_name || ' '::text || family_name\n        from user_profile\n     where user_profile.user_id = author_id)            as \"author_name\",\n    created_at,\n    updated_at,\n    published_at,\n    likes,\n    views,\n    live_up_to_date,\n    exists(select 1 from resource_like where resource_id = resource.id and user_id = $9)                         as \"is_liked!\",\n   display_name                                                                  as \"display_name!\",\n   language                                                                      as \"language!\",\n   description                                                                   as \"description!\",\n   translated_description                                                        as \"translated_description!: Json<HashMap<String,String>>\",\n   draft_or_live                                                                 as \"draft_or_live!: DraftOrLive\",\n   (\n       select row(resource_data_module.id, kind, is_complete)\n       from resource_data_module\n       where resource_data_id = resource_data.id\n    )                                               as \"cover?: (ModuleId, ModuleKind, bool)\",\n   array(select row (category_id)\n         from resource_data_category\n         where resource_data_id = resource_data.id)     as \"categories!: Vec<(CategoryId,)>\",\n   array(select row (affiliation_id)\n         from resource_data_affiliation\n         where resource_data_id = resource_data.id)     as \"affiliations!: Vec<(AffiliationId,)>\",\n   array(select row (age_range_id)\n         from resource_data_age_range\n         where resource_data_id = resource_data.id)     as \"age_ranges!: Vec<(AgeRangeId,)>\",\n   array(\n            select row (rdr.id, rdr.display_name, resource_type_id, resource_content)\n            from resource_data_resource \"rdr\"\n            where rdr.resource_data_id= resource_data.id\n        )                                               as \"additional_resource!: Vec<(AddId, String, TypeId, Value)>\",\n   locked                                     as \"locked!\",\n   other_keywords                             as \"other_keywords!\",\n   translated_keywords                        as \"translated_keywords!\",\n   rating                                     as \"rating!: Option<ResourceRating>\",\n   blocked                                    as \"blocked!\",\n   curated                                    as \"curated!\"\nfrom cte1\ninner join resource_data on cte1.id = resource_data.id\ninner join resource on (\n    resource_data.id = resource.draft_id\n    or (\n        resource_data.id = resource.live_id\n        and last_synced_at is not null\n        and resource.published_at is not null\n    )\n)\nleft join resource_admin_data \"admin\" on admin.resource_id = resource.id\nwhere ord > (1 * $7 * $8)\norder by ord asc\nlimit $8\n"
   },
   "05bbabcca8dd32c111fe7308edf49359bf549213810253605bb4bf7eccedbca2": {
     "describe": {
@@ -346,6 +635,184 @@
       }
     },
     "query": "\n        with cte as (\n            select jdar.id              as id,\n                   jdar.display_name,\n                   resource_type_id,\n                   resource_content,\n                   author_id,\n                   updated_at,\n                   created_at\n            from jig_data_additional_resource \"jdar\"\n            inner join jig on jig.live_id = jdar.jig_data_id\n            inner join jig_data on jig.live_id = jig_data.id\n            where author_id = $1 and jig.published_at is not null\n           ),\n           cte1 as (\n              select cdr.id              as id,\n                cdr.display_name,\n                resource_type_id,\n                resource_content,\n                author_id,\n                updated_at,\n                created_at\n          from course_data_resource \"cdr\"\n          inner join course on course.live_id = cdr.course_data_id\n          inner join course_data on course.live_id = course_data.id\n          where author_id = $1 and course.published_at is not null\n          ),\n          cte2 as (\n            select *\n            from unnest(array(\n                select\n                (array_agg(id))[1] as id\n                from (select id, updated_at, created_at from cte union all select id, updated_at, created_at from cte1)\n                resource\n                group by resource.updated_at, resource.created_at\n                order by coalesce(resource.updated_at, created_at))) with ordinality t(id\n                , ord) order by ord\n         )\n          select cte3.id                as \"id!: AddId\",\n                 display_name           as \"display_name!\",\n                 resource_type_id       as \"resource_type_id!: TypeId\",\n                 resource_content        as \"resource_content!\"\n         from\n          (select * from cte\n          union all\n          select * from cte1) cte3\n        inner join cte2 on cte2.id = cte3.id\n        where ord > (1 * $2 * $3)\n        order by ord asc\n        limit $3\n            "
+  },
+  "07436ad6820515a6bdcbe4fc24b958f0f6c3d6546e0129b080eb010d320dde7b": {
+    "describe": {
+      "columns": [
+        {
+          "name": "resource_id: ResourceId",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "display_name",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "creator_id: UserId",
+          "ordinal": 2,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "author_id: UserId",
+          "ordinal": 3,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "author_name",
+          "ordinal": 4,
+          "type_info": "Text"
+        },
+        {
+          "name": "created_at",
+          "ordinal": 5,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "updated_at",
+          "ordinal": 6,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "published_at",
+          "ordinal": 7,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "privacy_level!: PrivacyLevel",
+          "ordinal": 8,
+          "type_info": "Int2"
+        },
+        {
+          "name": "language",
+          "ordinal": 9,
+          "type_info": "Text"
+        },
+        {
+          "name": "description",
+          "ordinal": 10,
+          "type_info": "Text"
+        },
+        {
+          "name": "translated_description!: Json<HashMap<String, String>>",
+          "ordinal": 11,
+          "type_info": "Jsonb"
+        },
+        {
+          "name": "likes",
+          "ordinal": 12,
+          "type_info": "Int8"
+        },
+        {
+          "name": "views",
+          "ordinal": 13,
+          "type_info": "Int8"
+        },
+        {
+          "name": "live_up_to_date",
+          "ordinal": 14,
+          "type_info": "Bool"
+        },
+        {
+          "name": "locked",
+          "ordinal": 15,
+          "type_info": "Bool"
+        },
+        {
+          "name": "other_keywords",
+          "ordinal": 16,
+          "type_info": "Text"
+        },
+        {
+          "name": "translated_keywords",
+          "ordinal": 17,
+          "type_info": "Text"
+        },
+        {
+          "name": "rating?: ResourceRating",
+          "ordinal": 18,
+          "type_info": "Int2"
+        },
+        {
+          "name": "blocked",
+          "ordinal": 19,
+          "type_info": "Bool"
+        },
+        {
+          "name": "is_liked!",
+          "ordinal": 20,
+          "type_info": "Bool"
+        },
+        {
+          "name": "curated",
+          "ordinal": 21,
+          "type_info": "Bool"
+        },
+        {
+          "name": "cover?: (ModuleId, ModuleKind, bool)",
+          "ordinal": 22,
+          "type_info": "Record"
+        },
+        {
+          "name": "categories!: Vec<(CategoryId,)>",
+          "ordinal": 23,
+          "type_info": "RecordArray"
+        },
+        {
+          "name": "affiliations!: Vec<(AffiliationId,)>",
+          "ordinal": 24,
+          "type_info": "RecordArray"
+        },
+        {
+          "name": "age_ranges!: Vec<(AgeRangeId,)>",
+          "ordinal": 25,
+          "type_info": "RecordArray"
+        },
+        {
+          "name": "additional_resource!: Vec<(AddId, String, TypeId, Value)>",
+          "ordinal": 26,
+          "type_info": "RecordArray"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        true,
+        true,
+        null,
+        false,
+        true,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        false,
+        null,
+        false,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Int4",
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\nwith cte as (\n    select id      as \"resource_id\",\n           creator_id,\n           author_id,\n           likes,\n           views,\n           live_up_to_date,\n           case\n               when $2 = 0 then resource.draft_id\n               when $2 = 1 then resource.live_id\n               end as \"draft_or_live_id\",\n           published_at,\n           rating,\n           blocked,\n           curated\n    from resource\n    left join resource_admin_data \"admin\" on admin.resource_id = resource.id\n    where id = $1\n)\nselect cte.resource_id                                          as \"resource_id: ResourceId\",\n        display_name,\n        creator_id                                          as \"creator_id: UserId\",\n        author_id                                           as \"author_id: UserId\",\n        (select given_name || ' '::text || family_name\n        from user_profile\n        where user_profile.user_id = author_id)            as \"author_name\",\n        created_at,\n        updated_at,\n        published_at,\n        privacy_level                                       as \"privacy_level!: PrivacyLevel\",\n        language,\n        description,\n        translated_description                              as \"translated_description!: Json<HashMap<String, String>>\",\n        likes,\n        views,\n        live_up_to_date,\n        locked,\n        other_keywords,\n        translated_keywords,\n        rating                                               as \"rating?: ResourceRating\",\n        blocked                                              as \"blocked\",\n        exists(select 1 from resource_like where resource_id = $1 and user_id = $3)  as \"is_liked!\",\n        curated,\n        (\n                select row(resource_data_module.id, kind, is_complete)\n                from resource_data_module\n                where resource_data_id = resource_data.id\n        )                                               as \"cover?: (ModuleId, ModuleKind, bool)\",\n        array(select row (category_id)\n                from resource_data_category\n                where resource_data_id = cte.draft_or_live_id)     as \"categories!: Vec<(CategoryId,)>\",\n        array(select row (affiliation_id)\n                from resource_data_affiliation\n                where resource_data_id = cte.draft_or_live_id)     as \"affiliations!: Vec<(AffiliationId,)>\",\n        array(select row (age_range_id)\n                from resource_data_age_range\n                where resource_data_id = cte.draft_or_live_id)     as \"age_ranges!: Vec<(AgeRangeId,)>\",\n        array(\n                select row (rdr.id, rdr.display_name, resource_type_id, resource_content)\n                from resource_data_resource \"rdr\"\n                where rdr.resource_data_id = cte.draft_or_live_id\n    )                                                    as \"additional_resource!: Vec<(AddId, String, TypeId, Value)>\"\nfrom resource_data\n         inner join cte on cte.draft_or_live_id = resource_data.id\n"
   },
   "07b1496a54fbb0cebc203d43806992842291ecfbcac2c386eb550c8e4b694b7e": {
     "describe": {
@@ -725,98 +1192,6 @@
     },
     "query": "select user_id \"id!: UserId\" from user_auth_basic where user_id <> $1 and lower(email) = lower($2) for update"
   },
-  "10b86d28cabce5e262d584f687f8ea9797042d573e665a64c5d880ec465de853": {
-    "describe": {
-      "columns": [
-        {
-          "name": "id!: JigId",
-          "ordinal": 0,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "creator_id: UserId",
-          "ordinal": 1,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "author_id: UserId",
-          "ordinal": 2,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "author_name",
-          "ordinal": 3,
-          "type_info": "Text"
-        },
-        {
-          "name": "live_id!",
-          "ordinal": 4,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "draft_id!",
-          "ordinal": 5,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "published_at",
-          "ordinal": 6,
-          "type_info": "Timestamptz"
-        },
-        {
-          "name": "liked_count!",
-          "ordinal": 7,
-          "type_info": "Int8"
-        },
-        {
-          "name": "live_up_to_date!",
-          "ordinal": 8,
-          "type_info": "Bool"
-        },
-        {
-          "name": "play_count!",
-          "ordinal": 9,
-          "type_info": "Int8"
-        },
-        {
-          "name": "rating?: JigRating",
-          "ordinal": 10,
-          "type_info": "Int2"
-        },
-        {
-          "name": "blocked!",
-          "ordinal": 11,
-          "type_info": "Bool"
-        },
-        {
-          "name": "curated!",
-          "ordinal": 12,
-          "type_info": "Bool"
-        }
-      ],
-      "nullable": [
-        false,
-        true,
-        true,
-        null,
-        false,
-        false,
-        true,
-        false,
-        false,
-        null,
-        true,
-        false,
-        false
-      ],
-      "parameters": {
-        "Left": [
-          "UuidArray"
-        ]
-      }
-    },
-    "query": "\nselect jig.id                                       as \"id!: JigId\",\n       creator_id                               as \"creator_id: UserId\",\n       author_id                                as \"author_id: UserId\",\n       (select given_name || ' '::text || family_name\n        from user_profile\n        where user_profile.user_id = author_id) as \"author_name\",\n       live_id                                  as \"live_id!\",\n       draft_id                                 as \"draft_id!\",\n       published_at,\n       liked_count                              as \"liked_count!\",\n       live_up_to_date                          as \"live_up_to_date!\",\n       (\n           select play_count\n           from jig_play_count\n           where jig_play_count.jig_id = jig.id\n       )                                        as \"play_count!\",\n       rating                                   as \"rating?: JigRating\",\n       blocked                                  as \"blocked!\",\n       curated                                  as \"curated!\"\nfrom jig\n         inner join unnest($1::uuid[])\n    with ordinality t(id, ord) using (id)\n    inner join jig_admin_data \"admin\" on admin.jig_id = jig.id\n    order by ord asc\n    "
-  },
   "11623dd925dc935401e7c2ef73941a1a46d253df579b98af410e69d1e578850d": {
     "describe": {
       "columns": [],
@@ -1042,6 +1417,170 @@
       }
     },
     "query": "\nupdate resource_data_resource\nset resource_content = $3\nwhere resource_data_id = $1 and id = $2\n            "
+  },
+  "1518c2e069f11ce933249e2f25d446f93495ab115666e850f9ef7d785020c469": {
+    "describe": {
+      "columns": [
+        {
+          "name": "course_id: CourseId",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "privacy_level: PrivacyLevel",
+          "ordinal": 1,
+          "type_info": "Int2"
+        },
+        {
+          "name": "creator_id?: UserId",
+          "ordinal": 2,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "author_id?: UserId",
+          "ordinal": 3,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "author_name",
+          "ordinal": 4,
+          "type_info": "Text"
+        },
+        {
+          "name": "published_at",
+          "ordinal": 5,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "likes",
+          "ordinal": 6,
+          "type_info": "Int8"
+        },
+        {
+          "name": "plays",
+          "ordinal": 7,
+          "type_info": "Int8"
+        },
+        {
+          "name": "live_up_to_date",
+          "ordinal": 8,
+          "type_info": "Bool"
+        },
+        {
+          "name": "is_liked!",
+          "ordinal": 9,
+          "type_info": "Bool"
+        },
+        {
+          "name": "display_name!",
+          "ordinal": 10,
+          "type_info": "Text"
+        },
+        {
+          "name": "updated_at",
+          "ordinal": 11,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "language!",
+          "ordinal": 12,
+          "type_info": "Text"
+        },
+        {
+          "name": "description!",
+          "ordinal": 13,
+          "type_info": "Text"
+        },
+        {
+          "name": "translated_description!: Json<HashMap<String,String>>",
+          "ordinal": 14,
+          "type_info": "Jsonb"
+        },
+        {
+          "name": "draft_or_live!: DraftOrLive",
+          "ordinal": 15,
+          "type_info": "Int2"
+        },
+        {
+          "name": "other_keywords!",
+          "ordinal": 16,
+          "type_info": "Text"
+        },
+        {
+          "name": "translated_keywords!",
+          "ordinal": 17,
+          "type_info": "Text"
+        },
+        {
+          "name": "cover?: (ModuleId, ModuleKind, bool)",
+          "ordinal": 18,
+          "type_info": "Record"
+        },
+        {
+          "name": "categories!: Vec<(CategoryId,)>",
+          "ordinal": 19,
+          "type_info": "RecordArray"
+        },
+        {
+          "name": "affiliations!: Vec<(AffiliationId,)>",
+          "ordinal": 20,
+          "type_info": "RecordArray"
+        },
+        {
+          "name": "age_ranges!: Vec<(AgeRangeId,)>",
+          "ordinal": 21,
+          "type_info": "RecordArray"
+        },
+        {
+          "name": "additional_resource!: Vec<(AddId, String, TypeId, Value)>",
+          "ordinal": 22,
+          "type_info": "RecordArray"
+        },
+        {
+          "name": "items!: Vec<(JigId,)>",
+          "ordinal": 23,
+          "type_info": "RecordArray"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        true,
+        true,
+        null,
+        true,
+        false,
+        false,
+        false,
+        null,
+        false,
+        true,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Int2",
+          "Int2Array",
+          "UuidArray",
+          "Int4",
+          "Int4",
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\nwith cte as (\n    select (array_agg(cd.id))[1]\n    from course_data \"cd\"\n          left join course on (draft_id = cd.id or (live_id = cd.id and cd.last_synced_at is not null and published_at is not null))\n          left join course_data_resource \"resource\" on cd.id = resource.course_data_id\n    where (author_id = $1 or $1 is null)\n        and (cd.draft_or_live = $2 or $2 is null)\n        and (cd.privacy_level = any($3) or $3 = array[]::smallint[])\n        and (resource.resource_type_id = any($4) or $4 = array[]::uuid[])\n    group by coalesce(updated_at, created_at)\n    order by coalesce(updated_at, created_at) desc\n),\ncte1 as (\n    select * from unnest(array(select cte.array_agg from cte)) with ordinality t(id\n   , ord) order by ord\n)\nselect course.id                                                                as \"course_id: CourseId\",\n    privacy_level                                                               as \"privacy_level: PrivacyLevel\",\n    creator_id                                                                  as \"creator_id?: UserId\",\n    author_id                                                                   as \"author_id?: UserId\",\n    (select given_name || ' '::text || family_name\n     from user_profile\n     where user_profile.user_id = author_id)                                     as \"author_name\",\n    published_at,\n    likes,\n    plays,\n    live_up_to_date,\n    exists(select 1 from course_like where course_id = course.id and user_id = $7)    as \"is_liked!\",\n    display_name                                                                  as \"display_name!\",\n    updated_at,\n    language                                                                      as \"language!\",\n    description                                                                   as \"description!\",\n    translated_description                                                        as \"translated_description!: Json<HashMap<String,String>>\",\n    draft_or_live                                                                 as \"draft_or_live!: DraftOrLive\",\n    other_keywords                                                                as \"other_keywords!\",\n    translated_keywords                                                           as \"translated_keywords!\",\n    (\n        select row(course_data_module.id, kind, is_complete)\n        from course_data_module\n        where course_data_id = course_data.id and \"index\" = 0\n        order by \"index\"\n    )                                                   as \"cover?: (ModuleId, ModuleKind, bool)\",\n    array(select row (category_id)\n            from course_data_category\n            where course_data_id = course_data.id)     as \"categories!: Vec<(CategoryId,)>\",\n    array(select row (affiliation_id)\n            from course_data_affiliation\n            where course_data_id = course_data.id)          as \"affiliations!: Vec<(AffiliationId,)>\",\n    array(select row (age_range_id)\n            from course_data_age_range\n            where course_data_id = course_data.id)          as \"age_ranges!: Vec<(AgeRangeId,)>\",\n    array(select row (id, display_name, resource_type_id, resource_content)\n                from course_data_resource\n                where course_data_id = course_data.id\n          )                                          as \"additional_resource!: Vec<(AddId, String, TypeId, Value)>\",\n    array(\n        select row(jig_id)\n        from course_data_jig\n        where course_data_jig.course_data_id = course_data.id\n        order by \"index\"\n    )                                                     as \"items!: Vec<(JigId,)>\"\nfrom cte1\ninner join course_data on cte1.id = course_data.id\ninner join course on (\n    course_data.id = course.draft_id\n    or (\n        course_data.id = course.live_id\n        and last_synced_at is not null\n        and course.published_at is not null\n    )\n)\nwhere ord > (1 * $5 * $6)\norder by ord asc\nlimit $6\n"
   },
   "160b640822791b21c7d5d057e0d388bfdf669e70b2a2eeb99056919681a607ee": {
     "describe": {
@@ -2319,98 +2858,6 @@
     },
     "query": "\nselect id,\n       kind as \"kind: MediaKind\",\n       created_at,\n       updated_at,\n       array(select media_url from web_media_library_url where media_id = $1) as \"urls!\"\nfrom web_media_library\nwhere id = $1"
   },
-  "31ddaef5cc384f51f217e8bb8d9a1f182472945d238217fb64b7942e031ac71e": {
-    "describe": {
-      "columns": [
-        {
-          "name": "id!: ResourceId",
-          "ordinal": 0,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "creator_id: UserId",
-          "ordinal": 1,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "author_id: UserId",
-          "ordinal": 2,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "author_name",
-          "ordinal": 3,
-          "type_info": "Text"
-        },
-        {
-          "name": "live_id!",
-          "ordinal": 4,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "draft_id!",
-          "ordinal": 5,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "published_at",
-          "ordinal": 6,
-          "type_info": "Timestamptz"
-        },
-        {
-          "name": "likes!",
-          "ordinal": 7,
-          "type_info": "Int8"
-        },
-        {
-          "name": "views!",
-          "ordinal": 8,
-          "type_info": "Int8"
-        },
-        {
-          "name": "live_up_to_date!",
-          "ordinal": 9,
-          "type_info": "Bool"
-        },
-        {
-          "name": "rating?: ResourceRating",
-          "ordinal": 10,
-          "type_info": "Int2"
-        },
-        {
-          "name": "blocked!",
-          "ordinal": 11,
-          "type_info": "Bool"
-        },
-        {
-          "name": "curated!",
-          "ordinal": 12,
-          "type_info": "Bool"
-        }
-      ],
-      "nullable": [
-        false,
-        true,
-        true,
-        null,
-        false,
-        false,
-        true,
-        false,
-        false,
-        false,
-        true,
-        false,
-        false
-      ],
-      "parameters": {
-        "Left": [
-          "UuidArray"
-        ]
-      }
-    },
-    "query": "\nselect resource.id                                       as \"id!: ResourceId\",\n       creator_id                               as \"creator_id: UserId\",\n       author_id                                as \"author_id: UserId\",\n       (select given_name || ' '::text || family_name\n        from user_profile\n        where user_profile.user_id = author_id) as \"author_name\",\n       live_id                                  as \"live_id!\",\n       draft_id                                 as \"draft_id!\",\n       published_at,\n       likes                                     as \"likes!\",\n       views                                    as \"views!\",\n       live_up_to_date                          as \"live_up_to_date!\",\n       rating                                   as \"rating?: ResourceRating\",\n       blocked                                  as \"blocked!\",\n       curated                                  as \"curated!\"\nfrom resource\ninner join unnest($1::uuid[])\n    with ordinality t(id, ord) using (id)\ninner join resource_admin_data \"admin\" on admin.resource_id = resource.id\norder by ord asc\n    "
-  },
   "32570ca7632e0f254fa15681ead459f2a97592e3c49a36d2273b2cf43c6c6d90": {
     "describe": {
       "columns": [],
@@ -2974,153 +3421,6 @@
       }
     },
     "query": "\nupdate course_data_module\nset\n    index = case when index = $2 then $3 else index + 1 end,\n    updated_at = now()\nwhere course_data_id = $1 and index between $3 and $2\n"
-  },
-  "3a8fa6f5c9cb213f1d06fe3599c1038b93b52adc2195af68aaba23f7e91fb20d": {
-    "describe": {
-      "columns": [
-        {
-          "name": "course_id: CourseId",
-          "ordinal": 0,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "display_name",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "creator_id?: UserId",
-          "ordinal": 2,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "author_id?: UserId",
-          "ordinal": 3,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "author_name",
-          "ordinal": 4,
-          "type_info": "Text"
-        },
-        {
-          "name": "published_at",
-          "ordinal": 5,
-          "type_info": "Timestamptz"
-        },
-        {
-          "name": "updated_at",
-          "ordinal": 6,
-          "type_info": "Timestamptz"
-        },
-        {
-          "name": "privacy_level!: PrivacyLevel",
-          "ordinal": 7,
-          "type_info": "Int2"
-        },
-        {
-          "name": "language",
-          "ordinal": 8,
-          "type_info": "Text"
-        },
-        {
-          "name": "description",
-          "ordinal": 9,
-          "type_info": "Text"
-        },
-        {
-          "name": "translated_description!: Json<HashMap<String, String>>",
-          "ordinal": 10,
-          "type_info": "Jsonb"
-        },
-        {
-          "name": "likes",
-          "ordinal": 11,
-          "type_info": "Int8"
-        },
-        {
-          "name": "plays",
-          "ordinal": 12,
-          "type_info": "Int8"
-        },
-        {
-          "name": "live_up_to_date",
-          "ordinal": 13,
-          "type_info": "Bool"
-        },
-        {
-          "name": "other_keywords",
-          "ordinal": 14,
-          "type_info": "Text"
-        },
-        {
-          "name": "translated_keywords",
-          "ordinal": 15,
-          "type_info": "Text"
-        },
-        {
-          "name": "cover?: (ModuleId, ModuleKind, bool)",
-          "ordinal": 16,
-          "type_info": "Record"
-        },
-        {
-          "name": "categories!: Vec<(CategoryId,)>",
-          "ordinal": 17,
-          "type_info": "RecordArray"
-        },
-        {
-          "name": "affiliations!: Vec<(AffiliationId,)>",
-          "ordinal": 18,
-          "type_info": "RecordArray"
-        },
-        {
-          "name": "age_ranges!: Vec<(AgeRangeId,)>",
-          "ordinal": 19,
-          "type_info": "RecordArray"
-        },
-        {
-          "name": "additional_resource!: Vec<(AddId, String, TypeId, Value)>",
-          "ordinal": 20,
-          "type_info": "RecordArray"
-        },
-        {
-          "name": "items!: Vec<(JigId,)>",
-          "ordinal": 21,
-          "type_info": "RecordArray"
-        }
-      ],
-      "nullable": [
-        false,
-        false,
-        true,
-        true,
-        null,
-        true,
-        true,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Int4"
-        ]
-      }
-    },
-    "query": "\nwith cte as (\n    select id      as \"course_id\",\n           creator_id,\n           author_id,\n           likes,\n           plays,\n           live_up_to_date,\n           case\n               when $2 = 0 then course.draft_id\n               when $2 = 1 then course.live_id\n               end as \"draft_or_live_id\",\n           published_at\n    from course\n    where id = $1\n)\nselect cte.course_id                                          as \"course_id: CourseId\",\n       display_name,\n       creator_id                                             as \"creator_id?: UserId\",\n       author_id                                              as \"author_id?: UserId\",\n       (select given_name || ' '::text || family_name\n        from user_profile\n        where user_profile.user_id = author_id)            as \"author_name\",\n       published_at,\n       updated_at,\n       privacy_level                                       as \"privacy_level!: PrivacyLevel\",\n       language,\n       description,\n       translated_description                              as \"translated_description!: Json<HashMap<String, String>>\",\n       likes,\n       plays,\n       live_up_to_date,\n       other_keywords,\n       translated_keywords,\n       (\n            select row(course_data_module.id, kind, is_complete)\n            from course_data_module\n            where course_data_id = cte.draft_or_live_id and \"index\" = 0\n            order by \"index\"\n        )                                                   as \"cover?: (ModuleId, ModuleKind, bool)\",\n       array(select row (category_id)\n             from course_data_category\n             where course_data_id = cte.draft_or_live_id)     as \"categories!: Vec<(CategoryId,)>\",\n       array(select row (affiliation_id)\n             from course_data_affiliation\n             where course_data_id = cte.draft_or_live_id)     as \"affiliations!: Vec<(AffiliationId,)>\",\n       array(select row (age_range_id)\n             from course_data_age_range\n             where course_data_id = cte.draft_or_live_id)     as \"age_ranges!: Vec<(AgeRangeId,)>\",\n       array(\n             select row (jdar.id, jdar.display_name, resource_type_id, resource_content)\n             from course_data_resource \"jdar\"\n             where jdar.course_data_id = cte.draft_or_live_id\n       )                                                    as \"additional_resource!: Vec<(AddId, String, TypeId, Value)>\",\n       array(\n           select row(jig_id)\n           from course_data_jig\n           where course_data_id = cte.draft_or_live_id\n           order by \"index\"\n       )                                                     as \"items!: Vec<(JigId,)>\"\nfrom course_data\n         inner join cte on cte.draft_or_live_id = course_data.id\n"
   },
   "3ad66986079ea2df21f1a6af0c50510d362a19addcf3bc0f62b8f3948ea14cf8": {
     "describe": {
@@ -4118,225 +4418,6 @@
     },
     "query": "\ninsert into pro_dev_data_category(pro_dev_data_id, category_id)\nselect $2, category_id\nfrom pro_dev_data_category\nwhere pro_dev_data_id = $1\n        "
   },
-  "4f6d2ddbd67bbb8151bfd7108517f9a2e6b8982cc7c98075c2f22969db1ef482": {
-    "describe": {
-      "columns": [
-        {
-          "name": "jig_id: JigId",
-          "ordinal": 0,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "display_name",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "creator_id: UserId",
-          "ordinal": 2,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "author_id: UserId",
-          "ordinal": 3,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "author_name",
-          "ordinal": 4,
-          "type_info": "Text"
-        },
-        {
-          "name": "created_at",
-          "ordinal": 5,
-          "type_info": "Timestamptz"
-        },
-        {
-          "name": "updated_at",
-          "ordinal": 6,
-          "type_info": "Timestamptz"
-        },
-        {
-          "name": "published_at",
-          "ordinal": 7,
-          "type_info": "Timestamptz"
-        },
-        {
-          "name": "privacy_level!: PrivacyLevel",
-          "ordinal": 8,
-          "type_info": "Int2"
-        },
-        {
-          "name": "language",
-          "ordinal": 9,
-          "type_info": "Text"
-        },
-        {
-          "name": "description",
-          "ordinal": 10,
-          "type_info": "Text"
-        },
-        {
-          "name": "translated_description!: Json<HashMap<String, String>>",
-          "ordinal": 11,
-          "type_info": "Jsonb"
-        },
-        {
-          "name": "direction: TextDirection",
-          "ordinal": 12,
-          "type_info": "Int2"
-        },
-        {
-          "name": "display_score",
-          "ordinal": 13,
-          "type_info": "Bool"
-        },
-        {
-          "name": "track_assessments",
-          "ordinal": 14,
-          "type_info": "Bool"
-        },
-        {
-          "name": "drag_assist",
-          "ordinal": 15,
-          "type_info": "Bool"
-        },
-        {
-          "name": "theme: ThemeId",
-          "ordinal": 16,
-          "type_info": "Int2"
-        },
-        {
-          "name": "audio_background: AudioBackground",
-          "ordinal": 17,
-          "type_info": "Int2"
-        },
-        {
-          "name": "liked_count",
-          "ordinal": 18,
-          "type_info": "Int8"
-        },
-        {
-          "name": "play_count",
-          "ordinal": 19,
-          "type_info": "Int8"
-        },
-        {
-          "name": "live_up_to_date",
-          "ordinal": 20,
-          "type_info": "Bool"
-        },
-        {
-          "name": "locked",
-          "ordinal": 21,
-          "type_info": "Bool"
-        },
-        {
-          "name": "other_keywords",
-          "ordinal": 22,
-          "type_info": "Text"
-        },
-        {
-          "name": "translated_keywords",
-          "ordinal": 23,
-          "type_info": "Text"
-        },
-        {
-          "name": "rating?: JigRating",
-          "ordinal": 24,
-          "type_info": "Int2"
-        },
-        {
-          "name": "blocked",
-          "ordinal": 25,
-          "type_info": "Bool"
-        },
-        {
-          "name": "curated",
-          "ordinal": 26,
-          "type_info": "Bool"
-        },
-        {
-          "name": "audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>",
-          "ordinal": 27,
-          "type_info": "RecordArray"
-        },
-        {
-          "name": "audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>",
-          "ordinal": 28,
-          "type_info": "RecordArray"
-        },
-        {
-          "name": "modules!: Vec<(ModuleId, ModuleKind, bool)>",
-          "ordinal": 29,
-          "type_info": "RecordArray"
-        },
-        {
-          "name": "categories!: Vec<(CategoryId,)>",
-          "ordinal": 30,
-          "type_info": "RecordArray"
-        },
-        {
-          "name": "affiliations!: Vec<(AffiliationId,)>",
-          "ordinal": 31,
-          "type_info": "RecordArray"
-        },
-        {
-          "name": "age_ranges!: Vec<(AgeRangeId,)>",
-          "ordinal": 32,
-          "type_info": "RecordArray"
-        },
-        {
-          "name": "additional_resource!: Vec<(AddId, String, TypeId, Value)>",
-          "ordinal": 33,
-          "type_info": "RecordArray"
-        }
-      ],
-      "nullable": [
-        false,
-        false,
-        true,
-        true,
-        null,
-        false,
-        true,
-        true,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        true,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        true,
-        false,
-        false,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Int4"
-        ]
-      }
-    },
-    "query": "\nwith cte as (\n    select id      as \"jig_id\",\n           creator_id,\n           author_id,\n           liked_count,\n           play_count,\n           live_up_to_date,\n           case\n               when $2 = 0 then jig.draft_id\n               when $2 = 1 then jig.live_id\n               end as \"draft_or_live_id\",\n           published_at,\n           rating,\n           blocked,\n           curated\n    from jig\n    left join jig_play_count on jig_play_count.jig_id = jig.id\n    left join jig_admin_data \"admin\" on admin.jig_id = jig.id\n    where id = $1\n)\nselect cte.jig_id                                          as \"jig_id: JigId\",\n        display_name,\n        creator_id                                          as \"creator_id: UserId\",\n        author_id                                           as \"author_id: UserId\",\n        (select given_name || ' '::text || family_name\n        from user_profile\n        where user_profile.user_id = author_id)            as \"author_name\",\n        created_at,\n        updated_at,\n        published_at,\n        privacy_level                                       as \"privacy_level!: PrivacyLevel\",\n        language,\n        description,\n        translated_description                              as \"translated_description!: Json<HashMap<String, String>>\",\n        direction                                           as \"direction: TextDirection\",\n        display_score,\n        track_assessments,\n        drag_assist,\n        theme                                               as \"theme: ThemeId\",\n        audio_background                                    as \"audio_background: AudioBackground\",\n        liked_count,\n        play_count,\n        live_up_to_date,\n        locked,\n        other_keywords,\n        translated_keywords,\n        rating                                               as \"rating?: JigRating\",\n        blocked                                              as \"blocked\",\n        curated,\n        array(select row (unnest(audio_feedback_positive))) as \"audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>\",\n        array(select row (unnest(audio_feedback_negative))) as \"audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>\",\n        array(\n                select row (jig_data_module.id, kind, is_complete)\n                from jig_data_module\n                where jig_data_id = jig_data.id\n                order by \"index\"\n        )                                               as \"modules!: Vec<(ModuleId, ModuleKind, bool)>\",\n        array(select row (category_id)\n                from jig_data_category\n                where jig_data_id = cte.draft_or_live_id)     as \"categories!: Vec<(CategoryId,)>\",\n        array(select row (affiliation_id)\n                from jig_data_affiliation\n                where jig_data_id = cte.draft_or_live_id)     as \"affiliations!: Vec<(AffiliationId,)>\",\n        array(select row (age_range_id)\n                from jig_data_age_range\n                where jig_data_id = cte.draft_or_live_id)     as \"age_ranges!: Vec<(AgeRangeId,)>\",\n        array(\n                select row (jdar.id, jdar.display_name, resource_type_id, resource_content)\n                from jig_data_additional_resource \"jdar\"\n                where jdar.jig_data_id = cte.draft_or_live_id\n    )                                                    as \"additional_resource!: Vec<(AddId, String, TypeId, Value)>\"\nfrom jig_data\n         inner join cte on cte.draft_or_live_id = jig_data.id\n"
-  },
   "4fb49fe4ad3204755e0a09d701e36d421c6a6696509bd37c238b1a835e022d7b": {
     "describe": {
       "columns": [],
@@ -5219,6 +5300,27 @@
     },
     "query": "\nselect draft_id, live_id from jig where id = $1\n"
   },
+  "5f80e1587e107a868408269864c5d3a0eac7058a24171de0dd387a3ed38285ec": {
+    "describe": {
+      "columns": [
+        {
+          "name": "exists!",
+          "ordinal": 0,
+          "type_info": "Bool"
+        }
+      ],
+      "nullable": [
+        null
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\nselect exists (\n    select 1\n    from course_like\n    where\n        course_id = $1\n        and user_id = $2\n) as \"exists!\"\n    "
+  },
   "5ff5fa2a87043688acf1a71be7f3a293bd4cad618ed473b7ef536a116dabf50c": {
     "describe": {
       "columns": [],
@@ -5329,6 +5431,160 @@
       }
     },
     "query": "\ninsert into jig_data_additional_resource (jig_data_id, resource_type_id, resource_content, display_name)\nvalues ((select draft_id from jig where id = $1), $2, $3, $4)\nreturning id as \"id!: AdditionalResourceId\"\n        "
+  },
+  "63241f8e8294f070408e1796472a6b320a593f5cceb359900feff2d47e363493": {
+    "describe": {
+      "columns": [
+        {
+          "name": "course_id: CourseId",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "display_name",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "creator_id?: UserId",
+          "ordinal": 2,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "author_id?: UserId",
+          "ordinal": 3,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "author_name",
+          "ordinal": 4,
+          "type_info": "Text"
+        },
+        {
+          "name": "published_at",
+          "ordinal": 5,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "updated_at",
+          "ordinal": 6,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "privacy_level!: PrivacyLevel",
+          "ordinal": 7,
+          "type_info": "Int2"
+        },
+        {
+          "name": "language",
+          "ordinal": 8,
+          "type_info": "Text"
+        },
+        {
+          "name": "description",
+          "ordinal": 9,
+          "type_info": "Text"
+        },
+        {
+          "name": "translated_description!: Json<HashMap<String, String>>",
+          "ordinal": 10,
+          "type_info": "Jsonb"
+        },
+        {
+          "name": "likes",
+          "ordinal": 11,
+          "type_info": "Int8"
+        },
+        {
+          "name": "plays",
+          "ordinal": 12,
+          "type_info": "Int8"
+        },
+        {
+          "name": "live_up_to_date",
+          "ordinal": 13,
+          "type_info": "Bool"
+        },
+        {
+          "name": "other_keywords",
+          "ordinal": 14,
+          "type_info": "Text"
+        },
+        {
+          "name": "translated_keywords",
+          "ordinal": 15,
+          "type_info": "Text"
+        },
+        {
+          "name": "is_liked!",
+          "ordinal": 16,
+          "type_info": "Bool"
+        },
+        {
+          "name": "cover?: (ModuleId, ModuleKind, bool)",
+          "ordinal": 17,
+          "type_info": "Record"
+        },
+        {
+          "name": "categories!: Vec<(CategoryId,)>",
+          "ordinal": 18,
+          "type_info": "RecordArray"
+        },
+        {
+          "name": "affiliations!: Vec<(AffiliationId,)>",
+          "ordinal": 19,
+          "type_info": "RecordArray"
+        },
+        {
+          "name": "age_ranges!: Vec<(AgeRangeId,)>",
+          "ordinal": 20,
+          "type_info": "RecordArray"
+        },
+        {
+          "name": "additional_resource!: Vec<(AddId, String, TypeId, Value)>",
+          "ordinal": 21,
+          "type_info": "RecordArray"
+        },
+        {
+          "name": "items!: Vec<(JigId,)>",
+          "ordinal": 22,
+          "type_info": "RecordArray"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        true,
+        true,
+        null,
+        true,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Int4",
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\nwith cte as (\n    select id      as \"course_id\",\n           creator_id,\n           author_id,\n           likes,\n           plays,\n           live_up_to_date,\n           case\n               when $2 = 0 then course.draft_id\n               when $2 = 1 then course.live_id\n               end as \"draft_or_live_id\",\n           published_at\n    from course\n    where id = $1\n)\nselect cte.course_id                                          as \"course_id: CourseId\",\n       display_name,\n       creator_id                                             as \"creator_id?: UserId\",\n       author_id                                              as \"author_id?: UserId\",\n       (select given_name || ' '::text || family_name\n        from user_profile\n        where user_profile.user_id = author_id)            as \"author_name\",\n       published_at,\n       updated_at,\n       privacy_level                                       as \"privacy_level!: PrivacyLevel\",\n       language,\n       description,\n       translated_description                              as \"translated_description!: Json<HashMap<String, String>>\",\n       likes,\n       plays,\n       live_up_to_date,\n       other_keywords,\n       translated_keywords,\n       exists(select 1 from course_like where course_id = $1 and user_id = $3) as \"is_liked!\",\n       (\n            select row(course_data_module.id, kind, is_complete)\n            from course_data_module\n            where course_data_id = cte.draft_or_live_id and \"index\" = 0\n            order by \"index\"\n        )                                                   as \"cover?: (ModuleId, ModuleKind, bool)\",\n       array(select row (category_id)\n             from course_data_category\n             where course_data_id = cte.draft_or_live_id)     as \"categories!: Vec<(CategoryId,)>\",\n       array(select row (affiliation_id)\n             from course_data_affiliation\n             where course_data_id = cte.draft_or_live_id)     as \"affiliations!: Vec<(AffiliationId,)>\",\n       array(select row (age_range_id)\n             from course_data_age_range\n             where course_data_id = cte.draft_or_live_id)     as \"age_ranges!: Vec<(AgeRangeId,)>\",\n       array(\n             select row (jdar.id, jdar.display_name, resource_type_id, resource_content)\n             from course_data_resource \"jdar\"\n             where jdar.course_data_id = cte.draft_or_live_id\n       )                                                    as \"additional_resource!: Vec<(AddId, String, TypeId, Value)>\",\n       array(\n           select row(jig_id)\n           from course_data_jig\n           where course_data_id = cte.draft_or_live_id\n           order by \"index\"\n       )                                                     as \"items!: Vec<(JigId,)>\"\nfrom course_data\n         inner join cte on cte.draft_or_live_id = course_data.id\n"
   },
   "63282a245bbfff4db34ea00a9f53cf8f6cbbd26ff4106d3b53f3edf3e48197d0": {
     "describe": {
@@ -5443,6 +5699,87 @@
       }
     },
     "query": "\nwith delete as (\n        delete from user_font\n    where user_id = $1 and index = $2\n)\nselect 1 as discard\nfrom user_font\nwhere user_id = $1 and index > $2\nfor update\n        "
+  },
+  "64f01e53a838b6e910725d44ac1c71ee2d33e6aad13cb04c923cc65c98e7ee65": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id!: CourseId",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "creator_id?: UserId",
+          "ordinal": 1,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "author_id?: UserId",
+          "ordinal": 2,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "author_name",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "live_id!",
+          "ordinal": 4,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "draft_id!",
+          "ordinal": 5,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "published_at",
+          "ordinal": 6,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "likes!",
+          "ordinal": 7,
+          "type_info": "Int8"
+        },
+        {
+          "name": "plays!",
+          "ordinal": 8,
+          "type_info": "Int8"
+        },
+        {
+          "name": "live_up_to_date!",
+          "ordinal": 9,
+          "type_info": "Bool"
+        },
+        {
+          "name": "is_liked!",
+          "ordinal": 10,
+          "type_info": "Bool"
+        }
+      ],
+      "nullable": [
+        false,
+        true,
+        true,
+        null,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        null
+      ],
+      "parameters": {
+        "Left": [
+          "UuidArray",
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\nselect course.id                                       as \"id!: CourseId\",\n       creator_id                               as \"creator_id?: UserId\",\n       author_id                                as \"author_id?: UserId\",\n       (select given_name || ' '::text || family_name\n        from user_profile\n        where user_profile.user_id = author_id) as \"author_name\",\n       live_id                                  as \"live_id!\",\n       draft_id                                 as \"draft_id!\",\n       published_at,\n       likes                                    as \"likes!\",\n       plays                                    as \"plays!\",\n       live_up_to_date                          as \"live_up_to_date!\",\n       exists(select 1 from course_like where course_id = course.id and user_id = $2) as \"is_liked!\"\nfrom course\ninner join unnest($1::uuid[])\n    with ordinality t(id, ord) using (id)\norder by ord asc\n    "
   },
   "65948829df799e30f02233bf13324d6529c60ac67d8b890ff9a1ff67ba4675c4": {
     "describe": {
@@ -6458,6 +6795,32 @@
     },
     "query": "\nupdate resource_data\nset last_synced_at = now()\nwhere resource_data.id = any (select live_id from resource where resource.id = any ($1))\n"
   },
+  "7d3b39b739ff8d2bbf16dca9749521ebc130be37e4525f91deaaf16187ab2016": {
+    "describe": {
+      "columns": [
+        {
+          "name": "author_id: UserId",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "published_at?",
+          "ordinal": 1,
+          "type_info": "Timestamptz"
+        }
+      ],
+      "nullable": [
+        true,
+        true
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\nselect author_id    as \"author_id: UserId\",\n       published_at  as \"published_at?\"\nfrom course\nwhere id = $1\n    "
+  },
   "7de388b21267e45c30f82ed5f18a433423d535b7e22a752bcd95c82fc050190e": {
     "describe": {
       "columns": [
@@ -6767,80 +7130,6 @@
     },
     "query": "update image_metadata set last_synced_at = now() where id = any($1)"
   },
-  "842d4817e171e316e0f037914f41150ce7ca4719a49ff10c1661e19ef9daf024": {
-    "describe": {
-      "columns": [
-        {
-          "name": "id!: CourseId",
-          "ordinal": 0,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "creator_id?: UserId",
-          "ordinal": 1,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "author_id?: UserId",
-          "ordinal": 2,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "author_name",
-          "ordinal": 3,
-          "type_info": "Text"
-        },
-        {
-          "name": "live_id!",
-          "ordinal": 4,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "draft_id!",
-          "ordinal": 5,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "published_at",
-          "ordinal": 6,
-          "type_info": "Timestamptz"
-        },
-        {
-          "name": "likes!",
-          "ordinal": 7,
-          "type_info": "Int8"
-        },
-        {
-          "name": "plays!",
-          "ordinal": 8,
-          "type_info": "Int8"
-        },
-        {
-          "name": "live_up_to_date!",
-          "ordinal": 9,
-          "type_info": "Bool"
-        }
-      ],
-      "nullable": [
-        false,
-        true,
-        true,
-        null,
-        false,
-        false,
-        true,
-        false,
-        false,
-        false
-      ],
-      "parameters": {
-        "Left": [
-          "UuidArray"
-        ]
-      }
-    },
-    "query": "\nselect course.id                                       as \"id!: CourseId\",\n       creator_id                               as \"creator_id?: UserId\",\n       author_id                                as \"author_id?: UserId\",\n       (select given_name || ' '::text || family_name\n        from user_profile\n        where user_profile.user_id = author_id) as \"author_name\",\n       live_id                                  as \"live_id!\",\n       draft_id                                 as \"draft_id!\",\n       published_at,\n       likes                                    as \"likes!\",\n       plays                                    as \"plays!\",\n       live_up_to_date                          as \"live_up_to_date!\"\nfrom course\ninner join unnest($1::uuid[])\n    with ordinality t(id, ord) using (id)\norder by ord asc\n    "
-  },
   "84519449aef6978269fca20ecf493b800916711dc260fff2b2fdc537842fc947": {
     "describe": {
       "columns": [
@@ -7126,6 +7415,232 @@
     },
     "query": "select exists(select 1 from user_auth_basic where email = lower($1)) as \"exists!\""
   },
+  "8b891039c7cb54292727cf637293cbc896b32d0269f33a530e343c6c64b75117": {
+    "describe": {
+      "columns": [
+        {
+          "name": "jig_id: JigId",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "display_name",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "creator_id: UserId",
+          "ordinal": 2,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "author_id: UserId",
+          "ordinal": 3,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "author_name",
+          "ordinal": 4,
+          "type_info": "Text"
+        },
+        {
+          "name": "created_at",
+          "ordinal": 5,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "updated_at",
+          "ordinal": 6,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "published_at",
+          "ordinal": 7,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "privacy_level!: PrivacyLevel",
+          "ordinal": 8,
+          "type_info": "Int2"
+        },
+        {
+          "name": "language",
+          "ordinal": 9,
+          "type_info": "Text"
+        },
+        {
+          "name": "description",
+          "ordinal": 10,
+          "type_info": "Text"
+        },
+        {
+          "name": "translated_description!: Json<HashMap<String, String>>",
+          "ordinal": 11,
+          "type_info": "Jsonb"
+        },
+        {
+          "name": "direction: TextDirection",
+          "ordinal": 12,
+          "type_info": "Int2"
+        },
+        {
+          "name": "display_score",
+          "ordinal": 13,
+          "type_info": "Bool"
+        },
+        {
+          "name": "track_assessments",
+          "ordinal": 14,
+          "type_info": "Bool"
+        },
+        {
+          "name": "drag_assist",
+          "ordinal": 15,
+          "type_info": "Bool"
+        },
+        {
+          "name": "theme: ThemeId",
+          "ordinal": 16,
+          "type_info": "Int2"
+        },
+        {
+          "name": "audio_background: AudioBackground",
+          "ordinal": 17,
+          "type_info": "Int2"
+        },
+        {
+          "name": "liked_count",
+          "ordinal": 18,
+          "type_info": "Int8"
+        },
+        {
+          "name": "play_count",
+          "ordinal": 19,
+          "type_info": "Int8"
+        },
+        {
+          "name": "live_up_to_date",
+          "ordinal": 20,
+          "type_info": "Bool"
+        },
+        {
+          "name": "is_liked!",
+          "ordinal": 21,
+          "type_info": "Bool"
+        },
+        {
+          "name": "locked",
+          "ordinal": 22,
+          "type_info": "Bool"
+        },
+        {
+          "name": "other_keywords",
+          "ordinal": 23,
+          "type_info": "Text"
+        },
+        {
+          "name": "translated_keywords",
+          "ordinal": 24,
+          "type_info": "Text"
+        },
+        {
+          "name": "rating?: JigRating",
+          "ordinal": 25,
+          "type_info": "Int2"
+        },
+        {
+          "name": "blocked",
+          "ordinal": 26,
+          "type_info": "Bool"
+        },
+        {
+          "name": "curated",
+          "ordinal": 27,
+          "type_info": "Bool"
+        },
+        {
+          "name": "audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>",
+          "ordinal": 28,
+          "type_info": "RecordArray"
+        },
+        {
+          "name": "audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>",
+          "ordinal": 29,
+          "type_info": "RecordArray"
+        },
+        {
+          "name": "modules!: Vec<(ModuleId, ModuleKind, bool)>",
+          "ordinal": 30,
+          "type_info": "RecordArray"
+        },
+        {
+          "name": "categories!: Vec<(CategoryId,)>",
+          "ordinal": 31,
+          "type_info": "RecordArray"
+        },
+        {
+          "name": "affiliations!: Vec<(AffiliationId,)>",
+          "ordinal": 32,
+          "type_info": "RecordArray"
+        },
+        {
+          "name": "age_ranges!: Vec<(AgeRangeId,)>",
+          "ordinal": 33,
+          "type_info": "RecordArray"
+        },
+        {
+          "name": "additional_resource!: Vec<(AddId, String, TypeId, Value)>",
+          "ordinal": 34,
+          "type_info": "RecordArray"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        true,
+        true,
+        null,
+        false,
+        true,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        null,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Int4",
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\nwith cte as (\n    select id      as \"jig_id\",\n           creator_id,\n           author_id,\n           liked_count,\n           play_count,\n           live_up_to_date,\n           case\n               when $2 = 0 then jig.draft_id\n               when $2 = 1 then jig.live_id\n               end as \"draft_or_live_id\",\n           published_at,\n           rating,\n           blocked,\n           curated\n    from jig\n    left join jig_play_count on jig_play_count.jig_id = jig.id\n    left join jig_admin_data \"admin\" on admin.jig_id = jig.id\n    where id = $1\n)\nselect cte.jig_id                                          as \"jig_id: JigId\",\n        display_name,\n        creator_id                                          as \"creator_id: UserId\",\n        author_id                                           as \"author_id: UserId\",\n        (select given_name || ' '::text || family_name\n        from user_profile\n        where user_profile.user_id = author_id)            as \"author_name\",\n        created_at,\n        updated_at,\n        published_at,\n        privacy_level                                       as \"privacy_level!: PrivacyLevel\",\n        language,\n        description,\n        translated_description                              as \"translated_description!: Json<HashMap<String, String>>\",\n        direction                                           as \"direction: TextDirection\",\n        display_score,\n        track_assessments,\n        drag_assist,\n        theme                                               as \"theme: ThemeId\",\n        audio_background                                    as \"audio_background: AudioBackground\",\n        liked_count,\n        play_count,\n        live_up_to_date,\n        exists(select 1 from jig_like where jig_id = $1 and user_id = $3)    as \"is_liked!\", \n        locked,\n        other_keywords,\n        translated_keywords,\n        rating                                               as \"rating?: JigRating\",\n        blocked                                              as \"blocked\",\n        curated,\n        array(select row (unnest(audio_feedback_positive))) as \"audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>\",\n        array(select row (unnest(audio_feedback_negative))) as \"audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>\",\n        array(\n                select row (jig_data_module.id, kind, is_complete)\n                from jig_data_module\n                where jig_data_id = jig_data.id\n                order by \"index\"\n        )                                               as \"modules!: Vec<(ModuleId, ModuleKind, bool)>\",\n        array(select row (category_id)\n                from jig_data_category\n                where jig_data_id = cte.draft_or_live_id)     as \"categories!: Vec<(CategoryId,)>\",\n        array(select row (affiliation_id)\n                from jig_data_affiliation\n                where jig_data_id = cte.draft_or_live_id)     as \"affiliations!: Vec<(AffiliationId,)>\",\n        array(select row (age_range_id)\n                from jig_data_age_range\n                where jig_data_id = cte.draft_or_live_id)     as \"age_ranges!: Vec<(AgeRangeId,)>\",\n        array(\n                select row (jdar.id, jdar.display_name, resource_type_id, resource_content)\n                from jig_data_additional_resource \"jdar\"\n                where jdar.jig_data_id = cte.draft_or_live_id\n    )                                                    as \"additional_resource!: Vec<(AddId, String, TypeId, Value)>\"\nfrom jig_data\n         inner join cte on cte.draft_or_live_id = jig_data.id\n"
+  },
   "8b89d31edede1436cf8618bf8a9e27a5ef5e07d0958af9f6b7bab0ec7f2088cf": {
     "describe": {
       "columns": [
@@ -7258,6 +7773,105 @@
     },
     "query": "insert into web_media_library_url (media_id, media_url) values ($1, $2) on conflict (media_id, media_url) do nothing"
   },
+  "8ea552fcf9bc0e870cf55361b0328fee191991acb2f5ee7ab57fdb1e5b1fab0c": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id!: ResourceId",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "creator_id: UserId",
+          "ordinal": 1,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "author_id: UserId",
+          "ordinal": 2,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "author_name",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "live_id!",
+          "ordinal": 4,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "draft_id!",
+          "ordinal": 5,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "published_at",
+          "ordinal": 6,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "likes!",
+          "ordinal": 7,
+          "type_info": "Int8"
+        },
+        {
+          "name": "views!",
+          "ordinal": 8,
+          "type_info": "Int8"
+        },
+        {
+          "name": "live_up_to_date!",
+          "ordinal": 9,
+          "type_info": "Bool"
+        },
+        {
+          "name": "rating?: ResourceRating",
+          "ordinal": 10,
+          "type_info": "Int2"
+        },
+        {
+          "name": "is_liked!",
+          "ordinal": 11,
+          "type_info": "Bool"
+        },
+        {
+          "name": "blocked!",
+          "ordinal": 12,
+          "type_info": "Bool"
+        },
+        {
+          "name": "curated!",
+          "ordinal": 13,
+          "type_info": "Bool"
+        }
+      ],
+      "nullable": [
+        false,
+        true,
+        true,
+        null,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        true,
+        null,
+        false,
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "UuidArray",
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\nselect resource.id                                       as \"id!: ResourceId\",\n       creator_id                               as \"creator_id: UserId\",\n       author_id                                as \"author_id: UserId\",\n       (select given_name || ' '::text || family_name\n        from user_profile\n        where user_profile.user_id = author_id) as \"author_name\",\n       live_id                                  as \"live_id!\",\n       draft_id                                 as \"draft_id!\",\n       published_at,\n       likes                                     as \"likes!\",\n       views                                    as \"views!\",\n       live_up_to_date                          as \"live_up_to_date!\",\n       rating                                   as \"rating?: ResourceRating\",\n       exists(select 1 from resource_like where resource_id = resource.id and user_id = $2) as \"is_liked!\",\n       blocked                                  as \"blocked!\",\n       curated                                  as \"curated!\"\nfrom resource\ninner join unnest($1::uuid[])\n    with ordinality t(id, ord) using (id)\ninner join resource_admin_data \"admin\" on admin.resource_id = resource.id\norder by ord asc\n    "
+  },
   "8ec1ad8eb682a4f1fc2acafd761c7f043d02e675c1182014bcfb3196c63aaee2": {
     "describe": {
       "columns": [],
@@ -7368,6 +7982,31 @@
       }
     },
     "query": "\nupdate pro_dev_data_unit\nset index = index - 1\nwhere pro_dev_data_id = $1\n  and index > $2\n"
+  },
+  "919b222454362d32275ccbe3582b3ac0e743b64d930d8c52c1170340834f3b76": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\nupdate course\nset plays = plays + 1\nwhere id = $1;\n            "
+  },
+  "927db96321baca9ba81e6ea1a546cf396140c976e4b808e4e5bb4328503d6322": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\ndelete from course_like\nwhere course_id = $1 and user_id = $2\n    "
   },
   "932508742699d5ebb198b02fc4f4bcaa9fd0e50c4206e6536279163533526826": {
     "describe": {
@@ -7726,189 +8365,6 @@
     },
     "query": "\ndelete from jig_data where id = $1\n    "
   },
-  "984afe6ac6af82e80b7a47196534fc32af21759bbc6dc64ede9c0351a0bda521": {
-    "describe": {
-      "columns": [
-        {
-          "name": "resource_id: ResourceId",
-          "ordinal": 0,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "privacy_level: PrivacyLevel",
-          "ordinal": 1,
-          "type_info": "Int2"
-        },
-        {
-          "name": "creator_id?: UserId",
-          "ordinal": 2,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "author_id?: UserId",
-          "ordinal": 3,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "author_name",
-          "ordinal": 4,
-          "type_info": "Text"
-        },
-        {
-          "name": "created_at",
-          "ordinal": 5,
-          "type_info": "Timestamptz"
-        },
-        {
-          "name": "updated_at",
-          "ordinal": 6,
-          "type_info": "Timestamptz"
-        },
-        {
-          "name": "published_at",
-          "ordinal": 7,
-          "type_info": "Timestamptz"
-        },
-        {
-          "name": "likes",
-          "ordinal": 8,
-          "type_info": "Int8"
-        },
-        {
-          "name": "views",
-          "ordinal": 9,
-          "type_info": "Int8"
-        },
-        {
-          "name": "live_up_to_date",
-          "ordinal": 10,
-          "type_info": "Bool"
-        },
-        {
-          "name": "display_name!",
-          "ordinal": 11,
-          "type_info": "Text"
-        },
-        {
-          "name": "language!",
-          "ordinal": 12,
-          "type_info": "Text"
-        },
-        {
-          "name": "description!",
-          "ordinal": 13,
-          "type_info": "Text"
-        },
-        {
-          "name": "translated_description!: Json<HashMap<String,String>>",
-          "ordinal": 14,
-          "type_info": "Jsonb"
-        },
-        {
-          "name": "draft_or_live!: DraftOrLive",
-          "ordinal": 15,
-          "type_info": "Int2"
-        },
-        {
-          "name": "cover?: (ModuleId, ModuleKind, bool)",
-          "ordinal": 16,
-          "type_info": "Record"
-        },
-        {
-          "name": "categories!: Vec<(CategoryId,)>",
-          "ordinal": 17,
-          "type_info": "RecordArray"
-        },
-        {
-          "name": "affiliations!: Vec<(AffiliationId,)>",
-          "ordinal": 18,
-          "type_info": "RecordArray"
-        },
-        {
-          "name": "age_ranges!: Vec<(AgeRangeId,)>",
-          "ordinal": 19,
-          "type_info": "RecordArray"
-        },
-        {
-          "name": "additional_resource!: Vec<(AddId, String, TypeId, Value)>",
-          "ordinal": 20,
-          "type_info": "RecordArray"
-        },
-        {
-          "name": "locked!",
-          "ordinal": 21,
-          "type_info": "Bool"
-        },
-        {
-          "name": "other_keywords!",
-          "ordinal": 22,
-          "type_info": "Text"
-        },
-        {
-          "name": "translated_keywords!",
-          "ordinal": 23,
-          "type_info": "Text"
-        },
-        {
-          "name": "rating!: Option<ResourceRating>",
-          "ordinal": 24,
-          "type_info": "Int2"
-        },
-        {
-          "name": "blocked!",
-          "ordinal": 25,
-          "type_info": "Bool"
-        },
-        {
-          "name": "curated!",
-          "ordinal": 26,
-          "type_info": "Bool"
-        }
-      ],
-      "nullable": [
-        false,
-        false,
-        true,
-        true,
-        null,
-        false,
-        true,
-        true,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        true,
-        null,
-        null,
-        null,
-        null,
-        null,
-        false,
-        false,
-        false,
-        true,
-        false,
-        false
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Bool",
-          "Int2Array",
-          "UuidArray",
-          "Int2",
-          "Int4",
-          "Int4",
-          "Int4"
-        ]
-      }
-    },
-    "query": "\nwith cte as (\n    select array_agg(rd.id)\n    from resource_data \"rd\"\n          inner join resource on (draft_id = rd.id or (live_id = rd.id and rd.last_synced_at is not null and published_at is not null))\n          left join resource_admin_data \"admin\" on admin.resource_id = resource.id\n          left join resource_data_resource \"rdr\" on rd.id = rdr.resource_data_id\n    where (author_id = $1 or $1 is null)\n        and (blocked = $2 or $2 is null)\n        and (rd.privacy_level = any($3) or $3 = array[]::smallint[])\n        and (rdr.resource_type_id = any($4) or $4 = array[]::uuid[])\n        and (draft_or_live = $5 or $5 is null)\n    group by updated_at, created_at, resource.published_at, admin.resource_id\n    order by case when $6 = 0 then created_at\n        when $6 = 1 then published_at\n        else coalesce(updated_at, created_at)\n  end desc, resource_id\n),\ncte1 as (\n    select * from unnest(array((select cte.array_agg[1] from cte))) with ordinality t(id\n   , ord) order by ord\n)\nselect resource.id                                              as \"resource_id: ResourceId\",\n    privacy_level                                       as \"privacy_level: PrivacyLevel\",\n    creator_id                                          as \"creator_id?: UserId\",\n    author_id                                           as \"author_id?: UserId\",\n    (select given_name || ' '::text || family_name\n        from user_profile\n     where user_profile.user_id = author_id)            as \"author_name\",\n    created_at,\n    updated_at,\n    published_at,\n    likes,\n    views,\n    live_up_to_date,\n   display_name                                                                  as \"display_name!\",\n   language                                                                      as \"language!\",\n   description                                                                   as \"description!\",\n   translated_description                                                        as \"translated_description!: Json<HashMap<String,String>>\",\n   draft_or_live                                                                 as \"draft_or_live!: DraftOrLive\",\n   (\n       select row(resource_data_module.id, kind, is_complete)\n       from resource_data_module\n       where resource_data_id = resource_data.id\n    )                                               as \"cover?: (ModuleId, ModuleKind, bool)\",\n   array(select row (category_id)\n         from resource_data_category\n         where resource_data_id = resource_data.id)     as \"categories!: Vec<(CategoryId,)>\",\n   array(select row (affiliation_id)\n         from resource_data_affiliation\n         where resource_data_id = resource_data.id)     as \"affiliations!: Vec<(AffiliationId,)>\",\n   array(select row (age_range_id)\n         from resource_data_age_range\n         where resource_data_id = resource_data.id)     as \"age_ranges!: Vec<(AgeRangeId,)>\",\n   array(\n            select row (rdr.id, rdr.display_name, resource_type_id, resource_content)\n            from resource_data_resource \"rdr\"\n            where rdr.resource_data_id= resource_data.id\n        )                                               as \"additional_resource!: Vec<(AddId, String, TypeId, Value)>\",\n   locked                                     as \"locked!\",\n   other_keywords                             as \"other_keywords!\",\n   translated_keywords                        as \"translated_keywords!\",\n   rating                                     as \"rating!: Option<ResourceRating>\",\n   blocked                                    as \"blocked!\",\n   curated                                    as \"curated!\"\nfrom cte1\ninner join resource_data on cte1.id = resource_data.id\ninner join resource on (\n    resource_data.id = resource.draft_id\n    or (\n        resource_data.id = resource.live_id\n        and last_synced_at is not null\n        and resource.published_at is not null\n    )\n)\nleft join resource_admin_data \"admin\" on admin.resource_id = resource.id\nwhere ord > (1 * $7 * $8)\norder by ord asc\nlimit $8\n"
-  },
   "986130a83ea19f3782aa5e5c1c0a0a260c515e4aad15cc17d63aba20db572b2f": {
     "describe": {
       "columns": [],
@@ -7933,237 +8389,6 @@
       }
     },
     "query": "\nupdate resource\nset views = views + 1\nwhere id = $1;\n            "
-  },
-  "9902922f0877a5d81034f04ea2664878a139b49120662cc82d5af87d190478ce": {
-    "describe": {
-      "columns": [
-        {
-          "name": "jig_id: JigId",
-          "ordinal": 0,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "privacy_level: PrivacyLevel",
-          "ordinal": 1,
-          "type_info": "Int2"
-        },
-        {
-          "name": "creator_id?: UserId",
-          "ordinal": 2,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "author_id?: UserId",
-          "ordinal": 3,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "author_name",
-          "ordinal": 4,
-          "type_info": "Text"
-        },
-        {
-          "name": "created_at",
-          "ordinal": 5,
-          "type_info": "Timestamptz"
-        },
-        {
-          "name": "updated_at",
-          "ordinal": 6,
-          "type_info": "Timestamptz"
-        },
-        {
-          "name": "published_at",
-          "ordinal": 7,
-          "type_info": "Timestamptz"
-        },
-        {
-          "name": "liked_count",
-          "ordinal": 8,
-          "type_info": "Int8"
-        },
-        {
-          "name": "live_up_to_date",
-          "ordinal": 9,
-          "type_info": "Bool"
-        },
-        {
-          "name": "play_count!",
-          "ordinal": 10,
-          "type_info": "Int8"
-        },
-        {
-          "name": "display_name!",
-          "ordinal": 11,
-          "type_info": "Text"
-        },
-        {
-          "name": "language!",
-          "ordinal": 12,
-          "type_info": "Text"
-        },
-        {
-          "name": "description!",
-          "ordinal": 13,
-          "type_info": "Text"
-        },
-        {
-          "name": "translated_description!: Json<HashMap<String,String>>",
-          "ordinal": 14,
-          "type_info": "Jsonb"
-        },
-        {
-          "name": "direction!: TextDirection",
-          "ordinal": 15,
-          "type_info": "Int2"
-        },
-        {
-          "name": "display_score!",
-          "ordinal": 16,
-          "type_info": "Bool"
-        },
-        {
-          "name": "track_assessments!",
-          "ordinal": 17,
-          "type_info": "Bool"
-        },
-        {
-          "name": "drag_assist!",
-          "ordinal": 18,
-          "type_info": "Bool"
-        },
-        {
-          "name": "theme!: ThemeId",
-          "ordinal": 19,
-          "type_info": "Int2"
-        },
-        {
-          "name": "audio_background!: Option<AudioBackground>",
-          "ordinal": 20,
-          "type_info": "Int2"
-        },
-        {
-          "name": "draft_or_live!: DraftOrLive",
-          "ordinal": 21,
-          "type_info": "Int2"
-        },
-        {
-          "name": "audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>",
-          "ordinal": 22,
-          "type_info": "RecordArray"
-        },
-        {
-          "name": "audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>",
-          "ordinal": 23,
-          "type_info": "RecordArray"
-        },
-        {
-          "name": "modules!: Vec<(ModuleId, ModuleKind, bool)>",
-          "ordinal": 24,
-          "type_info": "RecordArray"
-        },
-        {
-          "name": "categories!: Vec<(CategoryId,)>",
-          "ordinal": 25,
-          "type_info": "RecordArray"
-        },
-        {
-          "name": "affiliations!: Vec<(AffiliationId,)>",
-          "ordinal": 26,
-          "type_info": "RecordArray"
-        },
-        {
-          "name": "age_ranges!: Vec<(AgeRangeId,)>",
-          "ordinal": 27,
-          "type_info": "RecordArray"
-        },
-        {
-          "name": "additional_resource!: Vec<(AddId, String, TypeId, Value)>",
-          "ordinal": 28,
-          "type_info": "RecordArray"
-        },
-        {
-          "name": "locked!",
-          "ordinal": 29,
-          "type_info": "Bool"
-        },
-        {
-          "name": "other_keywords!",
-          "ordinal": 30,
-          "type_info": "Text"
-        },
-        {
-          "name": "translated_keywords!",
-          "ordinal": 31,
-          "type_info": "Text"
-        },
-        {
-          "name": "rating!: Option<JigRating>",
-          "ordinal": 32,
-          "type_info": "Int2"
-        },
-        {
-          "name": "blocked!",
-          "ordinal": 33,
-          "type_info": "Bool"
-        },
-        {
-          "name": "curated!",
-          "ordinal": 34,
-          "type_info": "Bool"
-        }
-      ],
-      "nullable": [
-        false,
-        false,
-        true,
-        true,
-        null,
-        false,
-        true,
-        true,
-        false,
-        false,
-        null,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        true,
-        true,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        false,
-        false,
-        false,
-        true,
-        false,
-        false
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Int2",
-          "Bool",
-          "Int2Array",
-          "UuidArray",
-          "Int4",
-          "Int4",
-          "Int4"
-        ]
-      }
-    },
-    "query": "\nwith cte as (\n    select array_agg(jd.id)\n    from jig_data \"jd\"\n          inner join jig on (draft_id = jd.id or (live_id = jd.id and jd.last_synced_at is not null and published_at is not null))\n          left join jig_admin_data \"admin\" on admin.jig_id = jig.id\n          left join jig_data_additional_resource \"resource\" on jd.id = resource.jig_data_id\n    where (author_id = $1 or $1 is null) \n        and (jd.draft_or_live = $2 or $2 is null)\n        and (blocked = $3 or $3 is null)\n        and (jd.privacy_level = any($4) or $4 = array[]::smallint[])\n        and (resource.resource_type_id = any($5) or $5 = array[]::uuid[])\n    group by updated_at, created_at, jig.published_at, admin.jig_id\n    order by case when $6 = 0 then created_at\n        when $6 = 1 then published_at\n        else coalesce(updated_at, created_at)\n  end desc, jig_id\n),\ncte1 as (\n    select * from unnest(array((select cte.array_agg[1] from cte))) with ordinality t(id\n   , ord) order by ord\n)\nselect jig.id                                              as \"jig_id: JigId\",\n    privacy_level                                       as \"privacy_level: PrivacyLevel\",\n    creator_id                                          as \"creator_id?: UserId\",\n    author_id                                           as \"author_id?: UserId\",\n    (select given_name || ' '::text || family_name\n        from user_profile\n     where user_profile.user_id = author_id)            as \"author_name\",\n    created_at,\n    updated_at,\n    published_at,\n    liked_count,\n    live_up_to_date,\n    (\n         select play_count\n         from jig_play_count\n         where jig_play_count.jig_id = jig.id\n    )                                                   as \"play_count!\",\n   display_name                                                                  as \"display_name!\",\n   language                                                                      as \"language!\",\n   description                                                                   as \"description!\",\n   translated_description                                                        as \"translated_description!: Json<HashMap<String,String>>\",\n   direction                                                                     as \"direction!: TextDirection\",\n   display_score                                                                 as \"display_score!\",\n   track_assessments                                                             as \"track_assessments!\",\n   drag_assist                                                                   as \"drag_assist!\",\n   theme                                                                         as \"theme!: ThemeId\",\n   audio_background                                                              as \"audio_background!: Option<AudioBackground>\",\n   draft_or_live                                                                 as \"draft_or_live!: DraftOrLive\",\n   array(select row (unnest(audio_feedback_positive)))                           as \"audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>\",\n   array(select row (unnest(audio_feedback_negative)))                           as \"audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>\",\n   array(\n           select row (jig_data_module.id, kind, is_complete)\n           from jig_data_module\n           where jig_data_id = jig_data.id\n           order by \"index\"\n    )                                               as \"modules!: Vec<(ModuleId, ModuleKind, bool)>\",\n   array(select row (category_id)\n         from jig_data_category\n         where jig_data_id = jig_data.id)     as \"categories!: Vec<(CategoryId,)>\",\n   array(select row (affiliation_id)\n         from jig_data_affiliation\n         where jig_data_id = jig_data.id)     as \"affiliations!: Vec<(AffiliationId,)>\",\n   array(select row (age_range_id)\n         from jig_data_age_range\n         where jig_data_id = jig_data.id)     as \"age_ranges!: Vec<(AgeRangeId,)>\",\n   array(\n            select row (jdar.id, jdar.display_name, resource_type_id, resource_content)\n            from jig_data_additional_resource \"jdar\"\n            where jdar.jig_data_id = jig_data.id\n        )                                               as \"additional_resource!: Vec<(AddId, String, TypeId, Value)>\",\n   locked                                     as \"locked!\",\n   other_keywords                             as \"other_keywords!\",\n   translated_keywords                        as \"translated_keywords!\",\n   rating                                     as \"rating!: Option<JigRating>\",\n   blocked                                    as \"blocked!\",\n   curated                                    as \"curated!\"\nfrom cte1\ninner join jig_data on cte1.id = jig_data.id\ninner join jig on (\n    jig_data.id = jig.draft_id\n    or (\n        jig_data.id = jig.live_id\n        and last_synced_at is not null\n        and jig.published_at is not null\n    )\n)\nleft join jig_admin_data \"admin\" on admin.jig_id = jig.id\nwhere ord > (1 * $7 * $8)\norder by ord asc\nlimit $8\n"
   },
   "99fa41555d59f16f6c77672a3282c49bda64b93672deb98569dc677a6f987989": {
     "describe": {
@@ -8227,6 +8452,26 @@
       }
     },
     "query": "\n insert into course_data_module (\"index\", course_data_id, kind, is_complete, contents)\n select \"index\", $2 as \"course_id\", kind, is_complete, contents\n from course_data_module\n where course_data_id = $1\n            "
+  },
+  "9a3997c4126e05a79d792f8243b525964a40cd0cb6f4039335efc1a7ecc3790a": {
+    "describe": {
+      "columns": [
+        {
+          "name": "published_at?",
+          "ordinal": 0,
+          "type_info": "Timestamptz"
+        }
+      ],
+      "nullable": [
+        true
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\nselect published_at  as \"published_at?\"\nfrom course\nwhere id = $1\n    "
   },
   "9b23b8bffa20014d6e11cc9e5b6ebae981c9c32804ee3550f6731daff43883cf": {
     "describe": {
@@ -11138,163 +11383,6 @@
     },
     "query": "insert into user_pdf_upload (pdf_id) values($1)"
   },
-  "cf03b8d89f6ef9832c81cd6d4ed7ad1a1d878101bde3c4c287d3cb056d9efdd3": {
-    "describe": {
-      "columns": [
-        {
-          "name": "course_id: CourseId",
-          "ordinal": 0,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "privacy_level: PrivacyLevel",
-          "ordinal": 1,
-          "type_info": "Int2"
-        },
-        {
-          "name": "creator_id?: UserId",
-          "ordinal": 2,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "author_id?: UserId",
-          "ordinal": 3,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "author_name",
-          "ordinal": 4,
-          "type_info": "Text"
-        },
-        {
-          "name": "published_at",
-          "ordinal": 5,
-          "type_info": "Timestamptz"
-        },
-        {
-          "name": "likes",
-          "ordinal": 6,
-          "type_info": "Int8"
-        },
-        {
-          "name": "plays",
-          "ordinal": 7,
-          "type_info": "Int8"
-        },
-        {
-          "name": "live_up_to_date",
-          "ordinal": 8,
-          "type_info": "Bool"
-        },
-        {
-          "name": "display_name!",
-          "ordinal": 9,
-          "type_info": "Text"
-        },
-        {
-          "name": "updated_at",
-          "ordinal": 10,
-          "type_info": "Timestamptz"
-        },
-        {
-          "name": "language!",
-          "ordinal": 11,
-          "type_info": "Text"
-        },
-        {
-          "name": "description!",
-          "ordinal": 12,
-          "type_info": "Text"
-        },
-        {
-          "name": "translated_description!: Json<HashMap<String,String>>",
-          "ordinal": 13,
-          "type_info": "Jsonb"
-        },
-        {
-          "name": "draft_or_live!: DraftOrLive",
-          "ordinal": 14,
-          "type_info": "Int2"
-        },
-        {
-          "name": "other_keywords!",
-          "ordinal": 15,
-          "type_info": "Text"
-        },
-        {
-          "name": "translated_keywords!",
-          "ordinal": 16,
-          "type_info": "Text"
-        },
-        {
-          "name": "cover?: (ModuleId, ModuleKind, bool)",
-          "ordinal": 17,
-          "type_info": "Record"
-        },
-        {
-          "name": "categories!: Vec<(CategoryId,)>",
-          "ordinal": 18,
-          "type_info": "RecordArray"
-        },
-        {
-          "name": "affiliations!: Vec<(AffiliationId,)>",
-          "ordinal": 19,
-          "type_info": "RecordArray"
-        },
-        {
-          "name": "age_ranges!: Vec<(AgeRangeId,)>",
-          "ordinal": 20,
-          "type_info": "RecordArray"
-        },
-        {
-          "name": "additional_resource!: Vec<(AddId, String, TypeId, Value)>",
-          "ordinal": 21,
-          "type_info": "RecordArray"
-        },
-        {
-          "name": "items!: Vec<(JigId,)>",
-          "ordinal": 22,
-          "type_info": "RecordArray"
-        }
-      ],
-      "nullable": [
-        false,
-        false,
-        true,
-        true,
-        null,
-        true,
-        false,
-        false,
-        false,
-        false,
-        true,
-        false,
-        false,
-        false,
-        true,
-        false,
-        false,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Int2",
-          "Int2Array",
-          "UuidArray",
-          "Int4",
-          "Int4"
-        ]
-      }
-    },
-    "query": "\nwith cte as (\n    select (array_agg(cd.id))[1]\n    from course_data \"cd\"\n          left join course on (draft_id = cd.id or (live_id = cd.id and cd.last_synced_at is not null and published_at is not null))\n          left join course_data_resource \"resource\" on cd.id = resource.course_data_id\n    where (author_id = $1 or $1 is null)\n        and (cd.draft_or_live = $2 or $2 is null)\n        and (cd.privacy_level = any($3) or $3 = array[]::smallint[])\n        and (resource.resource_type_id = any($4) or $4 = array[]::uuid[])\n    group by coalesce(updated_at, created_at)\n    order by coalesce(updated_at, created_at) desc\n),\ncte1 as (\n    select * from unnest(array(select cte.array_agg from cte)) with ordinality t(id\n   , ord) order by ord\n)\nselect course.id                                                                as \"course_id: CourseId\",\n    privacy_level                                                               as \"privacy_level: PrivacyLevel\",\n    creator_id                                                                  as \"creator_id?: UserId\",\n    author_id                                                                   as \"author_id?: UserId\",\n    (select given_name || ' '::text || family_name\n     from user_profile\n     where user_profile.user_id = author_id)                                     as \"author_name\",\n    published_at,\n    likes,\n    plays,\n    live_up_to_date,\n    display_name                                                                  as \"display_name!\",\n    updated_at,\n    language                                                                      as \"language!\",\n    description                                                                   as \"description!\",\n    translated_description                                                        as \"translated_description!: Json<HashMap<String,String>>\",\n    draft_or_live                                                                 as \"draft_or_live!: DraftOrLive\",\n    other_keywords                                                                as \"other_keywords!\",\n    translated_keywords                                                           as \"translated_keywords!\",\n    (\n        select row(course_data_module.id, kind, is_complete)\n        from course_data_module\n        where course_data_id = course_data.id and \"index\" = 0\n        order by \"index\"\n    )                                                   as \"cover?: (ModuleId, ModuleKind, bool)\",\n    array(select row (category_id)\n            from course_data_category\n            where course_data_id = course_data.id)     as \"categories!: Vec<(CategoryId,)>\",\n    array(select row (affiliation_id)\n            from course_data_affiliation\n            where course_data_id = course_data.id)          as \"affiliations!: Vec<(AffiliationId,)>\",\n    array(select row (age_range_id)\n            from course_data_age_range\n            where course_data_id = course_data.id)          as \"age_ranges!: Vec<(AgeRangeId,)>\",\n    array(select row (id, display_name, resource_type_id, resource_content)\n                from course_data_resource\n                where course_data_id = course_data.id\n          )                                          as \"additional_resource!: Vec<(AddId, String, TypeId, Value)>\",\n    array(\n        select row(jig_id)\n        from course_data_jig\n        where course_data_jig.course_data_id = course_data.id\n        order by \"index\"\n    )                                                     as \"items!: Vec<(JigId,)>\"\nfrom cte1\ninner join course_data on cte1.id = course_data.id\ninner join course on (\n    course_data.id = course.draft_id\n    or (\n        course_data.id = course.live_id\n        and last_synced_at is not null\n        and course.published_at is not null\n    )\n)\nwhere ord > (1 * $5 * $6)\norder by ord asc\nlimit $6\n"
-  },
   "cf1d0807d549aca8d226a2808899ac14011e9f47f5470f912340af0e031b8bd6": {
     "describe": {
       "columns": [],
@@ -11906,6 +11994,244 @@
     },
     "query": "\nselect given_name\nfrom user_profile\nwhere user_id = $1\n        "
   },
+  "dcbe01a328fb5a5fe087549ffbf50744d2b55faca2b6d77780a3ac748b20fa72": {
+    "describe": {
+      "columns": [
+        {
+          "name": "jig_id: JigId",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "privacy_level: PrivacyLevel",
+          "ordinal": 1,
+          "type_info": "Int2"
+        },
+        {
+          "name": "creator_id?: UserId",
+          "ordinal": 2,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "author_id?: UserId",
+          "ordinal": 3,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "author_name",
+          "ordinal": 4,
+          "type_info": "Text"
+        },
+        {
+          "name": "created_at",
+          "ordinal": 5,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "updated_at",
+          "ordinal": 6,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "published_at",
+          "ordinal": 7,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "liked_count",
+          "ordinal": 8,
+          "type_info": "Int8"
+        },
+        {
+          "name": "live_up_to_date",
+          "ordinal": 9,
+          "type_info": "Bool"
+        },
+        {
+          "name": "is_liked!",
+          "ordinal": 10,
+          "type_info": "Bool"
+        },
+        {
+          "name": "play_count!",
+          "ordinal": 11,
+          "type_info": "Int8"
+        },
+        {
+          "name": "display_name!",
+          "ordinal": 12,
+          "type_info": "Text"
+        },
+        {
+          "name": "language!",
+          "ordinal": 13,
+          "type_info": "Text"
+        },
+        {
+          "name": "description!",
+          "ordinal": 14,
+          "type_info": "Text"
+        },
+        {
+          "name": "translated_description!: Json<HashMap<String,String>>",
+          "ordinal": 15,
+          "type_info": "Jsonb"
+        },
+        {
+          "name": "direction!: TextDirection",
+          "ordinal": 16,
+          "type_info": "Int2"
+        },
+        {
+          "name": "display_score!",
+          "ordinal": 17,
+          "type_info": "Bool"
+        },
+        {
+          "name": "track_assessments!",
+          "ordinal": 18,
+          "type_info": "Bool"
+        },
+        {
+          "name": "drag_assist!",
+          "ordinal": 19,
+          "type_info": "Bool"
+        },
+        {
+          "name": "theme!: ThemeId",
+          "ordinal": 20,
+          "type_info": "Int2"
+        },
+        {
+          "name": "audio_background!: Option<AudioBackground>",
+          "ordinal": 21,
+          "type_info": "Int2"
+        },
+        {
+          "name": "draft_or_live!: DraftOrLive",
+          "ordinal": 22,
+          "type_info": "Int2"
+        },
+        {
+          "name": "audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>",
+          "ordinal": 23,
+          "type_info": "RecordArray"
+        },
+        {
+          "name": "audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>",
+          "ordinal": 24,
+          "type_info": "RecordArray"
+        },
+        {
+          "name": "modules!: Vec<(ModuleId, ModuleKind, bool)>",
+          "ordinal": 25,
+          "type_info": "RecordArray"
+        },
+        {
+          "name": "categories!: Vec<(CategoryId,)>",
+          "ordinal": 26,
+          "type_info": "RecordArray"
+        },
+        {
+          "name": "affiliations!: Vec<(AffiliationId,)>",
+          "ordinal": 27,
+          "type_info": "RecordArray"
+        },
+        {
+          "name": "age_ranges!: Vec<(AgeRangeId,)>",
+          "ordinal": 28,
+          "type_info": "RecordArray"
+        },
+        {
+          "name": "additional_resource!: Vec<(AddId, String, TypeId, Value)>",
+          "ordinal": 29,
+          "type_info": "RecordArray"
+        },
+        {
+          "name": "locked!",
+          "ordinal": 30,
+          "type_info": "Bool"
+        },
+        {
+          "name": "other_keywords!",
+          "ordinal": 31,
+          "type_info": "Text"
+        },
+        {
+          "name": "translated_keywords!",
+          "ordinal": 32,
+          "type_info": "Text"
+        },
+        {
+          "name": "rating!: Option<JigRating>",
+          "ordinal": 33,
+          "type_info": "Int2"
+        },
+        {
+          "name": "blocked!",
+          "ordinal": 34,
+          "type_info": "Bool"
+        },
+        {
+          "name": "curated!",
+          "ordinal": 35,
+          "type_info": "Bool"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        true,
+        true,
+        null,
+        false,
+        true,
+        true,
+        false,
+        false,
+        null,
+        null,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Int2",
+          "Bool",
+          "Int2Array",
+          "UuidArray",
+          "Int4",
+          "Int4",
+          "Int4",
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\nwith cte as (\n    select array_agg(jd.id)\n    from jig_data \"jd\"\n          inner join jig on (draft_id = jd.id or (live_id = jd.id and jd.last_synced_at is not null and published_at is not null))\n          left join jig_admin_data \"admin\" on admin.jig_id = jig.id\n          left join jig_data_additional_resource \"resource\" on jd.id = resource.jig_data_id\n    where (author_id = $1 or $1 is null) \n        and (jd.draft_or_live = $2 or $2 is null)\n        and (blocked = $3 or $3 is null)\n        and (jd.privacy_level = any($4) or $4 = array[]::smallint[])\n        and (resource.resource_type_id = any($5) or $5 = array[]::uuid[])\n    group by updated_at, created_at, jig.published_at, admin.jig_id\n    order by case when $6 = 0 then created_at\n        when $6 = 1 then published_at\n        else coalesce(updated_at, created_at)\n  end desc, jig_id\n),\ncte1 as (\n    select * from unnest(array((select cte.array_agg[1] from cte))) with ordinality t(id\n   , ord) order by ord\n)\nselect jig.id                                              as \"jig_id: JigId\",\n    privacy_level                                       as \"privacy_level: PrivacyLevel\",\n    creator_id                                          as \"creator_id?: UserId\",\n    author_id                                           as \"author_id?: UserId\",\n    (select given_name || ' '::text || family_name\n        from user_profile\n     where user_profile.user_id = author_id)            as \"author_name\",\n    created_at,\n    updated_at,\n    published_at,\n    liked_count,\n    live_up_to_date,\n    exists(select 1 from jig_like where jig_id = jig.id and user_id = $9) as \"is_liked!\",\n    (\n         select play_count\n         from jig_play_count\n         where jig_play_count.jig_id = jig.id\n    )                                                   as \"play_count!\",\n   display_name                                                                  as \"display_name!\",\n   language                                                                      as \"language!\",\n   description                                                                   as \"description!\",\n   translated_description                                                        as \"translated_description!: Json<HashMap<String,String>>\",\n   direction                                                                     as \"direction!: TextDirection\",\n   display_score                                                                 as \"display_score!\",\n   track_assessments                                                             as \"track_assessments!\",\n   drag_assist                                                                   as \"drag_assist!\",\n   theme                                                                         as \"theme!: ThemeId\",\n   audio_background                                                              as \"audio_background!: Option<AudioBackground>\",\n   draft_or_live                                                                 as \"draft_or_live!: DraftOrLive\",\n   array(select row (unnest(audio_feedback_positive)))                           as \"audio_feedback_positive!: Vec<(AudioFeedbackPositive,)>\",\n   array(select row (unnest(audio_feedback_negative)))                           as \"audio_feedback_negative!: Vec<(AudioFeedbackNegative,)>\",\n   array(\n           select row (jig_data_module.id, kind, is_complete)\n           from jig_data_module\n           where jig_data_id = jig_data.id\n           order by \"index\"\n    )                                               as \"modules!: Vec<(ModuleId, ModuleKind, bool)>\",\n   array(select row (category_id)\n         from jig_data_category\n         where jig_data_id = jig_data.id)     as \"categories!: Vec<(CategoryId,)>\",\n   array(select row (affiliation_id)\n         from jig_data_affiliation\n         where jig_data_id = jig_data.id)     as \"affiliations!: Vec<(AffiliationId,)>\",\n   array(select row (age_range_id)\n         from jig_data_age_range\n         where jig_data_id = jig_data.id)     as \"age_ranges!: Vec<(AgeRangeId,)>\",\n   array(\n            select row (jdar.id, jdar.display_name, resource_type_id, resource_content)\n            from jig_data_additional_resource \"jdar\"\n            where jdar.jig_data_id = jig_data.id\n        )                                               as \"additional_resource!: Vec<(AddId, String, TypeId, Value)>\",\n   locked                                     as \"locked!\",\n   other_keywords                             as \"other_keywords!\",\n   translated_keywords                        as \"translated_keywords!\",\n   rating                                     as \"rating!: Option<JigRating>\",\n   blocked                                    as \"blocked!\",\n   curated                                    as \"curated!\"\nfrom cte1\ninner join jig_data on cte1.id = jig_data.id\ninner join jig on (\n    jig_data.id = jig.draft_id\n    or (\n        jig_data.id = jig.live_id\n        and last_synced_at is not null\n        and jig.published_at is not null\n    )\n)\nleft join jig_admin_data \"admin\" on admin.jig_id = jig.id\nwhere ord > (1 * $7 * $8)\norder by ord asc\nlimit $8\n"
+  },
   "dcf1c205342991479db185e57d7aef0339f4205a8e7fe6f1db2b89f02d0b0bd0": {
     "describe": {
       "columns": [
@@ -12468,177 +12794,6 @@
     },
     "query": "\nwith recursive cte(parent_id) as (\nselect parent_id from category where id = $1\nunion all\nselect c.parent_id from category c inner join cte on cte.parent_id = c.id\n) select exists(select 1 from cte where parent_id = $2) as \"would_cycle!\"\n    "
   },
-  "eec136e18ca1be43013aa5f7f4c02aca97055a0ca17186617eee8eae8e04a4ad": {
-    "describe": {
-      "columns": [
-        {
-          "name": "resource_id: ResourceId",
-          "ordinal": 0,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "display_name",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "creator_id: UserId",
-          "ordinal": 2,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "author_id: UserId",
-          "ordinal": 3,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "author_name",
-          "ordinal": 4,
-          "type_info": "Text"
-        },
-        {
-          "name": "created_at",
-          "ordinal": 5,
-          "type_info": "Timestamptz"
-        },
-        {
-          "name": "updated_at",
-          "ordinal": 6,
-          "type_info": "Timestamptz"
-        },
-        {
-          "name": "published_at",
-          "ordinal": 7,
-          "type_info": "Timestamptz"
-        },
-        {
-          "name": "privacy_level!: PrivacyLevel",
-          "ordinal": 8,
-          "type_info": "Int2"
-        },
-        {
-          "name": "language",
-          "ordinal": 9,
-          "type_info": "Text"
-        },
-        {
-          "name": "description",
-          "ordinal": 10,
-          "type_info": "Text"
-        },
-        {
-          "name": "translated_description!: Json<HashMap<String, String>>",
-          "ordinal": 11,
-          "type_info": "Jsonb"
-        },
-        {
-          "name": "likes",
-          "ordinal": 12,
-          "type_info": "Int8"
-        },
-        {
-          "name": "views",
-          "ordinal": 13,
-          "type_info": "Int8"
-        },
-        {
-          "name": "live_up_to_date",
-          "ordinal": 14,
-          "type_info": "Bool"
-        },
-        {
-          "name": "locked",
-          "ordinal": 15,
-          "type_info": "Bool"
-        },
-        {
-          "name": "other_keywords",
-          "ordinal": 16,
-          "type_info": "Text"
-        },
-        {
-          "name": "translated_keywords",
-          "ordinal": 17,
-          "type_info": "Text"
-        },
-        {
-          "name": "rating?: ResourceRating",
-          "ordinal": 18,
-          "type_info": "Int2"
-        },
-        {
-          "name": "blocked",
-          "ordinal": 19,
-          "type_info": "Bool"
-        },
-        {
-          "name": "curated",
-          "ordinal": 20,
-          "type_info": "Bool"
-        },
-        {
-          "name": "cover?: (ModuleId, ModuleKind, bool)",
-          "ordinal": 21,
-          "type_info": "Record"
-        },
-        {
-          "name": "categories!: Vec<(CategoryId,)>",
-          "ordinal": 22,
-          "type_info": "RecordArray"
-        },
-        {
-          "name": "affiliations!: Vec<(AffiliationId,)>",
-          "ordinal": 23,
-          "type_info": "RecordArray"
-        },
-        {
-          "name": "age_ranges!: Vec<(AgeRangeId,)>",
-          "ordinal": 24,
-          "type_info": "RecordArray"
-        },
-        {
-          "name": "additional_resource!: Vec<(AddId, String, TypeId, Value)>",
-          "ordinal": 25,
-          "type_info": "RecordArray"
-        }
-      ],
-      "nullable": [
-        false,
-        false,
-        true,
-        true,
-        null,
-        false,
-        true,
-        true,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        true,
-        false,
-        false,
-        null,
-        null,
-        null,
-        null,
-        null
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Int4"
-        ]
-      }
-    },
-    "query": "\nwith cte as (\n    select id      as \"resource_id\",\n           creator_id,\n           author_id,\n           likes,\n           views,\n           live_up_to_date,\n           case\n               when $2 = 0 then resource.draft_id\n               when $2 = 1 then resource.live_id\n               end as \"draft_or_live_id\",\n           published_at,\n           rating,\n           blocked,\n           curated\n    from resource\n    left join resource_admin_data \"admin\" on admin.resource_id = resource.id\n    where id = $1\n)\nselect cte.resource_id                                          as \"resource_id: ResourceId\",\n        display_name,\n        creator_id                                          as \"creator_id: UserId\",\n        author_id                                           as \"author_id: UserId\",\n        (select given_name || ' '::text || family_name\n        from user_profile\n        where user_profile.user_id = author_id)            as \"author_name\",\n        created_at,\n        updated_at,\n        published_at,\n        privacy_level                                       as \"privacy_level!: PrivacyLevel\",\n        language,\n        description,\n        translated_description                              as \"translated_description!: Json<HashMap<String, String>>\",\n        likes,\n        views,\n        live_up_to_date,\n        locked,\n        other_keywords,\n        translated_keywords,\n        rating                                               as \"rating?: ResourceRating\",\n        blocked                                              as \"blocked\",\n        curated,\n        (\n                select row(resource_data_module.id, kind, is_complete)\n                from resource_data_module\n                where resource_data_id = resource_data.id\n        )                                               as \"cover?: (ModuleId, ModuleKind, bool)\",\n        array(select row (category_id)\n                from resource_data_category\n                where resource_data_id = cte.draft_or_live_id)     as \"categories!: Vec<(CategoryId,)>\",\n        array(select row (affiliation_id)\n                from resource_data_affiliation\n                where resource_data_id = cte.draft_or_live_id)     as \"affiliations!: Vec<(AffiliationId,)>\",\n        array(select row (age_range_id)\n                from resource_data_age_range\n                where resource_data_id = cte.draft_or_live_id)     as \"age_ranges!: Vec<(AgeRangeId,)>\",\n        array(\n                select row (rdr.id, rdr.display_name, resource_type_id, resource_content)\n                from resource_data_resource \"rdr\"\n                where rdr.resource_data_id = cte.draft_or_live_id\n    )                                                    as \"additional_resource!: Vec<(AddId, String, TypeId, Value)>\"\nfrom resource_data\n         inner join cte on cte.draft_or_live_id = resource_data.id\n"
-  },
   "ef36b57ff9ff33f2f63f72fa62022287ac897ed5075fba89ba47a1356e0e2549": {
     "describe": {
       "columns": [
@@ -13181,6 +13336,19 @@
       }
     },
     "query": "\nupdate image_metadata\nset publish_at = $2, updated_at = now()\nwhere id = $1 and $2 is distinct from publish_at"
+  },
+  "fd9a09f133a9dac7bccaa640bc504296985b400ecdda4d3196f62e8800ea6063": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\ninsert into course_like(course_id, user_id)\nvalues ($1, $2)\n            "
   },
   "fe196f274875c6e293c5e80be927ac1e35c46f7699975b24a28b8cc1c136881d": {
     "describe": {

--- a/backend/api/src/db/jig.rs
+++ b/backend/api/src/db/jig.rs
@@ -173,7 +173,6 @@ with cte as (
            liked_count,
            play_count,
            live_up_to_date,
-           exists(select 1 from jig_like where jig_id = jig.id and user_id = $3) as "is_liked",
            case
                when $2 = 0 then jig.draft_id
                when $2 = 1 then jig.live_id
@@ -210,7 +209,7 @@ select cte.jig_id                                          as "jig_id: JigId",
         liked_count,
         play_count,
         live_up_to_date,
-        cte.is_liked,
+        exists(select 1 from jig_like where jig_id = $1 and user_id = $3)    as "is_liked!", 
         locked,
         other_keywords,
         translated_keywords,
@@ -351,7 +350,7 @@ select jig.id                                       as "id!: JigId",
        published_at,
        liked_count                              as "liked_count!",
        live_up_to_date                          as "live_up_to_date!",
-       exists(select 1 from jig_like where jig_id = jig.id and user_id = $2) as "is_liked",
+       exists(select 1 from jig_like where jig_id = jig.id and user_id = $2) as "is_liked!",
        (
            select play_count
            from jig_play_count
@@ -582,7 +581,7 @@ select jig.id                                              as "jig_id: JigId",
     published_at,
     liked_count,
     live_up_to_date,
-    exists(select 1 from jig_like where jig_id = jig.id and user_id = $9) as "is_liked",
+    exists(select 1 from jig_like where jig_id = jig.id and user_id = $9) as "is_liked!",
     (
          select play_count
          from jig_play_count

--- a/backend/api/src/db/resource.rs
+++ b/backend/api/src/db/resource.rs
@@ -148,7 +148,6 @@ with cte as (
            likes,
            views,
            live_up_to_date,
-           exists(select 1 from resource_like where resource_id = resource.id and user_id = $3)  as "is_liked",
            case
                when $2 = 0 then resource.draft_id
                when $2 = 1 then resource.live_id
@@ -183,7 +182,7 @@ select cte.resource_id                                          as "resource_id:
         translated_keywords,
         rating                                               as "rating?: ResourceRating",
         blocked                                              as "blocked",
-        cte.is_liked                                         as "is_liked",
+        exists(select 1 from resource_like where resource_id = $1 and user_id = $3)  as "is_liked!",
         curated,
         (
                 select row(resource_data_module.id, kind, is_complete)
@@ -294,7 +293,7 @@ select resource.id                                       as "id!: ResourceId",
        views                                    as "views!",
        live_up_to_date                          as "live_up_to_date!",
        rating                                   as "rating?: ResourceRating",
-       exists(select 1 from resource_like where resource_id = resource.id and user_id = $2) as "is_liked",
+       exists(select 1 from resource_like where resource_id = resource.id and user_id = $2) as "is_liked!",
        blocked                                  as "blocked!",
        curated                                  as "curated!"
 from resource
@@ -489,7 +488,7 @@ select resource.id                                              as "resource_id:
     likes,
     views,
     live_up_to_date,
-    exists(select 1 from resource_like where resource_id = resource.id and user_id = $9)                         as "is_liked",
+    exists(select 1 from resource_like where resource_id = resource.id and user_id = $9)                         as "is_liked!",
    display_name                                                                  as "display_name!",
    language                                                                      as "language!",
    description                                                                   as "description!",

--- a/backend/api/src/db/user/public_user.rs
+++ b/backend/api/src/db/user/public_user.rs
@@ -191,7 +191,7 @@ pub async fn browse_user_resources(
             "#,
         user_id.0,
         page as i32,
-        page_limit as i32
+        page_limit as i32,
     )
     .fetch_all(db)
     .await?;

--- a/backend/api/src/extractor.rs
+++ b/backend/api/src/extractor.rs
@@ -138,6 +138,14 @@ impl TokenUser {
     }
 }
 
+pub fn get_user_id(token: Option<TokenUser>) -> Option<UserId> {
+    if let Some(token) = token {
+        Some(token.user_id())
+    } else {
+        None
+    }
+}
+
 impl FromRequest for TokenUser {
     type Error = actix_web::Error;
     type Future = ReadyOrNot<'static, Result<Self, Self::Error>>;

--- a/backend/api/tests/integration/jig/snapshots/integration__jig__cover__update_no_modules_changes.snap
+++ b/backend/api/tests/integration/jig/snapshots/integration__jig__cover__update_no_modules_changes.snap
@@ -70,6 +70,7 @@ expression: body
     "translatedKeywords": "",
     "translatedDescription": {}
   },
+  "isLiked": false,
   "adminData": {
     "rating": null,
     "blocked": false,

--- a/backend/api/tests/integration/jig/snapshots/integration__jig__module__drag_up_down_modules-1.snap
+++ b/backend/api/tests/integration/jig/snapshots/integration__jig__module__drag_up_down_modules-1.snap
@@ -70,6 +70,7 @@ expression: body
     "translatedKeywords": "",
     "translatedDescription": {}
   },
+  "isLiked": false,
   "adminData": {
     "rating": null,
     "blocked": false,

--- a/backend/api/tests/integration/jig/snapshots/integration__jig__module__drag_up_down_modules-2.snap
+++ b/backend/api/tests/integration/jig/snapshots/integration__jig__module__drag_up_down_modules-2.snap
@@ -70,6 +70,7 @@ expression: body
     "translatedKeywords": "",
     "translatedDescription": {}
   },
+  "isLiked": false,
   "adminData": {
     "rating": null,
     "blocked": false,

--- a/backend/api/tests/integration/resource.rs
+++ b/backend/api/tests/integration/resource.rs
@@ -414,7 +414,7 @@ async fn browse_own_simple(port: u16) -> anyhow::Result<()> {
 
 #[test_service(
     setup = "setup_service",
-    fixtures("Fixture::MetaKinds", "Fixture::UserDefaultPerms", "Fixture::Resource")
+    fixtures("Fixture::MetaKinds", "Fixture::User", "Fixture::Resource")
 )]
 async fn count(port: u16) -> anyhow::Result<()> {
     let name = "count";
@@ -443,7 +443,7 @@ async fn count(port: u16) -> anyhow::Result<()> {
     setup = "setup_service",
     fixtures(
         "Fixture::MetaKinds",
-        "Fixture::UserDefaultPerms",
+        "Fixture::User",
         "Fixture::Resource",
         "Fixture::CategoryOrdering"
     )
@@ -613,7 +613,7 @@ async fn update_and_publish(port: u16) -> anyhow::Result<()> {
     setup = "setup_service",
     fixtures(
         "Fixture::MetaKinds",
-        "Fixture::UserDefaultPerms",
+        "Fixture::User",
         "Fixture::Resource",
         "Fixture::CategoryOrdering"
     )
@@ -686,7 +686,7 @@ async fn live_up_to_date_flag(port: u16) -> anyhow::Result<()> {
     setup = "setup_service",
     fixtures(
         "Fixture::MetaKinds",
-        "Fixture::UserDefaultPerms",
+        "Fixture::User",
         "Fixture::Resource",
         "Fixture::CategoryOrdering"
     )

--- a/backend/api/tests/integration/resource/snapshots/integration__resource__cover__update_no_modules_changes.snap
+++ b/backend/api/tests/integration/resource/snapshots/integration__resource__cover__update_no_modules_changes.snap
@@ -11,6 +11,7 @@ expression: body
   "likes": 0,
   "views": 0,
   "liveUpToDate": false,
+  "isLiked": false,
   "resourceData": {
     "draftOrLive": "draft",
     "displayName": "test Resource",

--- a/backend/api/tests/integration/snapshots/integration__course__browse_simple.snap
+++ b/backend/api/tests/integration/snapshots/integration__course__browse_simple.snap
@@ -13,6 +13,7 @@ expression: body
       "likes": 0,
       "plays": 0,
       "liveUpToDate": false,
+      "isLiked": false,
       "courseData": {
         "draftOrLive": "draft",
         "displayName": "course name1",
@@ -44,9 +45,10 @@ expression: body
       "creatorId": "7b96a41c-e406-11eb-8176-efd86dd7f444",
       "authorId": "7b96a41c-e406-11eb-8176-efd86dd7f444",
       "authorName": "Post Gres",
-      "likes": 0,
+      "likes": 1,
       "plays": 0,
       "liveUpToDate": false,
+      "isLiked": true,
       "courseData": {
         "draftOrLive": "draft",
         "displayName": "course name3",
@@ -75,9 +77,10 @@ expression: body
       "creatorId": "7b96a41c-e406-11eb-8176-efd86dd7f444",
       "authorId": "7b96a41c-e406-11eb-8176-efd86dd7f444",
       "authorName": "Post Gres",
-      "likes": 0,
+      "likes": 1,
       "plays": 0,
       "liveUpToDate": false,
+      "isLiked": true,
       "courseData": {
         "draftOrLive": "live",
         "displayName": "course name3",

--- a/backend/api/tests/integration/snapshots/integration__course__course_jig_index-1.snap
+++ b/backend/api/tests/integration/snapshots/integration__course__course_jig_index-1.snap
@@ -11,6 +11,7 @@ expression: body
   "likes": 0,
   "plays": 0,
   "liveUpToDate": false,
+  "isLiked": false,
   "courseData": {
     "draftOrLive": "draft",
     "displayName": "course name1",

--- a/backend/api/tests/integration/snapshots/integration__course__course_jig_index-2.snap
+++ b/backend/api/tests/integration/snapshots/integration__course__course_jig_index-2.snap
@@ -11,6 +11,7 @@ expression: body
   "likes": 0,
   "plays": 0,
   "liveUpToDate": false,
+  "isLiked": false,
   "courseData": {
     "draftOrLive": "draft",
     "displayName": "course name1",

--- a/backend/api/tests/integration/snapshots/integration__course__course_jig_index-3.snap
+++ b/backend/api/tests/integration/snapshots/integration__course__course_jig_index-3.snap
@@ -11,6 +11,7 @@ expression: body
   "likes": 0,
   "plays": 0,
   "liveUpToDate": false,
+  "isLiked": false,
   "courseData": {
     "draftOrLive": "live",
     "displayName": "course name1",

--- a/backend/api/tests/integration/snapshots/integration__course__course_jig_index-4.snap
+++ b/backend/api/tests/integration/snapshots/integration__course__course_jig_index-4.snap
@@ -11,6 +11,7 @@ expression: body
   "likes": 0,
   "plays": 0,
   "liveUpToDate": true,
+  "isLiked": false,
   "courseData": {
     "draftOrLive": "live",
     "displayName": "course name1",

--- a/backend/api/tests/integration/snapshots/integration__course__get-1.snap
+++ b/backend/api/tests/integration/snapshots/integration__course__get-1.snap
@@ -11,6 +11,7 @@ expression: body
   "likes": 0,
   "plays": 0,
   "liveUpToDate": false,
+  "isLiked": false,
   "courseData": {
     "draftOrLive": "draft",
     "displayName": "course name1",

--- a/backend/api/tests/integration/snapshots/integration__course__get-2.snap
+++ b/backend/api/tests/integration/snapshots/integration__course__get-2.snap
@@ -11,6 +11,7 @@ expression: body
   "likes": 0,
   "plays": 0,
   "liveUpToDate": false,
+  "isLiked": false,
   "courseData": {
     "draftOrLive": "live",
     "displayName": "course name1",

--- a/backend/api/tests/integration/snapshots/integration__course__live_up_to_date_flag-1.snap
+++ b/backend/api/tests/integration/snapshots/integration__course__live_up_to_date_flag-1.snap
@@ -11,6 +11,7 @@ expression: body
   "likes": 0,
   "plays": 0,
   "liveUpToDate": false,
+  "isLiked": false,
   "courseData": {
     "draftOrLive": "draft",
     "displayName": "course name1",

--- a/backend/api/tests/integration/snapshots/integration__course__live_up_to_date_flag-2.snap
+++ b/backend/api/tests/integration/snapshots/integration__course__live_up_to_date_flag-2.snap
@@ -11,6 +11,7 @@ expression: body
   "likes": 0,
   "plays": 0,
   "liveUpToDate": true,
+  "isLiked": false,
   "courseData": {
     "draftOrLive": "live",
     "displayName": "course name1",

--- a/backend/api/tests/integration/snapshots/integration__course__publish_modules-1.snap
+++ b/backend/api/tests/integration/snapshots/integration__course__publish_modules-1.snap
@@ -11,6 +11,7 @@ expression: body
   "likes": 0,
   "plays": 0,
   "liveUpToDate": false,
+  "isLiked": false,
   "courseData": {
     "draftOrLive": "draft",
     "displayName": "course name1",

--- a/backend/api/tests/integration/snapshots/integration__course__publish_modules-2.snap
+++ b/backend/api/tests/integration/snapshots/integration__course__publish_modules-2.snap
@@ -11,6 +11,7 @@ expression: body
   "likes": 0,
   "plays": 0,
   "liveUpToDate": false,
+  "isLiked": false,
   "courseData": {
     "draftOrLive": "live",
     "displayName": "course name1",

--- a/backend/api/tests/integration/snapshots/integration__course__publish_modules-3.snap
+++ b/backend/api/tests/integration/snapshots/integration__course__publish_modules-3.snap
@@ -11,6 +11,7 @@ expression: body
   "likes": 0,
   "plays": 0,
   "liveUpToDate": true,
+  "isLiked": false,
   "courseData": {
     "draftOrLive": "live",
     "displayName": "course name1",

--- a/backend/api/tests/integration/snapshots/integration__course__update_and_publish_browse-1.snap
+++ b/backend/api/tests/integration/snapshots/integration__course__update_and_publish_browse-1.snap
@@ -11,6 +11,7 @@ expression: body
   "likes": 0,
   "plays": 0,
   "liveUpToDate": false,
+  "isLiked": false,
   "courseData": {
     "draftOrLive": "draft",
     "displayName": "course name1",

--- a/backend/api/tests/integration/snapshots/integration__course__update_and_publish_browse-2.snap
+++ b/backend/api/tests/integration/snapshots/integration__course__update_and_publish_browse-2.snap
@@ -11,6 +11,7 @@ expression: body
   "likes": 0,
   "plays": 0,
   "liveUpToDate": false,
+  "isLiked": false,
   "courseData": {
     "draftOrLive": "draft",
     "displayName": "course name1",

--- a/backend/api/tests/integration/snapshots/integration__course__update_and_publish_browse-3.snap
+++ b/backend/api/tests/integration/snapshots/integration__course__update_and_publish_browse-3.snap
@@ -11,6 +11,7 @@ expression: body
   "likes": 0,
   "plays": 0,
   "liveUpToDate": false,
+  "isLiked": false,
   "courseData": {
     "draftOrLive": "live",
     "displayName": "course name1",

--- a/backend/api/tests/integration/snapshots/integration__course__update_and_publish_browse-4.snap
+++ b/backend/api/tests/integration/snapshots/integration__course__update_and_publish_browse-4.snap
@@ -13,6 +13,7 @@ expression: body
       "likes": 0,
       "plays": 0,
       "liveUpToDate": true,
+      "isLiked": false,
       "courseData": {
         "draftOrLive": "draft",
         "displayName": "course name1",
@@ -47,6 +48,7 @@ expression: body
       "likes": 0,
       "plays": 0,
       "liveUpToDate": false,
+      "isLiked": false,
       "courseData": {
         "draftOrLive": "draft",
         "displayName": "course name2",

--- a/backend/api/tests/integration/snapshots/integration__jig__browse_order_by-1.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__browse_order_by-1.snap
@@ -72,6 +72,7 @@ expression: body
         "translatedKeywords": "",
         "translatedDescription": {}
       },
+      "isLiked": false,
       "adminData": {
         "rating": null,
         "blocked": false,
@@ -123,6 +124,7 @@ expression: body
         "translatedKeywords": "",
         "translatedDescription": {}
       },
+      "isLiked": false,
       "adminData": {
         "rating": null,
         "blocked": false,
@@ -168,6 +170,7 @@ expression: body
         "translatedKeywords": "",
         "translatedDescription": {}
       },
+      "isLiked": false,
       "adminData": {
         "rating": null,
         "blocked": false,
@@ -213,6 +216,7 @@ expression: body
         "translatedKeywords": "",
         "translatedDescription": {}
       },
+      "isLiked": false,
       "adminData": {
         "rating": null,
         "blocked": false,

--- a/backend/api/tests/integration/snapshots/integration__jig__browse_order_by-2.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__browse_order_by-2.snap
@@ -72,6 +72,7 @@ expression: body
         "translatedKeywords": "",
         "translatedDescription": {}
       },
+      "isLiked": false,
       "adminData": {
         "rating": null,
         "blocked": false,
@@ -123,6 +124,7 @@ expression: body
         "translatedKeywords": "",
         "translatedDescription": {}
       },
+      "isLiked": false,
       "adminData": {
         "rating": null,
         "blocked": false,
@@ -168,6 +170,7 @@ expression: body
         "translatedKeywords": "",
         "translatedDescription": {}
       },
+      "isLiked": false,
       "adminData": {
         "rating": null,
         "blocked": false,
@@ -213,6 +216,7 @@ expression: body
         "translatedKeywords": "",
         "translatedDescription": {}
       },
+      "isLiked": false,
       "adminData": {
         "rating": null,
         "blocked": false,

--- a/backend/api/tests/integration/snapshots/integration__jig__browse_order_by-3.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__browse_order_by-3.snap
@@ -72,6 +72,7 @@ expression: body
         "translatedKeywords": "",
         "translatedDescription": {}
       },
+      "isLiked": false,
       "adminData": {
         "rating": null,
         "blocked": false,
@@ -123,6 +124,7 @@ expression: body
         "translatedKeywords": "",
         "translatedDescription": {}
       },
+      "isLiked": false,
       "adminData": {
         "rating": null,
         "blocked": false,
@@ -168,6 +170,7 @@ expression: body
         "translatedKeywords": "",
         "translatedDescription": {}
       },
+      "isLiked": false,
       "adminData": {
         "rating": null,
         "blocked": false,
@@ -213,6 +216,7 @@ expression: body
         "translatedKeywords": "",
         "translatedDescription": {}
       },
+      "isLiked": false,
       "adminData": {
         "rating": null,
         "blocked": false,

--- a/backend/api/tests/integration/snapshots/integration__jig__browse_simple.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__browse_simple.snap
@@ -72,6 +72,7 @@ expression: body
         "translatedKeywords": "",
         "translatedDescription": {}
       },
+      "isLiked": false,
       "adminData": {
         "rating": null,
         "blocked": false,
@@ -123,6 +124,7 @@ expression: body
         "translatedKeywords": "",
         "translatedDescription": {}
       },
+      "isLiked": false,
       "adminData": {
         "rating": null,
         "blocked": false,
@@ -168,6 +170,7 @@ expression: body
         "translatedKeywords": "",
         "translatedDescription": {}
       },
+      "isLiked": false,
       "adminData": {
         "rating": null,
         "blocked": false,
@@ -213,6 +216,7 @@ expression: body
         "translatedKeywords": "",
         "translatedDescription": {}
       },
+      "isLiked": false,
       "adminData": {
         "rating": null,
         "blocked": false,

--- a/backend/api/tests/integration/snapshots/integration__jig__clone-1.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__clone-1.snap
@@ -41,6 +41,7 @@ expression: body
     "translatedKeywords": "",
     "translatedDescription": {}
   },
+  "isLiked": false,
   "adminData": {
     "rating": null,
     "blocked": false,

--- a/backend/api/tests/integration/snapshots/integration__jig__clone-2.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__clone-2.snap
@@ -41,6 +41,7 @@ expression: body
     "translatedKeywords": "",
     "translatedDescription": {}
   },
+  "isLiked": false,
   "adminData": {
     "rating": null,
     "blocked": false,

--- a/backend/api/tests/integration/snapshots/integration__jig__create_default-2.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__create_default-2.snap
@@ -41,6 +41,7 @@ expression: body
     "translatedKeywords": "",
     "translatedDescription": {}
   },
+  "isLiked": false,
   "adminData": {
     "rating": null,
     "blocked": false,

--- a/backend/api/tests/integration/snapshots/integration__jig__create_default-3.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__create_default-3.snap
@@ -41,6 +41,7 @@ expression: body
     "translatedKeywords": "",
     "translatedDescription": {}
   },
+  "isLiked": false,
   "adminData": {
     "rating": null,
     "blocked": false,

--- a/backend/api/tests/integration/snapshots/integration__jig__get-1.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__get-1.snap
@@ -70,6 +70,7 @@ expression: body
     "translatedKeywords": "",
     "translatedDescription": {}
   },
+  "isLiked": false,
   "adminData": {
     "rating": null,
     "blocked": false,

--- a/backend/api/tests/integration/snapshots/integration__jig__get-2.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__get-2.snap
@@ -70,6 +70,7 @@ expression: body
     "translatedKeywords": "",
     "translatedDescription": {}
   },
+  "isLiked": false,
   "adminData": {
     "rating": null,
     "blocked": false,

--- a/backend/api/tests/integration/snapshots/integration__jig__live_up_to_date_flag-1.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__live_up_to_date_flag-1.snap
@@ -47,6 +47,7 @@ expression: body
     "translatedKeywords": "",
     "translatedDescription": {}
   },
+  "isLiked": false,
   "adminData": {
     "rating": null,
     "blocked": false,

--- a/backend/api/tests/integration/snapshots/integration__jig__live_up_to_date_flag-2.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__live_up_to_date_flag-2.snap
@@ -47,6 +47,7 @@ expression: body
     "translatedKeywords": "",
     "translatedDescription": {}
   },
+  "isLiked": false,
   "adminData": {
     "rating": null,
     "blocked": false,

--- a/backend/api/tests/integration/snapshots/integration__jig__update_and_publish-1.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__update_and_publish-1.snap
@@ -47,6 +47,7 @@ expression: body
     "translatedKeywords": "",
     "translatedDescription": {}
   },
+  "isLiked": false,
   "adminData": {
     "rating": null,
     "blocked": false,

--- a/backend/api/tests/integration/snapshots/integration__jig__update_and_publish-2.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__update_and_publish-2.snap
@@ -50,6 +50,7 @@ expression: body
     "translatedKeywords": "",
     "translatedDescription": {}
   },
+  "isLiked": false,
   "adminData": {
     "rating": null,
     "blocked": false,

--- a/backend/api/tests/integration/snapshots/integration__jig__update_and_publish-3.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__update_and_publish-3.snap
@@ -47,6 +47,7 @@ expression: body
     "translatedKeywords": "",
     "translatedDescription": {}
   },
+  "isLiked": false,
   "adminData": {
     "rating": null,
     "blocked": false,

--- a/backend/api/tests/integration/snapshots/integration__jig__update_and_publish-4.snap
+++ b/backend/api/tests/integration/snapshots/integration__jig__update_and_publish-4.snap
@@ -50,6 +50,7 @@ expression: body
     "translatedKeywords": "",
     "translatedDescription": {}
   },
+  "isLiked": false,
   "adminData": {
     "rating": null,
     "blocked": false,

--- a/backend/api/tests/integration/snapshots/integration__resource__browse_order_by-1.snap
+++ b/backend/api/tests/integration/snapshots/integration__resource__browse_order_by-1.snap
@@ -13,6 +13,7 @@ expression: body
       "likes": 0,
       "views": 0,
       "liveUpToDate": false,
+      "isLiked": false,
       "resourceData": {
         "draftOrLive": "draft",
         "displayName": "resource2",
@@ -50,6 +51,7 @@ expression: body
       "likes": 0,
       "views": 0,
       "liveUpToDate": false,
+      "isLiked": false,
       "resourceData": {
         "draftOrLive": "live",
         "displayName": "resource2",
@@ -81,12 +83,13 @@ expression: body
     {
       "id": "af827e00-1519-11ed-87fa-7b1aa26c85a8",
       "publishedAt": "2022-06-22T17:57:33.149359Z",
-      "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
-      "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
-      "authorName": "Bobby Tables",
-      "likes": 0,
+      "creatorId": "7b96a41c-e406-11eb-8176-efd86dd7f444",
+      "authorId": "7b96a41c-e406-11eb-8176-efd86dd7f444",
+      "authorName": "Post Gres",
+      "likes": 1,
       "views": 0,
       "liveUpToDate": false,
+      "isLiked": true,
       "resourceData": {
         "draftOrLive": "draft",
         "displayName": "resource3",
@@ -124,6 +127,7 @@ expression: body
       "likes": 0,
       "views": 0,
       "liveUpToDate": false,
+      "isLiked": false,
       "resourceData": {
         "draftOrLive": "draft",
         "displayName": "resource1",

--- a/backend/api/tests/integration/snapshots/integration__resource__browse_order_by-2.snap
+++ b/backend/api/tests/integration/snapshots/integration__resource__browse_order_by-2.snap
@@ -13,6 +13,7 @@ expression: body
       "likes": 0,
       "views": 0,
       "liveUpToDate": false,
+      "isLiked": false,
       "resourceData": {
         "draftOrLive": "draft",
         "displayName": "resource2",
@@ -50,6 +51,7 @@ expression: body
       "likes": 0,
       "views": 0,
       "liveUpToDate": false,
+      "isLiked": false,
       "resourceData": {
         "draftOrLive": "live",
         "displayName": "resource2",
@@ -81,12 +83,13 @@ expression: body
     {
       "id": "af827e00-1519-11ed-87fa-7b1aa26c85a8",
       "publishedAt": "2022-06-22T17:57:33.149359Z",
-      "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
-      "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
-      "authorName": "Bobby Tables",
-      "likes": 0,
+      "creatorId": "7b96a41c-e406-11eb-8176-efd86dd7f444",
+      "authorId": "7b96a41c-e406-11eb-8176-efd86dd7f444",
+      "authorName": "Post Gres",
+      "likes": 1,
       "views": 0,
       "liveUpToDate": false,
+      "isLiked": true,
       "resourceData": {
         "draftOrLive": "draft",
         "displayName": "resource3",
@@ -124,6 +127,7 @@ expression: body
       "likes": 0,
       "views": 0,
       "liveUpToDate": false,
+      "isLiked": false,
       "resourceData": {
         "draftOrLive": "draft",
         "displayName": "resource1",

--- a/backend/api/tests/integration/snapshots/integration__resource__browse_order_by-3.snap
+++ b/backend/api/tests/integration/snapshots/integration__resource__browse_order_by-3.snap
@@ -13,6 +13,7 @@ expression: body
       "likes": 0,
       "views": 0,
       "liveUpToDate": false,
+      "isLiked": false,
       "resourceData": {
         "draftOrLive": "draft",
         "displayName": "resource1",
@@ -63,6 +64,7 @@ expression: body
       "likes": 0,
       "views": 0,
       "liveUpToDate": false,
+      "isLiked": false,
       "resourceData": {
         "draftOrLive": "live",
         "displayName": "resource2",
@@ -100,6 +102,7 @@ expression: body
       "likes": 0,
       "views": 0,
       "liveUpToDate": false,
+      "isLiked": false,
       "resourceData": {
         "draftOrLive": "draft",
         "displayName": "resource2",
@@ -131,12 +134,13 @@ expression: body
     {
       "id": "af827e00-1519-11ed-87fa-7b1aa26c85a8",
       "publishedAt": "2022-06-22T17:57:33.149359Z",
-      "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
-      "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
-      "authorName": "Bobby Tables",
-      "likes": 0,
+      "creatorId": "7b96a41c-e406-11eb-8176-efd86dd7f444",
+      "authorId": "7b96a41c-e406-11eb-8176-efd86dd7f444",
+      "authorName": "Post Gres",
+      "likes": 1,
       "views": 0,
       "liveUpToDate": false,
+      "isLiked": true,
       "resourceData": {
         "draftOrLive": "draft",
         "displayName": "resource3",

--- a/backend/api/tests/integration/snapshots/integration__resource__browse_own_simple.snap
+++ b/backend/api/tests/integration/snapshots/integration__resource__browse_own_simple.snap
@@ -13,6 +13,7 @@ expression: body
       "likes": 0,
       "views": 0,
       "liveUpToDate": false,
+      "isLiked": false,
       "resourceData": {
         "draftOrLive": "draft",
         "displayName": "resource2",
@@ -50,6 +51,7 @@ expression: body
       "likes": 0,
       "views": 0,
       "liveUpToDate": false,
+      "isLiked": false,
       "resourceData": {
         "draftOrLive": "live",
         "displayName": "resource2",
@@ -79,39 +81,6 @@ expression: body
       }
     },
     {
-      "id": "af827e00-1519-11ed-87fa-7b1aa26c85a8",
-      "publishedAt": "2022-06-22T17:57:33.149359Z",
-      "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
-      "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
-      "authorName": "Bobby Tables",
-      "likes": 0,
-      "views": 0,
-      "liveUpToDate": false,
-      "resourceData": {
-        "draftOrLive": "live",
-        "displayName": "resource3",
-        "cover": null,
-        "ageRanges": [],
-        "affiliations": [],
-        "language": "en",
-        "categories": [],
-        "description": "test description",
-        "createdAt": "2021-03-04T00:46:26.134651Z",
-        "lastEdited": "[last_edited]",
-        "privacyLevel": "public",
-        "locked": false,
-        "otherKeywords": "",
-        "translatedKeywords": "",
-        "translatedDescription": {},
-        "additionalResources": []
-      },
-      "adminData": {
-        "rating": null,
-        "blocked": false,
-        "curated": false
-      }
-    },
-    {
       "id": "d8067526-1518-11ed-87fa-ebaf880b6d9c",
       "publishedAt": "2022-06-24T17:57:33.149359Z",
       "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
@@ -120,6 +89,7 @@ expression: body
       "likes": 0,
       "views": 0,
       "liveUpToDate": false,
+      "isLiked": false,
       "resourceData": {
         "draftOrLive": "live",
         "displayName": "resource1",
@@ -163,5 +133,5 @@ expression: body
     }
   ],
   "pages": 1,
-  "totalResourceCount": 4
+  "totalResourceCount": 3
 }

--- a/backend/api/tests/integration/snapshots/integration__resource__browse_simple-1.snap
+++ b/backend/api/tests/integration/snapshots/integration__resource__browse_simple-1.snap
@@ -13,6 +13,7 @@ expression: body
       "likes": 0,
       "views": 0,
       "liveUpToDate": false,
+      "isLiked": false,
       "resourceData": {
         "draftOrLive": "draft",
         "displayName": "resource2",
@@ -50,6 +51,7 @@ expression: body
       "likes": 0,
       "views": 0,
       "liveUpToDate": false,
+      "isLiked": false,
       "resourceData": {
         "draftOrLive": "live",
         "displayName": "resource2",
@@ -81,12 +83,13 @@ expression: body
     {
       "id": "af827e00-1519-11ed-87fa-7b1aa26c85a8",
       "publishedAt": "2022-06-22T17:57:33.149359Z",
-      "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
-      "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
-      "authorName": "Bobby Tables",
-      "likes": 0,
+      "creatorId": "7b96a41c-e406-11eb-8176-efd86dd7f444",
+      "authorId": "7b96a41c-e406-11eb-8176-efd86dd7f444",
+      "authorName": "Post Gres",
+      "likes": 1,
       "views": 0,
       "liveUpToDate": false,
+      "isLiked": true,
       "resourceData": {
         "draftOrLive": "draft",
         "displayName": "resource3",
@@ -124,6 +127,7 @@ expression: body
       "likes": 0,
       "views": 0,
       "liveUpToDate": false,
+      "isLiked": false,
       "resourceData": {
         "draftOrLive": "draft",
         "displayName": "resource1",

--- a/backend/api/tests/integration/snapshots/integration__resource__browse_simple-2.snap
+++ b/backend/api/tests/integration/snapshots/integration__resource__browse_simple-2.snap
@@ -13,6 +13,7 @@ expression: body
       "likes": 0,
       "views": 0,
       "liveUpToDate": false,
+      "isLiked": false,
       "resourceData": {
         "draftOrLive": "draft",
         "displayName": "resource2",
@@ -44,12 +45,13 @@ expression: body
     {
       "id": "af827e00-1519-11ed-87fa-7b1aa26c85a8",
       "publishedAt": "2022-06-22T17:57:33.149359Z",
-      "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
-      "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
-      "authorName": "Bobby Tables",
-      "likes": 0,
+      "creatorId": "7b96a41c-e406-11eb-8176-efd86dd7f444",
+      "authorId": "7b96a41c-e406-11eb-8176-efd86dd7f444",
+      "authorName": "Post Gres",
+      "likes": 1,
       "views": 0,
       "liveUpToDate": false,
+      "isLiked": true,
       "resourceData": {
         "draftOrLive": "draft",
         "displayName": "resource3",
@@ -87,6 +89,7 @@ expression: body
       "likes": 0,
       "views": 0,
       "liveUpToDate": false,
+      "isLiked": false,
       "resourceData": {
         "draftOrLive": "draft",
         "displayName": "resource1",

--- a/backend/api/tests/integration/snapshots/integration__resource__browse_simple-3.snap
+++ b/backend/api/tests/integration/snapshots/integration__resource__browse_simple-3.snap
@@ -13,6 +13,7 @@ expression: body
       "likes": 0,
       "views": 0,
       "liveUpToDate": false,
+      "isLiked": false,
       "resourceData": {
         "draftOrLive": "live",
         "displayName": "resource2",
@@ -44,12 +45,13 @@ expression: body
     {
       "id": "af827e00-1519-11ed-87fa-7b1aa26c85a8",
       "publishedAt": "2022-06-22T17:57:33.149359Z",
-      "creatorId": "1f241e1b-b537-493f-a230-075cb16315be",
-      "authorId": "1f241e1b-b537-493f-a230-075cb16315be",
-      "authorName": "Bobby Tables",
-      "likes": 0,
+      "creatorId": "7b96a41c-e406-11eb-8176-efd86dd7f444",
+      "authorId": "7b96a41c-e406-11eb-8176-efd86dd7f444",
+      "authorName": "Post Gres",
+      "likes": 1,
       "views": 0,
       "liveUpToDate": false,
+      "isLiked": true,
       "resourceData": {
         "draftOrLive": "live",
         "displayName": "resource3",
@@ -83,6 +85,7 @@ expression: body
       "likes": 0,
       "views": 0,
       "liveUpToDate": false,
+      "isLiked": false,
       "resourceData": {
         "draftOrLive": "live",
         "displayName": "resource1",

--- a/backend/api/tests/integration/snapshots/integration__resource__clone-1.snap
+++ b/backend/api/tests/integration/snapshots/integration__resource__clone-1.snap
@@ -11,6 +11,7 @@ expression: body
   "likes": 0,
   "views": 0,
   "liveUpToDate": false,
+  "isLiked": false,
   "resourceData": {
     "draftOrLive": "draft",
     "displayName": "resource1",

--- a/backend/api/tests/integration/snapshots/integration__resource__clone-2.snap
+++ b/backend/api/tests/integration/snapshots/integration__resource__clone-2.snap
@@ -11,6 +11,7 @@ expression: body
   "likes": 0,
   "views": 0,
   "liveUpToDate": false,
+  "isLiked": false,
   "resourceData": {
     "draftOrLive": "live",
     "displayName": "resource1",

--- a/backend/api/tests/integration/snapshots/integration__resource__create_default-2.snap
+++ b/backend/api/tests/integration/snapshots/integration__resource__create_default-2.snap
@@ -11,6 +11,7 @@ expression: body
   "likes": 0,
   "views": 0,
   "liveUpToDate": false,
+  "isLiked": false,
   "resourceData": {
     "draftOrLive": "draft",
     "displayName": "",

--- a/backend/api/tests/integration/snapshots/integration__resource__create_default-3.snap
+++ b/backend/api/tests/integration/snapshots/integration__resource__create_default-3.snap
@@ -11,6 +11,7 @@ expression: body
   "likes": 0,
   "views": 0,
   "liveUpToDate": false,
+  "isLiked": false,
   "resourceData": {
     "draftOrLive": "live",
     "displayName": "",

--- a/backend/api/tests/integration/snapshots/integration__resource__get-1.snap
+++ b/backend/api/tests/integration/snapshots/integration__resource__get-1.snap
@@ -11,6 +11,7 @@ expression: body
   "likes": 0,
   "views": 0,
   "liveUpToDate": false,
+  "isLiked": false,
   "resourceData": {
     "draftOrLive": "draft",
     "displayName": "resource1",

--- a/backend/api/tests/integration/snapshots/integration__resource__get-2.snap
+++ b/backend/api/tests/integration/snapshots/integration__resource__get-2.snap
@@ -11,6 +11,7 @@ expression: body
   "likes": 0,
   "views": 0,
   "liveUpToDate": false,
+  "isLiked": false,
   "resourceData": {
     "draftOrLive": "live",
     "displayName": "resource1",

--- a/backend/api/tests/integration/snapshots/integration__resource__live_up_to_date_flag-1.snap
+++ b/backend/api/tests/integration/snapshots/integration__resource__live_up_to_date_flag-1.snap
@@ -11,6 +11,7 @@ expression: body
   "likes": 0,
   "views": 0,
   "liveUpToDate": false,
+  "isLiked": false,
   "resourceData": {
     "draftOrLive": "draft",
     "displayName": "resource1",

--- a/backend/api/tests/integration/snapshots/integration__resource__live_up_to_date_flag-2.snap
+++ b/backend/api/tests/integration/snapshots/integration__resource__live_up_to_date_flag-2.snap
@@ -11,6 +11,7 @@ expression: body
   "likes": 0,
   "views": 0,
   "liveUpToDate": true,
+  "isLiked": false,
   "resourceData": {
     "draftOrLive": "live",
     "displayName": "resource1",

--- a/backend/api/tests/integration/snapshots/integration__resource__update_and_publish-1.snap
+++ b/backend/api/tests/integration/snapshots/integration__resource__update_and_publish-1.snap
@@ -11,6 +11,7 @@ expression: body
   "likes": 0,
   "views": 0,
   "liveUpToDate": false,
+  "isLiked": false,
   "resourceData": {
     "draftOrLive": "draft",
     "displayName": "resource1",

--- a/backend/api/tests/integration/snapshots/integration__resource__update_and_publish-2.snap
+++ b/backend/api/tests/integration/snapshots/integration__resource__update_and_publish-2.snap
@@ -11,6 +11,7 @@ expression: body
   "likes": 0,
   "views": 0,
   "liveUpToDate": false,
+  "isLiked": false,
   "resourceData": {
     "draftOrLive": "draft",
     "displayName": "resource1",

--- a/backend/api/tests/integration/snapshots/integration__resource__update_and_publish-3.snap
+++ b/backend/api/tests/integration/snapshots/integration__resource__update_and_publish-3.snap
@@ -11,6 +11,7 @@ expression: body
   "likes": 0,
   "views": 0,
   "liveUpToDate": false,
+  "isLiked": false,
   "resourceData": {
     "draftOrLive": "live",
     "displayName": "resource1",

--- a/backend/api/tests/integration/snapshots/integration__resource__update_and_publish-4.snap
+++ b/backend/api/tests/integration/snapshots/integration__resource__update_and_publish-4.snap
@@ -11,6 +11,7 @@ expression: body
   "likes": 0,
   "views": 0,
   "liveUpToDate": true,
+  "isLiked": false,
   "resourceData": {
     "draftOrLive": "live",
     "displayName": "resource1",

--- a/backend/api/tests/integration/snapshots/integration__resource__update_privacy_level-1.snap
+++ b/backend/api/tests/integration/snapshots/integration__resource__update_privacy_level-1.snap
@@ -11,6 +11,7 @@ expression: body
   "likes": 0,
   "views": 0,
   "liveUpToDate": false,
+  "isLiked": false,
   "resourceData": {
     "draftOrLive": "draft",
     "displayName": "resource1",

--- a/backend/api/tests/integration/snapshots/integration__resource__update_privacy_level-2.snap
+++ b/backend/api/tests/integration/snapshots/integration__resource__update_privacy_level-2.snap
@@ -11,6 +11,7 @@ expression: body
   "likes": 0,
   "views": 0,
   "liveUpToDate": true,
+  "isLiked": false,
   "resourceData": {
     "draftOrLive": "live",
     "displayName": "resource1",

--- a/backend/api/tests/integration/snapshots/integration__resource__update_privacy_level-3.snap
+++ b/backend/api/tests/integration/snapshots/integration__resource__update_privacy_level-3.snap
@@ -11,6 +11,7 @@ expression: body
   "likes": 0,
   "views": 0,
   "liveUpToDate": true,
+  "isLiked": false,
   "resourceData": {
     "draftOrLive": "live",
     "displayName": "resource1",

--- a/backend/api/tests/integration/user/snapshots/integration__user__public_user__browse_user_courses-1.snap
+++ b/backend/api/tests/integration/user/snapshots/integration__user__public_user__browse_user_courses-1.snap
@@ -13,6 +13,7 @@ expression: body
       "likes": 0,
       "plays": 0,
       "liveUpToDate": false,
+      "isLiked": false,
       "courseData": {
         "draftOrLive": "live",
         "displayName": "course name2",

--- a/backend/api/tests/integration/user/snapshots/integration__user__public_user__browse_user_courses-2.snap
+++ b/backend/api/tests/integration/user/snapshots/integration__user__public_user__browse_user_courses-2.snap
@@ -10,9 +10,10 @@ expression: body
       "creatorId": "7b96a41c-e406-11eb-8176-efd86dd7f444",
       "authorId": "7b96a41c-e406-11eb-8176-efd86dd7f444",
       "authorName": "Post Gres",
-      "likes": 0,
+      "likes": 1,
       "plays": 0,
       "liveUpToDate": false,
+      "isLiked": true,
       "courseData": {
         "draftOrLive": "live",
         "displayName": "course name3",

--- a/backend/api/tests/integration/user/snapshots/integration__user__public_user__browse_user_jigs.snap
+++ b/backend/api/tests/integration/user/snapshots/integration__user__public_user__browse_user_jigs.snap
@@ -72,6 +72,7 @@ expression: body
         "translatedKeywords": "",
         "translatedDescription": {}
       },
+      "isLiked": false,
       "adminData": {
         "rating": null,
         "blocked": false,
@@ -123,6 +124,7 @@ expression: body
         "translatedKeywords": "",
         "translatedDescription": {}
       },
+      "isLiked": false,
       "adminData": {
         "rating": null,
         "blocked": false,
@@ -168,6 +170,7 @@ expression: body
         "translatedKeywords": "",
         "translatedDescription": {}
       },
+      "isLiked": false,
       "adminData": {
         "rating": null,
         "blocked": false,

--- a/frontend/apps/crates/components/src/module/_common/edit/entry/state.rs
+++ b/frontend/apps/crates/components/src/module/_common/edit/entry/state.rs
@@ -209,6 +209,7 @@ where
                         likes: 0,
                         plays: 0,
                         live_up_to_date: false,
+                        is_liked: false,
                         jig_data: JigData {
                             created_at: chrono::offset::Utc::now(),
                             last_edited: None,

--- a/frontend/apps/crates/components/src/module/_common/play/entry/state.rs
+++ b/frontend/apps/crates/components/src/module/_common/play/entry/state.rs
@@ -117,6 +117,7 @@ where
                         author_name: None,
                         published_at: None,
                         live_up_to_date: false,
+                        is_liked: false,
                         jig_data: JigData {
                             created_at: chrono::offset::Utc::now(),
                             last_edited: None,

--- a/frontend/apps/crates/entry/asset/edit/src/edit/sidebar/debug.rs
+++ b/frontend/apps/crates/entry/asset/edit/src/edit/sidebar/debug.rs
@@ -25,6 +25,7 @@ pub fn get_jig() -> JigResponse {
         author_name: None,
         published_at: None,
         live_up_to_date: false,
+        is_liked: false,
         jig_data: JigData {
             created_at: chrono::offset::Utc::now(),
             draft_or_live: DraftOrLive::Draft,

--- a/frontend/apps/crates/entry/asset/edit/src/studio/dom.rs
+++ b/frontend/apps/crates/entry/asset/edit/src/studio/dom.rs
@@ -1,6 +1,6 @@
 use components::page_header::{PageHeader, PageHeaderConfig, PageLinks};
 use dominator::{events, html, on_click_go_to_url, Dom};
-use utils::routes::{AssetRoute, Route, HomeRoute};
+use utils::routes::{AssetRoute, HomeRoute, Route};
 
 use super::actions;
 

--- a/shared/rust/src/api/endpoints/course.rs
+++ b/shared/rust/src/api/endpoints/course.rs
@@ -4,9 +4,10 @@ use crate::{
         course::{
             CourseBrowsePath, CourseBrowseQuery, CourseBrowseResponse, CourseClonePath,
             CourseCreatePath, CourseCreateRequest, CourseDeletePath, CourseGetDraftPath,
-            CourseGetLivePath, CourseId, CoursePublishPath, CourseResponse, CourseSearchPath,
-            CourseSearchQuery, CourseSearchResponse, CourseUpdateDraftDataPath,
-            CourseUpdateDraftDataRequest,
+            CourseGetLivePath, CourseId, CourseLikePath, CourseLikedPath, CourseLikedResponse,
+            CoursePublishPath, CourseResponse, CourseSearchPath, CourseSearchQuery,
+            CourseSearchResponse, CourseUnlikePath, CourseUpdateDraftDataPath,
+            CourseUpdateDraftDataRequest, CourseViewPath,
         },
         CreateResponse,
     },
@@ -165,4 +166,56 @@ impl ApiEndpoint for Clone {
     type Res = CreateResponse<CourseId>;
     type Err = EmptyError;
     const METHOD: Method = Method::Post;
+}
+
+/// Like a Course
+///
+/// # Authorization
+/// * Admin, BasicAuth
+pub struct Like;
+impl ApiEndpoint for Like {
+    type Path = CourseLikePath;
+    type Req = ();
+    type Res = ();
+    type Err = EmptyError;
+    const METHOD: Method = Method::Put;
+}
+
+/// Unlike a Course
+///
+/// # Authorization
+/// * Admin, BasicAuth
+pub struct Unlike;
+impl ApiEndpoint for Unlike {
+    type Path = CourseUnlikePath;
+    type Req = ();
+    type Res = ();
+    type Err = EmptyError;
+    const METHOD: Method = Method::Delete;
+}
+
+/// Is a Course liked by a user
+///
+/// # Authorization
+/// * Admin, BasicAuth
+pub struct Liked;
+impl ApiEndpoint for Liked {
+    type Path = CourseLikedPath;
+    type Req = ();
+    type Res = CourseLikedResponse;
+    type Err = EmptyError;
+    const METHOD: Method = Method::Get;
+}
+
+/// View a Course
+///
+/// # Authorization
+/// * None
+pub struct View;
+impl ApiEndpoint for View {
+    type Path = CourseViewPath;
+    type Req = ();
+    type Res = ();
+    type Err = EmptyError;
+    const METHOD: Method = Method::Put;
 }

--- a/shared/rust/src/domain/course.rs
+++ b/shared/rust/src/domain/course.rs
@@ -143,7 +143,7 @@ pub struct CourseResponse {
     pub live_up_to_date: bool,
 
     /// Liked by current user.
-    pub is_liked: Option<bool>,
+    pub is_liked: bool,
 
     /// The data of the requested Course.
     pub course_data: CourseData,
@@ -384,8 +384,23 @@ pub struct CourseSearchResponse {
     pub total_course_count: u64,
 }
 
+/// Response for whether a user has liked a Course.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct CourseLikedResponse {
+    /// Whether the authenticated user has liked the current Course
+    pub is_liked: bool,
+}
+
 make_path_parts!(CourseDeletePath => "/v1/course/{}" => CourseId);
 
 make_path_parts!(CourseClonePath => "/v1/course/{}/clone" => CourseId);
+
+make_path_parts!(CourseLikePath => "/v1/course/{}/like" => CourseId);
+
+make_path_parts!(CourseUnlikePath => "/v1/course/{}/unlike" => CourseId);
+
+make_path_parts!(CourseLikedPath => "/v1/course/{}/like" => CourseId);
+
+make_path_parts!(CourseViewPath => "/v1/course/{}/view" => CourseId);
 
 into_uuid![CourseId];

--- a/shared/rust/src/domain/course.rs
+++ b/shared/rust/src/domain/course.rs
@@ -142,6 +142,9 @@ pub struct CourseResponse {
     /// Live is current to Draft
     pub live_up_to_date: bool,
 
+    /// Liked by current user.
+    pub is_liked: Option<bool>,
+
     /// The data of the requested Course.
     pub course_data: CourseData,
 }

--- a/shared/rust/src/domain/jig.rs
+++ b/shared/rust/src/domain/jig.rs
@@ -468,6 +468,9 @@ pub struct JigResponse {
     /// The data of the requested JIG.
     pub jig_data: JigData,
 
+    /// Liked by current user.
+    pub is_liked: Option<bool>,
+
     /// Admin data for Jig
     pub admin_data: JigAdminData,
 }
@@ -759,7 +762,7 @@ pub struct JigCountResponse {
 
 make_path_parts!(JigLikePath => "/v1/jig/{}/like" => JigId);
 
-make_path_parts!(JigUnlikePath => "/v1/jig/{}/like" => JigId);
+make_path_parts!(JigUnlikePath => "/v1/jig/{}/unlike" => JigId);
 
 make_path_parts!(JigLikedPath => "/v1/jig/{}/like" => JigId);
 

--- a/shared/rust/src/domain/jig.rs
+++ b/shared/rust/src/domain/jig.rs
@@ -469,7 +469,7 @@ pub struct JigResponse {
     pub jig_data: JigData,
 
     /// Liked by current user.
-    pub is_liked: Option<bool>,
+    pub is_liked: bool,
 
     /// Admin data for Jig
     pub admin_data: JigAdminData,

--- a/shared/rust/src/domain/resource.rs
+++ b/shared/rust/src/domain/resource.rs
@@ -59,7 +59,7 @@ pub struct ResourceResponse {
     pub live_up_to_date: bool,
 
     /// Liked by current user.
-    pub is_liked: Option<bool>,
+    pub is_liked: bool,
 
     /// The data of the requested Resource.
     pub resource_data: ResourceData,
@@ -522,7 +522,7 @@ impl TryFrom<u8> for ResourceRating {
 
 make_path_parts!(ResourceLikePath => "/v1/resource/{}/like" => ResourceId);
 
-make_path_parts!(ResourceUnlikePath => "/v1/resource/{}/like" => ResourceId);
+make_path_parts!(ResourceUnlikePath => "/v1/resource/{}/unlike" => ResourceId);
 
 make_path_parts!(ResourceLikedPath => "/v1/resource/{}/like" => ResourceId);
 

--- a/shared/rust/src/domain/resource.rs
+++ b/shared/rust/src/domain/resource.rs
@@ -58,6 +58,9 @@ pub struct ResourceResponse {
     /// Live is current to Draft
     pub live_up_to_date: bool,
 
+    /// Liked by current user.
+    pub is_liked: Option<bool>,
+
     /// The data of the requested Resource.
     pub resource_data: ResourceData,
 


### PR DESCRIPTION
https://github.com/ji-devs/ji-cloud/issues/3553

@MendyBerger 

## Added
- `is_liked` field in `JigResponse`, `CourseResponse`, and `ResourceResponse`
- Added `like`, `liked`, `view`, and `unlike` endpoints for Courses