### PR TITLE
chore(shared): Add wrap_uuid macro to make it easier to add Uuid newtypes

### DIFF
--- a/shared/rust/src/domain/additional_resource.rs
+++ b/shared/rust/src/domain/additional_resource.rs
@@ -6,13 +6,11 @@ use crate::{
 };
 use macros::make_path_parts;
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 
-/// Wrapper type around [`Uuid`](Uuid), represents the ID of an additional resource.
-#[derive(Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Debug, PathPart)]
-#[cfg_attr(feature = "backend", derive(sqlx::Type))]
-#[cfg_attr(feature = "backend", sqlx(transparent))]
-pub struct AdditionalResourceId(pub Uuid);
+wrap_uuid! {
+    /// Wrapper type around [`Uuid`](Uuid), represents the ID of an additional resource.
+    pub struct AdditionalResourceId
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -118,5 +116,3 @@ pub enum ResourceContent {
     /// Additional resource kind: pdf
     PdfId(PdfId),
 }
-
-into_uuid![AdditionalResourceId];

--- a/shared/rust/src/domain/animation.rs
+++ b/shared/rust/src/domain/animation.rs
@@ -8,7 +8,6 @@ use macros::make_path_parts;
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "backend")]
 use sqlx::postgres::PgRow;
-use uuid::Uuid;
 
 /// Animation Kinds
 #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
@@ -32,11 +31,10 @@ impl AnimationKind {
     }
 }
 
-/// Wrapper type around [`Uuid`], represents the ID of an animation.
-#[derive(Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Debug, PathPart)]
-#[cfg_attr(feature = "backend", derive(sqlx::Type))]
-#[cfg_attr(feature = "backend", sqlx(transparent))]
-pub struct AnimationId(pub Uuid);
+wrap_uuid! {
+    /// Wrapper type around [`Uuid`], represents the ID of an animation.
+    pub struct AnimationId
+}
 
 make_path_parts!(AnimationGetPath => "/v1/animation/{}" => AnimationId);
 
@@ -175,5 +173,3 @@ pub struct AnimationUploadResponse {
 }
 
 make_path_parts!(AnimationDeletePath => "/v1/animation/{}" => AnimationId);
-
-into_uuid![AnimationId];

--- a/shared/rust/src/domain/audio.rs
+++ b/shared/rust/src/domain/audio.rs
@@ -6,7 +6,6 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "backend")]
 use sqlx::postgres::PgRow;
