### PR TITLE
fix(fe/pro-dev/edit/unit): update data on editor & sidebar after changes

### DIFF
--- a/frontend/apps/crates/entry/asset/edit/src/edit/sidebar/spot/actions.rs
+++ b/frontend/apps/crates/entry/asset/edit/src/edit/sidebar/spot/actions.rs
@@ -50,7 +50,7 @@ pub fn add_empty_module_after(state: Rc<SpotState>) {
             state
                 .sidebar
                 .asset_edit_state
-                .set_route_pro_dev(ProDevEditRoute::Unit(None));
+                .set_route_pro_dev(ProDevEditRoute::Landing);
         }
     }
 }
@@ -88,7 +88,7 @@ pub fn move_index(state: Rc<SpotState>, move_target: MoveTarget) {
                 },
                 SidebarSpotItem::ProDev(unit) => {
                     pro_dev_actions::update_unit_index(
-                        &Rc::clone(&state),
+                        Rc::clone(&state),
                         unit.as_ref(),
                         target as u16
                     ).await;

--- a/frontend/apps/crates/entry/asset/edit/src/edit/sidebar/spot/pro_dev/actions.rs
+++ b/frontend/apps/crates/entry/asset/edit/src/edit/sidebar/spot/pro_dev/actions.rs
@@ -53,7 +53,7 @@ pub async fn delete(state: &Rc<SpotState>, item: &Option<Rc<ProDevSpot>>) {
     }
 }
 
-pub async fn update_unit_index(state: &Rc<SpotState>, item: Option<&Rc<ProDevSpot>>, index: u16) {
+pub async fn update_unit_index(state: Rc<SpotState>, item: Option<&Rc<ProDevSpot>>, index: u16) {
     let req = ProDevUnitUpdateRequest {
         index: Some(index),
         description: None,
@@ -62,6 +62,7 @@ pub async fn update_unit_index(state: &Rc<SpotState>, item: Option<&Rc<ProDevSpo
     };
 
     if let Some(item) = item.clone() {
+        log::info!("index: {index}");
         match &**item {
             ProDevSpot::Cover(_) => unimplemented!(),
             ProDevSpot::Unit(item) => {


### PR DESCRIPTION
## What
- unit editor window and sidebar properly registers changes when changes are submitted