### PR TITLE
fix(fe/asset/play/jig): remove resource display name from info panel

### DIFF
--- a/frontend/apps/crates/entry/asset/play/src/jig/sidebar/dom/info.rs
+++ b/frontend/apps/crates/entry/asset/play/src/jig/sidebar/dom/info.rs
@@ -103,12 +103,11 @@ fn render_jig_info(state: Rc<State>, jig: &JigResponse) -> Dom {
                 html!("a", {
                     .prop("slot", "additional-resources")
                     .prop("target", "_BLANK")
-                    .prop("title", &resource.display_name)
                     .prop("href", resource.resource_content.get_link())
+                    .prop("title", &resource.display_name)
                     .child(html!("fa-icon", {
                         .prop("icon", "fa-light fa-file")
                     }))
-                    .text(format!(" {}  ", &resource.display_name).as_str())
                     .text_signal(resource_type_name_signal(Rc::clone(&state), resource.resource_type_id))
                 })
             }))

--- a/frontend/apps/crates/utils/src/toasts.rs
+++ b/frontend/apps/crates/utils/src/toasts.rs
@@ -1,4 +1,3 @@
-use std::error::Error;
 use std::sync::Arc;
 use std::{borrow::Cow, sync::Mutex};
 

--- a/frontend/elements/src/entry/asset/play/jig/sidebar/jig-info.ts
+++ b/frontend/elements/src/entry/asset/play/jig/sidebar/jig-info.ts
@@ -199,7 +199,7 @@ export class _ extends LitElement {
                             <a href=${this.href} .target=${this.target}>
                                 <div class="author">
                                     ${this.byJiTeam
-                    ? html`
+                ? html`
                                             <img-ui
                                                 path="entry/home/search-results/ji-logo-blue.svg"
                                             ></img-ui>
@@ -207,7 +207,7 @@ export class _ extends LitElement {
                                                 >${STR_JI_TEAM} -
                                             </span>
                                         `
-                    : nothing}
+                : nothing}
                                     ${this.author}
                                 </div>
                             </a>
@@ -245,18 +245,16 @@ export class _ extends LitElement {
                             <slot name="categories"></slot>
                         </div>
                     </section>
-                    ${
-                        this.showResources ? html`
+                    ${this.showResources ? html`
                         <section class="additional-resources-section">
                             <h4>${STR_ADDITIONAL_RESOURCES}</h4>
                             <div class="additional-resources-items">
-                                <slot name="additional-resources"></slot>
+                                 <slot name="additional-resources"></slot>
                             </div>
-                        </section>` 
-                        :   nothing
-                    }
-                    ${
-                        this.showPlaylists ? html`
+                        </section>`
+                : nothing
+            }
+                    ${this.showPlaylists ? html`
                         <section class="playlists-section">
                         <div>
                             <h4>${STR_PLAYLISTS}</h4>
@@ -265,9 +263,9 @@ export class _ extends LitElement {
                         <div class="playlists">
                             <slot name="playlists"></slot>
                         </div>
-                        </section>  ` 
-                        :   nothing
-                    }
+                        </section>  `
+                : nothing
+            }
                     <section class="report-section">
                         <slot name="report"></slot>
                         <slot name="report-sent"></slot>


### PR DESCRIPTION
https://github.com/ji-devs/ji-cloud/issues/3817