### PR TITLE
style(fe/asset/edit/pro-dev): rm display name from Preview button

### DIFF
--- a/frontend/apps/crates/entry/asset/edit/src/edit/sidebar/header/dom.rs
+++ b/frontend/apps/crates/entry/asset/edit/src/edit/sidebar/header/dom.rs
@@ -5,7 +5,8 @@ use std::rc::Rc;
 use web_sys::HtmlInputElement;
 
 use crate::edit::sidebar::{jig::actions::get_player_settings, state::SidebarSetting};
-
+use shared::domain::asset::AssetType
+;
 use super::super::{actions as sidebar_actions, state::Sidebar as SidebarState};
 use utils::{
     asset::{AssetPlayerOptions, CoursePlayerOptions, ProDevPlayerOptions},
@@ -99,7 +100,14 @@ impl HeaderDom {
                 }),
                 html!("jig-edit-sidebar-preview-button", {
                     .prop("slot", "preview")
-                    .prop("assetDisplayName", asset_edit_state.asset.asset_type().display_name())
+                    .prop("assetDisplayName", {
+                        let asset_type = asset_edit_state.asset.asset_type();
+                        if asset_type != AssetType::ProDev {
+                            asset_type.display_name()
+                        } else {
+                            ""
+                        }
+                    })
                     .event(clone!(sidebar_state, asset_edit_state => move |_: events::Click| {
                         match &sidebar_state.settings {
                             SidebarSetting::Jig(jig) => {

--- a/frontend/apps/crates/entry/asset/edit/src/edit/sidebar/header/dom.rs
+++ b/frontend/apps/crates/entry/asset/edit/src/edit/sidebar/header/dom.rs
@@ -4,10 +4,9 @@ use shared::domain::asset::{AssetId, DraftOrLive};
 use std::rc::Rc;
 use web_sys::HtmlInputElement;
 
-use crate::edit::sidebar::{jig::actions::get_player_settings, state::SidebarSetting};
-use shared::domain::asset::AssetType
-;
 use super::super::{actions as sidebar_actions, state::Sidebar as SidebarState};
+use crate::edit::sidebar::{jig::actions::get_player_settings, state::SidebarSetting};
+use shared::domain::asset::AssetType;
 use utils::{
     asset::{AssetPlayerOptions, CoursePlayerOptions, ProDevPlayerOptions},
     prelude::*,
@@ -63,7 +62,7 @@ impl HeaderDom {
                     .prop("weight", "medium")
                     .text(&format!("{}{}{}",
                         STR_MY_JIGS_1,
-                        asset_edit_state.asset.asset_type().display_name(),
+                        asset_edit_state.asset.asset_type().sidebar_header(),
                         STR_MY_JIGS_2
                     ))
                     .event(clone!(asset_edit_state => move |_:events::Click| {

--- a/shared/rust/src/domain/asset.rs
+++ b/shared/rust/src/domain/asset.rs
@@ -88,7 +88,7 @@ impl AssetType {
             Self::Jig => "JIG",
             Self::Resource => "resource",
             Self::Course => "course",
-            Self::ProDev => "Pro Dev",
+            Self::ProDev => "ProDev",
         }
     }
 
@@ -98,7 +98,17 @@ impl AssetType {
             Self::Jig => "JIG",
             Self::Resource => "Resource",
             Self::Course => "Course",
-            Self::ProDev => "Pro Dev",
+            Self::ProDev => "ProDev",
+        }
+    }
+
+    /// return to gallery button on sidebar
+    pub fn sidebar_header(&self) -> &'static str {
+        match self {
+            Self::Jig => "JIG",
+            Self::Resource => "resource",
+            Self::Course => "course",
+            Self::ProDev => "ProDev course",
         }
     }
 


### PR DESCRIPTION
https://github.com/ji-devs/ji-cloud/issues/3832

## Added
- Remove "Pro Dev" on preview button
- Change "My Pro Devs" to "My ProDev courses" for gallery return button on sidebar  