### PR TITLE
fix(fe/user/signup): change error message for existing username

### DIFF
--- a/frontend/apps/crates/entry/user/src/register/pages/step_1/state.rs
+++ b/frontend/apps/crates/entry/user/src/register/pages/step_1/state.rs
@@ -91,7 +91,7 @@ impl NameError {
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::Empty => "Can't be empty!",
-            Self::Exists => "Already exists!",
+            Self::Exists => "Sorry, this username is taken. Please try another.",
         }
     }
 }


### PR DESCRIPTION
https://github.com/ji-devs/ji-cloud/issues/3727

## Added
- message change from "Already exists!" to "Sorry, this username is taken. Please try another." 