### PR TITLE
fix(fe/user): Include Stripe setup intent ID in the subscribe request

### DIFF
--- a/frontend/apps/crates/entry/user/src/router.rs
+++ b/frontend/apps/crates/entry/user/src/router.rs
@@ -59,7 +59,9 @@ impl Router {
                 }
                 UserRoute::SchoolEnd => Some(SchoolEnd::new().render()),
                 UserRoute::Subscribe1(plan_type) => Some(Subscribe1::new(plan_type).render()),
-                UserRoute::Subscribe2(plan_type) => Some(Subscribe2::new(plan_type).render()),
+                UserRoute::Subscribe2(plan_type, params) => {
+                    Some(Subscribe2::new(plan_type, params).render())
+                }
                 UserRoute::Welcome => Some(Welcome::new().render()),
             },
             _ => None,

--- a/frontend/apps/crates/entry/user/src/subscribe1/actions.rs
+++ b/frontend/apps/crates/entry/user/src/subscribe1/actions.rs
@@ -31,7 +31,7 @@ impl Subscribe1 {
             let redirect_url = format!(
                 "{}{}",
                 SETTINGS.get().unwrap_ji().remote_target.pages_url(),
-                Route::User(UserRoute::Subscribe2(state.plan_type)).to_string()
+                Route::User(UserRoute::Subscribe2(state.plan_type, None)).to_string()
             );
             stripe.unwrap_ji().submit(&redirect_url).await;
         }));

--- a/frontend/apps/crates/entry/user/src/subscribe2/actions.rs
+++ b/frontend/apps/crates/entry/user/src/subscribe2/actions.rs
@@ -19,7 +19,9 @@ impl Subscribe2 {
         spawn_local(clone!(state => async move {
             let req: CreateSubscriptionRequest = CreateSubscriptionRequest {
                 plan_type: state.plan_type,
-                setup_intent_id: Default::default(),
+                setup_intent_id: state.params
+                    .as_ref()
+                    .and_then(|params| params.setup_intent.clone()),
                 promotion_code: Default::default()
             };
             endpoints::billing::CreateSubscription::api_with_auth(CreateSubscriptionPath(), Some(req)).await.unwrap_ji();

--- a/frontend/apps/crates/entry/user/src/subscribe2/state.rs
+++ b/frontend/apps/crates/entry/user/src/subscribe2/state.rs
@@ -1,15 +1,18 @@
 use dominator_helpers::futures::AsyncLoader;
 use shared::domain::billing::PlanType;
 use std::rc::Rc;
+use utils::routes::StripeRedirectParams;
 
 pub struct Subscribe2 {
     pub plan_type: PlanType,
+    pub params: Option<StripeRedirectParams>,
     pub loader: AsyncLoader,
 }
 impl Subscribe2 {
-    pub fn new(plan_type: PlanType) -> Rc<Self> {
+    pub fn new(plan_type: PlanType, params: Option<StripeRedirectParams>) -> Rc<Self> {
         Rc::new(Self {
             plan_type,
+            params,
             loader: AsyncLoader::new(),
         })
     }


### PR DESCRIPTION
We need to include the setup intent ID in the subscribe request so that we can mark the payment method as the default payment method. Without a default, once a trial expires, Stripe won't be able to successfully charge the customer.