-use uuid::Uuid;
 
 /// Types for user audio library.
 pub mod user {
@@ -64,11 +63,10 @@ pub mod user {
     make_path_parts!(UserAudioDeletePath => "/v1/user/me/audio/{}" => AudioId);
 }
 
-/// Wrapper type around [`Uuid`](Uuid), represents the ID of an audio file.
-#[derive(Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Debug, PathPart)]
-#[cfg_attr(feature = "backend", derive(sqlx::Type))]
-#[cfg_attr(feature = "backend", sqlx(transparent))]
-pub struct AudioId(pub Uuid);
+wrap_uuid! {
+    /// Wrapper type around [`Uuid`](Uuid), represents the ID of an audio file.
+    pub struct AudioId
+}
 
 /// Represents different kinds of audio.
 #[derive(Serialize, Deserialize, Copy, Clone, Debug)]
@@ -166,5 +164,3 @@ struct DbAudio {
     pub created_at: DateTime<Utc>,
     pub updated_at: Option<DateTime<Utc>>,
 }
-
-into_uuid![AudioId];

--- a/shared/rust/src/domain/category.rs
+++ b/shared/rust/src/domain/category.rs
@@ -7,15 +7,12 @@ use uuid::Uuid;
 
 use crate::{api::endpoints::PathPart, domain::user::UserScope};
 
-/// Wrapper type around [`Uuid`], represents the ID of a category.
-///
-/// [`Uuid`]: ../../uuid/struct.Uuid.html
-#[derive(Hash, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Debug, PathPart)]
-#[cfg_attr(feature = "backend", derive(sqlx::Type))]
-#[cfg_attr(feature = "backend", sqlx(transparent))]
-pub struct CategoryId(pub Uuid);
-
-into_uuid!(CategoryId);
+wrap_uuid! {
+    /// Wrapper type around [`Uuid`], represents the ID of a category.
+    ///
+    /// [`Uuid`]: ../../uuid/struct.Uuid.html
+    pub struct CategoryId
+}
 
 #[derive(Serialize, Deserialize, Debug)]
 /// The response returned when a request for categories is successful.

--- a/shared/rust/src/domain/circle.rs
+++ b/shared/rust/src/domain/circle.rs
@@ -3,18 +3,16 @@
 use chrono::{DateTime, Utc};
 use macros::make_path_parts;
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 
 use crate::api::endpoints::PathPart;
 
 use super::{asset::UserOrMe, image::ImageId, user::UserId};
 
-/// Wrapper type around [`Uuid`], represents the ID of a Circle.
-#[derive(Hash, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Debug, PathPart)]
-#[cfg_attr(feature = "backend", derive(sqlx::Type))]
-#[cfg_attr(feature = "backend", sqlx(transparent))]
-#[serde(rename_all = "camelCase")]
-pub struct CircleId(pub Uuid);
+wrap_uuid! {
+    /// Wrapper type around [`Uuid`], represents the ID of a Circle.
+    #[serde(rename_all = "camelCase")]
+    pub struct CircleId
+}
 
 /// The response returned when a request for `GET`ing a Circle is successful.
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -194,5 +192,3 @@ pub struct BrowseMembersResponse {
     /// user id of member
     pub count: u32,
 }
-
-into_uuid![CircleId];

--- a/shared/rust/src/domain/course.rs
+++ b/shared/rust/src/domain/course.rs
@@ -4,7 +4,6 @@ use chrono::{DateTime, Utc};
 use macros::make_path_parts;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use uuid::Uuid;
 
 use super::{
     super::api::endpoints::PathPart,
@@ -17,11 +16,10 @@ use super::{
     user::UserId,
 };
 
-/// Wrapper type around [`Uuid`], represents the ID of a Course.
-#[derive(Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Debug, PathPart)]
-#[cfg_attr(feature = "backend", derive(sqlx::Type))]
-#[cfg_attr(feature = "backend", sqlx(transparent))]
-pub struct CourseId(pub Uuid);
+wrap_uuid! {
+    /// Wrapper type around [`Uuid`], represents the ID of a Course.
+    pub struct CourseId
+}
 
 make_path_parts!(CourseCreatePath => "/v1/course");
 
@@ -402,5 +400,3 @@ make_path_parts!(CourseUnlikePath => "/v1/course/{}/unlike" => CourseId);
 make_path_parts!(CourseLikedPath => "/v1/course/{}/like" => CourseId);
 
 make_path_parts!(CourseViewPath => "/v1/course/{}/view" => CourseId);
-
-into_uuid![CourseId];

--- a/shared/rust/src/domain/image.rs
+++ b/shared/rust/src/domain/image.rs
@@ -17,7 +17,6 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "backend")]
 use sqlx::{postgres::PgRow, types::Json};
 use std::collections::HashMap;
-use uuid::Uuid;
 
 make_path_parts!(ImageGetPath => "/v1/image/{}" => ImageId);
 
@@ -60,13 +59,12 @@ impl ImageSize {
     }
 }
 
-/// Wrapper type around [`Uuid`], represents the ID of a image.
-///
-/// [`Uuid`]: ../../uuid/struct.Uuid.html
-#[derive(Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Debug, PathPart, Hash)]
-#[cfg_attr(feature = "backend", derive(sqlx::Type))]
-#[cfg_attr(feature = "backend", sqlx(transparent))]
-pub struct ImageId(pub Uuid);
+wrap_uuid! {
+    /// Wrapper type around [`Uuid`], represents the ID of a image.
+    ///
+    /// [`Uuid`]: ../../uuid/struct.Uuid.html
+    pub struct ImageId
+}
 
 make_path_parts!(ImageCreatePath => "/v1/image");
 
