### PR TITLE
fix(fe/asset/play/pro-dev): disable nav arrows on first and last units

### DIFF
--- a/frontend/apps/crates/entry/asset/play/src/pro_dev/player_popup/action.rs
+++ b/frontend/apps/crates/entry/asset/play/src/pro_dev/player_popup/action.rs
@@ -6,28 +6,28 @@ use futures_signals::signal::{Signal, SignalExt};
 use shared::domain::pro_dev::ProDevResponse;
 
 impl PlayerPopup {
-    pub fn page_back_signal(&self) -> impl Signal<Item = bool> {
-        self.player_state
-            .current_page
-            .signal()
-            .map(move |current_page| {
-                let current_page = current_page.unwrap_or(0);
-                if current_page > 0 {
+    pub fn navigate_previous_signal(&self) -> impl Signal<Item = bool> {
+        self.player_state.active_unit.signal().map(
+            move |active_unit| {
+                if active_unit > Some(0) {
                     false
                 } else {
                     true
                 }
-            })
+            },
+        )
     }
 
-    pub fn page_forward_signal(&self, pro_dev: &Rc<ProDevResponse>) -> impl Signal<Item = bool> {
+    pub fn navigate_forward_signal(
+        &self,
+        pro_dev: &Rc<ProDevResponse>,
+    ) -> impl Signal<Item = bool> {
         self.player_state
-            .current_page
+            .active_unit
             .signal()
-            .map(clone!(pro_dev => move |current_page| {
-                let current_page = current_page.unwrap_or(0);
-                let num_pages = (pro_dev.pro_dev_data.units.len() + 9) / 10;
-                if current_page < (num_pages - 1)  {
+            .map(clone!(pro_dev => move |active_unit| {
+                let last_index = pro_dev.pro_dev_data.units.len();
+                if active_unit < Some(last_index - 1)  {
                     false
                 } else {
                     true

--- a/frontend/apps/crates/entry/asset/play/src/pro_dev/player_popup/dom.rs
+++ b/frontend/apps/crates/entry/asset/play/src/pro_dev/player_popup/dom.rs
@@ -72,7 +72,7 @@ impl Component<PlayerPopup> for Rc<PlayerPopup> {
                                     html!("button", {  // back arrow button
                                         .text("<")
                                         .style("order", "0")
-                                        .prop_signal("hidden", state.page_back_signal())
+                                        .prop_signal("hidden", state.navigate_previous_signal())
                                         .event(clone!(state => move |_: events::Click| {
                                             let index = state.player_state.active_unit.get().unwrap_or(0);
                                             let current_page = state.player_state.current_page.get().unwrap_or(0);
@@ -96,7 +96,7 @@ impl Component<PlayerPopup> for Rc<PlayerPopup> {
                                     html!("button", {  // forward arrow button
                                         .text(">")
                                         .style("order", "2")
-                                        .prop_signal("hidden", state.page_forward_signal(&pro_dev))
+                                        .prop_signal("hidden", state.navigate_forward_signal(&pro_dev))
                                         .event(clone!(state, pro_dev => move |_: events::Click| {
                                                 let index = state.player_state.active_unit.get().unwrap_or(0);
                                                 let current_page = state.player_state.current_page.get().unwrap_or(0);

--- a/frontend/apps/crates/entry/module/legacy/play/src/base/activities/talk_type/actions.rs
+++ b/frontend/apps/crates/entry/module/legacy/play/src/base/activities/talk_type/actions.rs
@@ -91,7 +91,7 @@ impl HintLetters {
         match self.indices.pop() {
             None => None,
             Some(index) => {
-                let mut entry = &mut self.letters[index];
+                let entry = &mut self.letters[index];
                 entry.revealed = true;
                 Some(&entry.letter)
             }


### PR DESCRIPTION
## Fix
- forward and back arrow buttons disable when first or last units are active in player

## Cargo Check
- remove unnecessary `mut` in crates/entry/module/legacy/play/src/base/activities/talk_type/actions.rs:94