### PR TITLE
feat(fe/module-assist): Hide popup when audio-only instructions, except for timer and override

### DIFF
--- a/frontend/apps/crates/entry/asset/play/src/jig/actions.rs
+++ b/frontend/apps/crates/entry/asset/play/src/jig/actions.rs
@@ -222,7 +222,7 @@ pub fn play_assist_audio(state: Rc<JigPlayer>) {
 
                     // For the `Instructions` variant, we display a default text in the popup when a _timer_ is set. In that case
                     // we don't want to fire the done event when audio completes.
-                    if !(state.timer.get_cloned().is_some() && module_assist.module_assist_type.is_instructions()) && module_assist.text.is_none() {
+                    if !((state.timer.get_cloned().is_some() || module_assist.always_show) && module_assist.module_assist_type.is_instructions()) && module_assist.text.is_none() {
                         // If there is no text, then we can notify the activity that the assist audio has completed.
                         module_assist_done(state.clone(), module_assist.clone());
                     }

--- a/frontend/apps/crates/entry/asset/play/src/jig/state.rs
+++ b/frontend/apps/crates/entry/asset/play/src/jig/state.rs
@@ -114,6 +114,7 @@ pub fn can_load_liked_status(jig: &JigResponse) -> bool {
 pub struct PlayModuleAssist {
     pub text: Option<String>,
     pub audio: Option<Audio>,
+    pub always_show: bool,
     pub module_assist_type: ModuleAssistType,
 }
 
@@ -125,6 +126,7 @@ impl PlayModuleAssist {
         Self {
             text: module_assist.text,
             audio: module_assist.audio,
+            always_show: module_assist.always_show,
             module_assist_type,
         }
     }

--- a/frontend/apps/crates/entry/module/drag-drop/play/src/debug.rs
+++ b/frontend/apps/crates/entry/module/drag-drop/play/src/debug.rs
@@ -183,13 +183,13 @@ impl DebugSettings {
                         theme: ThemeId::Chalkboard,
                         instructions: ModuleAssist::default(),
                         //feedback: Instructions::default(),
-                        feedback: ModuleAssist {
-                            text: Some("good job!".to_string()),
-                            audio: Some(Audio {
+                        feedback: ModuleAssist::new(
+                            Some("good job!".to_string()),
+                            Some(Audio {
                                 id: AudioId(Uuid::parse_str(AUDIO_UUID).unwrap_ji()),
                                 lib: MediaLibrary::User,
                             }),
-                        },
+                        ),
                         backgrounds: Backgrounds {
                             layer_1: None, //Some(Background::Color(hex_to_rgba8("#ff0000"))),
                             layer_2: None,

--- a/frontend/apps/crates/entry/module/find-answer/play/src/base/game/playing/dom.rs
+++ b/frontend/apps/crates/entry/module/find-answer/play/src/base/game/playing/dom.rs
@@ -71,10 +71,7 @@ pub fn render(state: Rc<PlayState>) -> Dom {
                     if is_in_iframe() {
                         // If we're in an iframe, send a message to the player to play the audio from
                         // the module assist component. This allows students to replay the question audio.
-                        let module_assist = ModuleAssist {
-                            text: None,
-                            audio: Some(audio.clone()),
-                        };
+                        let module_assist = ModuleAssist::new(None, Some(audio.clone()));
                         let msg = IframeAction::new(ModuleToJigPlayerMessage::ModuleAssist(Some((module_assist, ModuleAssistType::InActivity))));
                         let _ = msg.try_post_message_to_player();
                     } else {

--- a/frontend/apps/crates/entry/module/find-answer/play/src/base/state.rs
+++ b/frontend/apps/crates/entry/module/find-answer/play/src/base/state.rs
@@ -86,7 +86,7 @@ impl Base {
             sticker_refs,
             question_field: content.question_field,
             module_phase: init_args.play_phase,
-            instructions: content.base.instructions,
+            instructions: content.base.instructions.always_show(),
             feedback: content.base.feedback,
             feedback_signal: Mutable::new(None),
         });

--- a/frontend/apps/crates/entry/module/flashcards/play/src/debug.rs
+++ b/frontend/apps/crates/entry/module/flashcards/play/src/debug.rs
@@ -56,10 +56,10 @@ impl DebugSettings {
                         base: BaseContent {
                             mode,
                             theme: ThemeId::Chalkboard,
-                            instructions: ModuleAssist {
-                                text: Some(String::from("Hello world!")),
-                                audio: None,
-                            },
+                            instructions: ModuleAssist::new(
+                                Some(String::from("Hello world!")),
+                                None,
+                            ),
                             pairs: if init_data.with_pairs {
                                 config::get_debug_pairs(mode)
                                     .into_iter()

--- a/shared/rust/src/domain/module/body.rs
+++ b/shared/rust/src/domain/module/body.rs
@@ -426,12 +426,33 @@ pub struct Audio {
 pub struct ModuleAssist {
     /// Text displayed in banner
     pub text: Option<String>,
-
     /// Audio played on module start
     pub audio: Option<Audio>,
+    /// Whether to always show module assistance
+    ///
+    /// This will override the default module assist behavior.
+    ///
+    /// Note: This value will never be persisted in the backend.
+    #[serde(skip)]
+    pub always_show: bool,
 }
 
 impl ModuleAssist {
+    /// Create a new ModuleAssist instance which doesn't override module assist behavior
+    pub fn new(text: Option<String>, audio: Option<Audio>) -> Self {
+        Self {
+            text,
+            audio,
+            ..Default::default()
+        }
+    }
+
+    /// Override default module assist behavior
+    pub fn always_show(mut self) -> Self {
+        self.always_show = true;
+        self
+    }
+
     /// Whether the instructions actually have either text or audio content set
     pub fn has_content(&self) -> bool {
         self.text.is_some() || self.audio.is_some()


### PR DESCRIPTION
Closes #3711 