### PR TITLE
fix: Pin rust nightly

### DIFF
--- a/frontend/apps/rust-toolchain.toml
+++ b/frontend/apps/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
-channel = "nightly"
+# channel = "nightly"
+channel = "nightly-2023-06-19"


### PR DESCRIPTION
`rustup update` on CI has become flakey over the few days.