@@ -234,7 +232,7 @@ pub struct ImageSearchQuery {
     /// correct that we get the desired ranking. This can also be interpreted as bit vector with comparison.
     ///
     /// *NOTE*: this means that with `i64` range supported by Algolia, we can only assign priority for
-    /// the first 62 tags. The remaining are all given a score of 1.  
+    /// the first 62 tags. The remaining are all given a score of 1.
     ///
     /// ## Example
     /// For an example request `[clothing, food, red, sports]`, we assign the scores:
@@ -480,5 +478,3 @@ struct DbImage {
 make_path_parts!(ImageDeletePath => "/v1/image/{}" => ImageId);
 
 make_path_parts!(ImagePutPath => "/v1/image/{}/use" => ImageId);
-
-into_uuid![ImageId];

--- a/shared/rust/src/domain/jig.rs
+++ b/shared/rust/src/domain/jig.rs
@@ -14,7 +14,6 @@ use std::{
     collections::{HashMap, HashSet},
     convert::TryFrom,
 };
-use uuid::Uuid;
 
 use super::{
     additional_resource::AdditionalResource,
@@ -26,11 +25,10 @@ use super::{
 };
 use crate::{api::endpoints::PathPart, domain::module::body::ThemeId};
 
-/// Wrapper type around [`Uuid`], represents the ID of a JIG.
-#[derive(Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Debug, PathPart, Hash)]
-#[cfg_attr(feature = "backend", derive(sqlx::Type))]
-#[cfg_attr(feature = "backend", sqlx(transparent))]
-pub struct JigId(pub Uuid);
+wrap_uuid! {
+    /// Wrapper type around [`Uuid`], represents the ID of a JIG.
+    pub struct JigId
+}
 
 make_path_parts!(JigCreatePath => "/v1/jig");
 
@@ -792,5 +790,3 @@ pub struct JigLikedResponse {
 make_path_parts!(JigPlayPath => "/v1/jig/{}/play" => JigId);
 
 make_path_parts!(JigAdminDataUpdatePath => "/v1/jig/{}/admin" => JigId);
-
-into_uuid![JigId];

--- a/shared/rust/src/domain/jig/curation.rs
+++ b/shared/rust/src/domain/jig/curation.rs
@@ -8,11 +8,10 @@ use crate::api::endpoints::PathPart;
 
 use super::{report::JigReport, JigId};
 
-/// Wrapper type around [`Uuid`](Uuid), represents the ID of a curation comment.
-#[derive(Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Debug, PathPart)]
-#[cfg_attr(feature = "backend", derive(sqlx::Type))]
-#[cfg_attr(feature = "backend", sqlx(transparent))]
-pub struct CommentId(pub Uuid);
+wrap_uuid! {
+    /// Wrapper type around [`Uuid`](Uuid), represents the ID of a curation comment.
+    pub struct CommentId
+}
 
 make_path_parts!(JigCurationPath => "/v1/jig/{}/curation" => JigId);
 
@@ -79,7 +78,7 @@ impl Default for JigCurationFieldsDone {
     }
 }
 
-/// Status of Curation  
+/// Status of Curation
 #[derive(Serialize, Deserialize, Copy, Clone, Eq, PartialEq, Debug)]
 #[cfg_attr(feature = "backend", derive(sqlx::Type))]
 #[serde(rename_all = "camelCase")]
@@ -210,5 +209,3 @@ pub struct JigCurationCommentResponse {
     /// Name of commenter
     pub author_name: String,
 }
-
-into_uuid![CommentId];

--- a/shared/rust/src/domain/jig/report.rs
+++ b/shared/rust/src/domain/jig/report.rs
@@ -9,11 +9,10 @@ use crate::api::endpoints::PathPart;
 
 use super::JigId;
 
-/// Wrapper type around [`Uuid`](Uuid), represents the ID of a curation comment.
-#[derive(Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Debug, PathPart)]
-#[cfg_attr(feature = "backend", derive(sqlx::Type))]
-#[cfg_attr(feature = "backend", sqlx(transparent))]
-pub struct ReportId(pub Uuid);
+wrap_uuid! {
+    /// Wrapper type around [`Uuid`](Uuid), represents the ID of a curation comment.
+    pub struct ReportId
+}
 
 make_path_parts!(GetJigReportPath => "/v1/jig/{}/report/{}" => JigId, ReportId);
 
@@ -120,5 +119,3 @@ impl JigReportType {
         serde_json::from_str(s).unwrap()
     }
 }
-
-into_uuid![ReportId];

--- a/shared/rust/src/domain/meta.rs
+++ b/shared/rust/src/domain/meta.rs
@@ -3,65 +3,48 @@
 use chrono::{DateTime, Utc};
 use macros::make_path_parts;
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 
-/// Wrapper type around [`Uuid`], represents [`ImageStyle::id`].
-#[derive(Hash, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
-#[cfg_attr(feature = "backend", derive(sqlx::Type))]
-#[cfg_attr(feature = "backend", sqlx(transparent))]
-pub struct ImageStyleId(pub Uuid);
+use crate::api::endpoints::PathPart;
 
-/// Wrapper type around [`Uuid`], represents [`AnimationStyle::id`].
-#[derive(Hash, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
-#[cfg_attr(feature = "backend", derive(sqlx::Type))]
-#[cfg_attr(feature = "backend", sqlx(transparent))]
-pub struct AnimationStyleId(pub Uuid);
+wrap_uuid! {
+    /// Wrapper type around [`Uuid`], represents [`ImageStyle::id`].
+    pub struct ImageStyleId
+}
 
-/// Wrapper type around [`Uuid`], represents [`AudioStyle::id`]. Note: not yet implemented
-#[derive(Hash, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
-#[cfg_attr(feature = "backend", derive(sqlx::Type))]
-#[cfg_attr(feature = "backend", sqlx(transparent))]
-pub struct AudioStyleId(pub Uuid);
+wrap_uuid! {
+    /// Wrapper type around [`Uuid`], represents [`AnimationStyle::id`].
+    pub struct AnimationStyleId
+}
 
-/// Wrapper type around [`Uuid`], represents [`AgeRange::id`].
-#[derive(Hash, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
-#[cfg_attr(feature = "backend", derive(sqlx::Type))]
-#[cfg_attr(feature = "backend", sqlx(transparent))]
-pub struct AgeRangeId(pub Uuid);
+wrap_uuid! {
+    /// Wrapper type around [`Uuid`], represents [`AudioStyle::id`]. Note: not yet implemented
+    pub struct AudioStyleId
+}
 
-/// Wrapper type around [`Uuid`], represents [`Affiliation::id`].
-#[derive(Hash, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
-#[cfg_attr(feature = "backend", derive(sqlx::Type))]
-#[cfg_attr(feature = "backend", sqlx(transparent))]
-pub struct AffiliationId(pub Uuid);
+wrap_uuid! {
+    /// Wrapper type around [`Uuid`], represents [`AgeRange::id`].
+    pub struct AgeRangeId
+}
 
-/// Wrapper type around [`Uuid`], represents [`AdditionalResource::id`].
-#[derive(Hash, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
-#[cfg_attr(feature = "backend", derive(sqlx::Type))]
-#[cfg_attr(feature = "backend", sqlx(transparent))]
-pub struct ResourceTypeId(pub Uuid);
+wrap_uuid! {
+    /// Wrapper type around [`Uuid`], represents [`Affiliation::id`].
+    pub struct AffiliationId
+}
 
-/// Wrapper type around [`Uuid`], represents [`Subject::id`].
-#[derive(Hash, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
-#[cfg_attr(feature = "backend", derive(sqlx::Type))]
-#[cfg_attr(feature = "backend", sqlx(transparent))]
-pub struct SubjectId(pub Uuid);
+wrap_uuid! {
+    /// Wrapper type around [`Uuid`], represents [`AdditionalResource::id`].
+    pub struct ResourceTypeId
+}
 
-/// Wrapper type around [`Uuid`], represents [`Report::id`].
-#[derive(Hash, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
-#[cfg_attr(feature = "backend", derive(sqlx::Type))]
-#[cfg_attr(feature = "backend", sqlx(transparent))]
-pub struct ReportId(pub Uuid);
+wrap_uuid! {
+    /// Wrapper type around [`Uuid`], represents [`Subject::id`].
+    pub struct SubjectId
+}
 
-into_uuid!(
-    ImageStyleId,
-    AnimationStyleId,
-    AffiliationId,
-    ResourceTypeId,
-    AgeRangeId,
-    SubjectId,
-    ReportId
-);
+wrap_uuid! {
+    /// Wrapper type around [`Uuid`], represents [`Report::id`].
+    pub struct ReportId
+}
 
 /// Wrapper type around [`i16`](std::i16), represents the index of an image tag.
 ///

--- a/shared/rust/src/domain/module.rs
+++ b/shared/rust/src/domain/module.rs
@@ -6,21 +6,19 @@ use chrono::{DateTime, Utc};
 use macros::make_path_parts;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
-use uuid::Uuid;
 
 /// Module bodies
 pub mod body;
 
 pub use body::Body as ModuleBody;
 
-/// Wrapper type around [`Uuid`](Uuid), represents the **unique ID** of a module.
-///
-/// This uniquely identifies a module. There is no other module that shares this ID.
-#[derive(Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Debug, PathPart)]
-#[cfg_attr(feature = "backend", derive(sqlx::Type))]
-#[cfg_attr(feature = "backend", sqlx(transparent))]
-#[serde(rename_all = "camelCase")]
-pub struct ModuleId(pub Uuid);
+wrap_uuid! {
+    /// Wrapper type around [`Uuid`](Uuid), represents the **unique ID** of a module.
+    ///
+    /// This uniquely identifies a module. There is no other module that shares this ID.
+    #[serde(rename_all = "camelCase")]
+    pub struct ModuleId
+}
 
 /// Represents the various kinds of data a module can represent.
 #[repr(i16)]
@@ -267,5 +265,3 @@ pub struct ModuleDeleteRequest {
     #[serde(flatten)]
     pub parent_id: AssetId,
 }
-
-into_uuid![ModuleId];

--- a/shared/rust/src/domain/pdf.rs
+++ b/shared/rust/src/domain/pdf.rs
@@ -2,7 +2,6 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 
 use crate::api::endpoints::PathPart;
 
@@ -62,11 +61,10 @@ pub mod user {
     make_path_parts!(UserPdfDeletePath => "/v1/user/me/pdf/{}" => PdfId);
 }
 
-/// Wrapper type around [`Uuid`](Uuid), represents the ID of an Pdf file.
-#[derive(Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Debug, PathPart)]
-#[cfg_attr(feature = "backend", derive(sqlx::Type))]
-#[cfg_attr(feature = "backend", sqlx(transparent))]
-pub struct PdfId(pub Uuid);
+wrap_uuid! {
+    /// Wrapper type around [`Uuid`](Uuid), represents the ID of an Pdf file.
+    pub struct PdfId
+}
 
 /// Response for getting a single Pdf file.
 #[derive(Serialize, Deserialize, Debug)]
@@ -96,5 +94,3 @@ pub struct PdfMetadata {
     /// When the Pdf was last updated.
     pub updated_at: Option<DateTime<Utc>>,
 }
-
-into_uuid![PdfId];

--- a/shared/rust/src/domain/pro_dev.rs
+++ b/shared/rust/src/domain/pro_dev.rs
@@ -3,7 +3,6 @@ use chrono::{DateTime, Utc};
 use macros::make_path_parts;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use uuid::Uuid;
 
 use self::unit::ProDevUnitId;
 
@@ -19,11 +18,10 @@ use super::{
 
 pub mod unit;
 
-/// Wrapper type around [`Uuid`], represents the ID of a ProDev.
-#[derive(Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Debug, PathPart)]
-#[cfg_attr(feature = "backend", derive(sqlx::Type))]
-#[cfg_attr(feature = "backend", sqlx(transparent))]
-pub struct ProDevId(pub Uuid);
+wrap_uuid! {
+    /// Wrapper type around [`Uuid`], represents the ID of a ProDev.
+    pub struct ProDevId
+}
 
 make_path_parts!(ProDevCreatePath => "/v1/pro-dev");
 
@@ -341,5 +339,3 @@ pub struct ProDevSearchResponse {
 }
 
 make_path_parts!(ProDevDeletePath => "/v1/pro-dev/{}" => ProDevId);
-
-into_uuid![ProDevId];

--- a/shared/rust/src/domain/pro_dev/unit.rs
+++ b/shared/rust/src/domain/pro_dev/unit.rs
@@ -9,15 +9,13 @@ use crate::{
 };
 use macros::make_path_parts;
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 
 use super::ProDevId;
 
-/// Wrapper type around [`Uuid`](Uuid), represents the ID of a Pro Dev Unit.
-#[derive(Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Debug, PathPart)]
-#[cfg_attr(feature = "backend", derive(sqlx::Type))]
-#[cfg_attr(feature = "backend", sqlx(transparent))]
-pub struct ProDevUnitId(pub Uuid);
+wrap_uuid! {
+    /// Wrapper type around [`Uuid`](Uuid), represents the ID of a Pro Dev Unit.
+    pub struct ProDevUnitId
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -117,5 +115,3 @@ pub struct Video {
     /// end timestamp
     pub end_at: Option<u32>,
 }
-
-into_uuid![ProDevUnitId];

--- a/shared/rust/src/domain/resource.rs
+++ b/shared/rust/src/domain/resource.rs
@@ -3,7 +3,6 @@ use chrono::{DateTime, Utc};
 use macros::make_path_parts;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, convert::TryFrom};
-use uuid::Uuid;
 
 pub mod curation;
 
@@ -21,11 +20,10 @@ use super::{
     user::UserId,
 };
 
-/// Wrapper type around [`Uuid`], represents the ID of a Resource.
-#[derive(Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Debug, PathPart)]
-#[cfg_attr(feature = "backend", derive(sqlx::Type))]
-#[cfg_attr(feature = "backend", sqlx(transparent))]
-pub struct ResourceId(pub Uuid);
+wrap_uuid! {
+    /// Wrapper type around [`Uuid`], represents the ID of a Resource.
+    pub struct ResourceId
+}
 
 make_path_parts!(ResourceCreatePath => "/v1/resource");
 
@@ -529,5 +527,3 @@ make_path_parts!(ResourceLikedPath => "/v1/resource/{}/like" => ResourceId);
 make_path_parts!(ResourceViewPath => "/v1/resource/{}/view" => ResourceId);
 
 make_path_parts!(ResourceAdminDataUpdatePath => "/v1/resource/{}/admin" => ResourceId);
-
-into_uuid![ResourceId];

--- a/shared/rust/src/domain/resource/curation.rs
+++ b/shared/rust/src/domain/resource/curation.rs
@@ -2,17 +2,15 @@
 use chrono::{DateTime, Utc};
 use macros::make_path_parts;
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 
 use crate::api::endpoints::PathPart;
 
 use super::{report::ResourceReport, ResourceId, UserId};
 
-/// Wrapper type around [`Uuid`](Uuid), represents the ID of a curation comment.
-#[derive(Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Debug, PathPart)]
-#[cfg_attr(feature = "backend", derive(sqlx::Type))]
-#[cfg_attr(feature = "backend", sqlx(transparent))]
-pub struct CommentId(pub Uuid);
+wrap_uuid! {
+    /// Wrapper type around [`Uuid`](Uuid), represents the ID of a curation comment.
+    pub struct CommentId
+}
 
 make_path_parts!(ResourceCurationPath => "/v1/resource/{}/curation" => ResourceId);
 
@@ -79,7 +77,7 @@ impl Default for ResourceCurationFieldsDone {
     }
 }
 
-/// Status of Curation  
+/// Status of Curation
 #[derive(Serialize, Deserialize, Copy, Clone, Eq, PartialEq, Debug)]
 #[cfg_attr(feature = "backend", derive(sqlx::Type))]
 #[serde(rename_all = "camelCase")]
@@ -206,5 +204,3 @@ pub struct ResourceCurationCommentResponse {
     /// Name of commenter
     pub author_name: String,
 }
-
-into_uuid![CommentId];

--- a/shared/rust/src/domain/resource/report.rs
+++ b/shared/rust/src/domain/resource/report.rs
@@ -9,11 +9,10 @@ use crate::api::endpoints::PathPart;
 
 use super::ResourceId;
 
-/// Wrapper type around [`Uuid`](Uuid), represents the ID of a curation comment.
-#[derive(Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Debug, PathPart)]
-#[cfg_attr(feature = "backend", derive(sqlx::Type))]
-#[cfg_attr(feature = "backend", sqlx(transparent))]
-pub struct ReportId(pub Uuid);
+wrap_uuid! {
+    /// Wrapper type around [`Uuid`](Uuid), represents the ID of a curation comment.
+    pub struct ReportId
+}
 
 make_path_parts!(GetResourceReportPath => "/v1/resource/{}/report/{}" => ResourceId, ReportId);
 
@@ -120,5 +119,3 @@ impl ResourceReportType {
         serde_json::from_str(s).unwrap()
     }
 }
-
-into_uuid![ReportId];

--- a/shared/rust/src/domain/user.rs
+++ b/shared/rust/src/domain/user.rs
@@ -4,7 +4,6 @@ use chrono::{DateTime, NaiveDate, Utc};
 use macros::make_path_parts;
 use serde::{Deserialize, Serialize, Serializer};
 use std::convert::TryFrom;
-use uuid::Uuid;
 
 use crate::{
     api::endpoints::PathPart,
@@ -17,11 +16,10 @@ use crate::{
 
 pub mod public_user;
 
-/// Wrapper type around [`Uuid`], represents the ID of a User.
-#[derive(Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Debug, PathPart)]
-#[cfg_attr(feature = "backend", derive(sqlx::Type))]
-#[cfg_attr(feature = "backend", sqlx(transparent))]
-pub struct UserId(pub Uuid);
+wrap_uuid! {
+    /// Wrapper type around [`Uuid`], represents the ID of a User.
+    pub struct UserId
+}
 
 impl std::fmt::Display for UserId {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
@@ -781,5 +779,3 @@ pub struct UserSearchResponse {
 }
 
 make_path_parts!(UserSearchPath => "/v1/user");
-
-into_uuid![UserId];


### PR DESCRIPTION
Part of #3697 - Some cleaning up so that Uuid newtypes can be implemented a bit more easily and consistently.

Adds a util macro to generate newtype wrappers around UUIDs:

```rust
wrap_uuid! {
    /// Wrapper type around [`Uuid`](Uuid), represents the **unique ID** of a module.
    ///
    /// This uniquely identifies a module. There is no other module that shares this ID.
    #[serde(rename_all = "camelCase")]
    pub struct ModuleId
}
```

Generates:

```rust
#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, PathPart, Hash)]
#[doc = " Wrapper type around [`Uuid`](Uuid), represents the **unique ID** of a module."]
#[doc = ""]
#[doc = " This uniquely identifies a module. There is no other module that shares this ID."]
#[serde(rename_all = "camelCase")]
#[cfg_attr(feature = "backend", derive(sqlx::Type))]
#[cfg_attr(feature = "backend", sqlx(transparent))]
pub struct ModuleId(pub uuid::Uuid);

impl From<ModuleId> for uuid::Uuid {
    fn from(t: ModuleId) -> Self {
        t.0
    }
}
```