### PR TITLE
feat(be/billing): Update subscription cancellation endpoint to allow cancel removal

### DIFF
--- a/shared/rust/src/api/endpoints/billing.rs
+++ b/shared/rust/src/api/endpoints/billing.rs
@@ -1,5 +1,8 @@
 use super::ApiEndpoint;
-use crate::domain::billing::{CreateSetupIntentPath, CreateSetupIntentRequest, SubscriptionPath};
+use crate::domain::billing::{
+    CreateSetupIntentPath, CreateSetupIntentRequest, SubscriptionCancellationStatusRequest,
+    UpdateSubscriptionCancellationPath,
+};
 use crate::{
     api::Method,
     domain::billing::{
@@ -18,14 +21,14 @@ impl ApiEndpoint for CreateSubscription {
     const METHOD: Method = Method::Post;
 }
 
-/// Cancel a subscription
-pub struct CancelSubscription;
-impl ApiEndpoint for CancelSubscription {
-    type Path = SubscriptionPath;
-    type Req = ();
+/// Set the cancellation status of a subscription
+pub struct UpdateSubscriptionCancellation;
+impl ApiEndpoint for UpdateSubscriptionCancellation {
+    type Path = UpdateSubscriptionCancellationPath;
+    type Req = SubscriptionCancellationStatusRequest;
     type Res = ();
     type Err = EmptyError;
-    const METHOD: Method = Method::Delete;
+    const METHOD: Method = Method::Patch;
 }
 
 /// Create a setup intent so that a customer can add a payment method

--- a/shared/rust/src/domain/billing.rs
+++ b/shared/rust/src/domain/billing.rs
@@ -272,6 +272,12 @@ impl SubscriptionStatus {
     pub const fn is_active(&self) -> bool {
         matches!(self, Self::Active)
     }
+
+    /// Whether the subscription is canceled.
+    #[must_use]
+    pub const fn is_canceled(&self) -> bool {
+        matches!(self, Self::Canceled)
+    }
 }
 
 #[cfg(feature = "backend")]
@@ -1030,4 +1036,22 @@ pub struct IndividualAccountResponse {
     pub account: Option<Account>,
 }
 
-make_path_parts!(SubscriptionPath => "/v1/subscription");
+/// Set a subscriptions cancellation status
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub enum CancellationStatus {
+    /// Cancel a subscription at the period end
+    #[serde(rename = "period-end")]
+    CancelAtPeriodEnd,
+    /// Remove a cancellation on a subscription
+    #[serde(rename = "remove")]
+    RemoveCancellation,
+}
+/// Whether to cancel a subscription at period end or to remove a cancellation status.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SubscriptionCancellationStatusRequest {
+    /// Set the cancellation status of a subscription
+    pub status: CancellationStatus,
+}
+
+make_path_parts!(UpdateSubscriptionCancellationPath => "/v1/subscription/cancel");


### PR DESCRIPTION
- Updates the cancel endpoint to use http `PATCH` request because it doesnt actually delete anything, it updates the sub;
- moves the endpoint to `/v1/subscription/cancel`
- Requires a request object with a `status` field with possible values of `period-end` or `remove` to cancel at period end, or remove cancellation respectively.