### PR TITLE
feat(fe/asset/play/jig): generate playlist names associated with jig

### DIFF
--- a/frontend/apps/crates/entry/asset/play/src/jig/actions.rs
+++ b/frontend/apps/crates/entry/asset/play/src/jig/actions.rs
@@ -7,6 +7,7 @@ use super::{
 use components::audio::mixer::{AudioHandle, AUDIO_MIXER};
 use dominator::clone;
 use futures_signals::signal::SignalExt;
+use shared::domain::jig::GetJigPlaylistsPath;
 use shared::{
     api::endpoints::{self, jig},
     domain::{
@@ -243,6 +244,7 @@ fn module_assist_done(state: Rc<JigPlayer>, play_module_assist: PlayModuleAssist
 pub fn load_data(state: Rc<JigPlayer>) {
     state.loader.load(clone!(state => async move {
         load_resource_types(Rc::clone(&state)).await;
+        load_jig_playlists(Rc::clone(&state)).await;
         load_jig(Rc::clone(&state)).await;
     }));
 }
@@ -305,6 +307,19 @@ async fn load_resource_types(state: Rc<JigPlayer>) {
         Err(_) => todo!(),
         Ok(meta) => {
             state.resource_types.set(meta.resource_types);
+        }
+    };
+}
+
+pub(crate) async fn load_jig_playlists(state: Rc<JigPlayer>) {
+    match endpoints::jig::GetJigPlaylists::api_no_auth(GetJigPlaylistsPath(state.jig_id), None)
+        .await
+    {
+        Err(_) => todo!(),
+        Ok(resp) => {
+            log::warn!("inside call");
+
+            state.playlists.set(resp.playlists);
         }
     };
 }

--- a/frontend/apps/crates/entry/asset/play/src/jig/state.rs
+++ b/frontend/apps/crates/entry/asset/play/src/jig/state.rs
@@ -10,6 +10,7 @@ use shared::domain::{
         body::{Audio, ModuleAssist, ModuleAssistType},
         ModuleId,
     },
+    playlist::PlaylistResponse,
 };
 use utils::asset::JigPlayerOptions;
 use web_sys::HtmlIFrameElement;
@@ -42,6 +43,7 @@ pub struct JigPlayer {
     pub bg_audio_playing: Mutable<bool>,
     pub module_assist_audio_handle: Rc<RefCell<Option<AudioHandle>>>,
     pub resource_types: Mutable<Vec<ResourceType>>,
+    pub playlists: Mutable<Vec<PlaylistResponse>>,
     pub module_assist: Mutable<Option<PlayModuleAssist>>,
     pub module_assist_visible: Mutable<bool>,
     pub is_full_screen: Mutable<bool>,
@@ -82,6 +84,7 @@ impl JigPlayer {
             bg_audio_playing: Mutable::new(true),
             module_assist_audio_handle: Rc::new(RefCell::new(None)),
             resource_types: Default::default(),
+            playlists: Default::default(),
             module_assist: Mutable::new(None),
             module_assist_visible: Mutable::new(false),
             is_full_screen: Mutable::new(false),

--- a/frontend/elements/src/entry/asset/play/jig/sidebar/jig-info.ts
+++ b/frontend/elements/src/entry/asset/play/jig/sidebar/jig-info.ts
@@ -105,6 +105,20 @@ export class _ extends LitElement {
                 }
                 .playlists-section .playlists {
                     display: grid;
+                    row-gap: 5px;
+                    margin-right: auto;
+                }
+                ::slotted(a[slot=playlists]) {
+                    color: var(--main-blue);
+                    font-weight: 450;
+                    text-decoration: none;
+                    font-size: 13px;
+                    display: flex;
+                    column-gap: 5px;
+                }
+
+                ::slotted(a[slot=playlists]:hover) {
+                    color: #55a8fc;
                 }
                 .report-section {
                     grid-template-columns: auto auto;
@@ -154,7 +168,7 @@ export class _ extends LitElement {
                         <div class="first-line">
                             <div class="author">
                                 ${this.byJiTeam
-                                    ? html`
+                ? html`
                                           <img-ui
                                               path="entry/home/search-results/ji-logo-blue.svg"
                                           ></img-ui>
@@ -162,7 +176,7 @@ export class _ extends LitElement {
                                               >${STR_JI_TEAM} -
                                           </span>
                                       `
-                                    : nothing}
+                : nothing}
                                 ${this.author}
                             </div>
                             <span class="published-at">
@@ -206,12 +220,11 @@ export class _ extends LitElement {
                         <div>
                             <h4>${STR_PLAYLISTS}</h4>
                             <!-- TODO: enable when ready -->
-                            <!-- <h5>${STR_PLAYLISTS_SUBHEADING}</h5> -->
+                            <h5>${STR_PLAYLISTS_SUBHEADING}</h5>
                         </div>
                         <div class="playlists">
                             <!-- TODO: enable when ready -->
-                            <!-- <slot name="playlists"></slot> -->
-                            Coming soon!
+                            <slot name="playlists"></slot>
                         </div>
                     </section>
                     <section class="report-section">


### PR DESCRIPTION
https://github.com/ji-devs/ji-cloud/issues/3817

## Added 
- clickable playlist names in the JIG info section