### PR TITLE
fix(fe/asset/edit/pro-dev): add unit spot using gear

### DIFF
--- a/frontend/apps/crates/entry/asset/edit/src/edit/actions/course_actions.rs
+++ b/frontend/apps/crates/entry/asset/edit/src/edit/actions/course_actions.rs
@@ -25,7 +25,7 @@ impl AssetEditState {
         }
 
         // add empty at the end
-        items.push(SidebarSpot::new_empty(&course.id.into()));
+        items.push(SidebarSpot::new_empty(&course.id.into(), None));
 
         let mut spots = self.sidebar_spots.lock_mut();
         for item in items {

--- a/frontend/apps/crates/entry/asset/edit/src/edit/actions/jig_actions.rs
+++ b/frontend/apps/crates/entry/asset/edit/src/edit/actions/jig_actions.rs
@@ -39,7 +39,7 @@ impl AssetEditState {
         };
 
         // add empty at the end
-        modules.push(SidebarSpot::new_empty(&jig.id.into()));
+        modules.push(SidebarSpot::new_empty(&jig.id.into(), None));
 
         let mut spots = self.sidebar_spots.lock_mut();
         for module in modules {

--- a/frontend/apps/crates/entry/asset/edit/src/edit/sidebar/spot/actions.rs
+++ b/frontend/apps/crates/entry/asset/edit/src/edit/sidebar/spot/actions.rs
@@ -34,7 +34,10 @@ pub fn add_empty_module_after(state: Rc<SpotState>) {
         .lock_mut()
         .insert_cloned(
             state.index + 1,
-            SidebarSpot::new_empty(&state.sidebar.asset_edit_state.asset_id),
+            SidebarSpot::new_empty(
+                &state.sidebar.asset_edit_state.asset_id,
+                Some(state.index + 1),
+            ),
         );
 
     match state.sidebar.asset_edit_state.asset_id {
@@ -50,7 +53,13 @@ pub fn add_empty_module_after(state: Rc<SpotState>) {
             state
                 .sidebar
                 .asset_edit_state
-                .set_route_pro_dev(ProDevEditRoute::Landing);
+                .target_index
+                .set(Some(state.index));
+
+            state
+                .sidebar
+                .asset_edit_state
+                .set_route_pro_dev(ProDevEditRoute::Unit(None));
         }
     }
 }
@@ -163,6 +172,8 @@ pub fn assign_to_empty_spot(state: &Rc<SpotState>, data: String) {
                 // add the new one. This is slightly less efficient because it fires signals
                 // for the entire list of modules, however, it is necessary so that the modules
                 // before and after this one can have their views updated.
+                log::info!("index: {:?}", state.index);
+
                 let mut modules = state.sidebar.asset_edit_state.sidebar_spots.lock_mut();
                 modules.remove(state.index);
                 modules.insert_cloned(state.index, module);
@@ -181,7 +192,7 @@ pub fn assign_to_empty_spot(state: &Rc<SpotState>, data: String) {
 
                 // if this is the empty module at the end
                 if !placeholder_exists && !state.sidebar.asset_edit_state.asset_id.is_pro_dev_id() {
-                    modules.push_cloned(SidebarSpot::new_empty(&state.sidebar.asset_edit_state.asset_id));
+                    modules.push_cloned(SidebarSpot::new_empty(&state.sidebar.asset_edit_state.asset_id, None));
                 }
 
                 // jigs are already saved in `assign_module_to_empty_spot`,

--- a/frontend/apps/crates/entry/asset/edit/src/edit/sidebar/spot/dom.rs
+++ b/frontend/apps/crates/entry/asset/edit/src/edit/sidebar/spot/dom.rs
@@ -271,6 +271,8 @@ impl SpotState {
                                     if idx == state.index {
                                         // Make sure that the module window is visible to the
                                         // teacher.
+
+                                        log::warn!("module");
                                         elem.scroll_into_view_with_scroll_into_view_options(ScrollIntoViewOptions::new().behavior(ScrollBehavior::Smooth));
                                         Some(html!("empty-fragment", {
                                             .apply(OverlayHandle::lifecycle(clone!(state, elem => move || {
@@ -294,6 +296,7 @@ impl SpotState {
                                     }
                                 },
                                 Some(ModuleHighlight::Unit(idx)) => {
+                                    log::warn!("unit");
                                     if idx == state.index {
                                         elem.scroll_into_view_with_scroll_into_view_options(ScrollIntoViewOptions::new().behavior(ScrollBehavior::Smooth));
                                         Some(html!("empty-fragment", {

--- a/frontend/apps/crates/entry/asset/edit/src/edit/sidebar/spot/state.rs
+++ b/frontend/apps/crates/entry/asset/edit/src/edit/sidebar/spot/state.rs
@@ -89,7 +89,7 @@ impl SpotState {
                 },
                 SidebarSpotItem::ProDev(pro_dev_spot) => {
                     match pro_dev_spot {
-                        None => "empty",
+                        None => "unit",
                         Some(item) =>
                             match &**item {
                                 ProDevSpot::Cover(_) => "thumbnail",
@@ -132,16 +132,25 @@ impl SpotState {
                             AssetEditRoute::Jig(_, JigEditRoute::Module(module_id)) if module_id == &module.id
                         )
                     }
-                    SidebarSpotItem::ProDev(Some(unit)) => {
-                        let id = match &**unit {
-                            ProDevSpot::Cover(_) => None,
-                            ProDevSpot::Unit(unit) => Some(unit.id),
-                        };
-                        matches!(
-                            route,
-                            AssetEditRoute::ProDev(_, ProDevEditRoute::Unit(unit_id)) if unit_id == &id
-                        )
-                    }
+                    SidebarSpotItem::ProDev(unit) => {
+                            match unit {
+                                Some(unit) => {
+                                    let id = match &**unit {
+                                        ProDevSpot::Cover(_) => None,
+                                        ProDevSpot::Unit(unit) => Some(unit.id),
+                                    };
+
+                                    matches!(
+                                        route,
+                                        AssetEditRoute::ProDev(_, ProDevEditRoute::Unit(unit_id)) if unit_id == &id
+                                    )
+                                },
+                                None => {
+                                    // Handle the None case here.
+                                    false // for example, you might simply return false
+                                },
+                            }
+                        }
                     _ => {
                         false
                     }

--- a/frontend/apps/crates/entry/asset/edit/src/edit/sidebar/state.rs
+++ b/frontend/apps/crates/entry/asset/edit/src/edit/sidebar/state.rs
@@ -102,11 +102,12 @@ impl Sidebar {
 #[derive(Clone, Debug)]
 pub struct SidebarSpot {
     pub item: SidebarSpotItem,
+    pub target_index: Mutable<Option<usize>>,
     pub is_incomplete: Mutable<bool>,
 }
 
 impl SidebarSpot {
-    pub fn new_empty(asset_id: &AssetId) -> Rc<Self> {
+    pub fn new_empty(asset_id: &AssetId, target_index: Option<usize>) -> Rc<Self> {
         let item = match asset_id {
             AssetId::JigId(_) => SidebarSpotItem::Jig(None),
             AssetId::CourseId(_) => SidebarSpotItem::Course(None),
@@ -115,6 +116,7 @@ impl SidebarSpot {
         };
         Rc::new(Self {
             item,
+            target_index: Mutable::new(target_index),
             is_incomplete: Mutable::new(false),
         })
     }
@@ -125,6 +127,7 @@ impl SidebarSpot {
                 Some(module) => !module.is_complete,
                 None => false,
             }),
+            target_index: Mutable::new(None),
             item: SidebarSpotItem::Jig(module.map(|module| Rc::new(module))),
         })
     }
@@ -132,6 +135,7 @@ impl SidebarSpot {
     pub fn new_course_cover(cover: LiteModule) -> Rc<Self> {
         Rc::new(Self {
             is_incomplete: Mutable::new(false),
+            target_index: Mutable::new(None),
             item: SidebarSpotItem::Course(Some(Rc::new(CourseSpot::Cover(cover)))),
         })
     }
@@ -139,6 +143,7 @@ impl SidebarSpot {
     pub fn new_course_item(jig: JigResponse) -> Rc<Self> {
         Rc::new(Self {
             is_incomplete: Mutable::new(false),
+            target_index: Mutable::new(None),
             item: SidebarSpotItem::Course(Some(Rc::new(CourseSpot::Item(jig)))),
         })
     }
@@ -146,6 +151,7 @@ impl SidebarSpot {
     pub fn new_pro_dev_cover(cover: LiteModule) -> Rc<Self> {
         Rc::new(Self {
             is_incomplete: Mutable::new(false),
+            target_index: Mutable::new(None),
             item: SidebarSpotItem::ProDev(Some(Rc::new(ProDevSpot::Cover(cover)))),
         })
     }
@@ -153,6 +159,7 @@ impl SidebarSpot {
     pub fn new_pro_dev_unit(unit: ProDevUnit) -> Rc<Self> {
         Rc::new(Self {
             is_incomplete: Mutable::new(false),
+            target_index: Mutable::new(None),
             item: SidebarSpotItem::ProDev(Some(Rc::new(ProDevSpot::Unit(unit)))),
         })
     }

--- a/frontend/apps/crates/entry/asset/edit/src/edit/state.rs
+++ b/frontend/apps/crates/entry/asset/edit/src/edit/state.rs
@@ -18,6 +18,7 @@ pub struct AssetEditState {
     pub sidebar_spots: MutableVec<Rc<SidebarSpot>>,
     pub route: Mutable<AssetEditRoute>,
     pub show_onboarding: Mutable<bool>,
+    pub target_index: Mutable<Option<usize>>,
     pub(super) play_jig: Mutable<Option<AssetPlayerOptions>>,
 }
 
@@ -35,6 +36,7 @@ impl AssetEditState {
             sidebar_spots: Default::default(),
             route: Mutable::new(route),
             play_jig: Mutable::new(None),
+            target_index: Mutable::new(None),
             show_onboarding: Mutable::new(show_onboarding),
         })
     }


### PR DESCRIPTION
https://github.com/ji-devs/ji-cloud/issues/3610

## FIX:
- add new units into specified spots 

## Added:
- new field `target_index` to `AssetEditState` and `SidebarSpot` 	