### PR TITLE
chore(be): Use crates.io sparse protocol for building images

### DIFF
--- a/backend/api/Dockerfile
+++ b/backend/api/Dockerfile
@@ -4,8 +4,10 @@
 
 FROM clux/muslrust:stable AS api-builder
 
-# Add our source code.
+# Use crates.io sparse protocol
+ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
+# Add our source code.
 RUN mkdir -p /workspace/backend/api
 COPY ./shared /workspace/shared
 COPY ./backend/core /workspace/backend/core


### PR DESCRIPTION
Could shave up to a minute off the build time.

~Will merge once the v1.68.0 base docker image is available.~