### PR TITLE
feat(fe/asset/play/jig): add keywords to info panel

### DIFF
--- a/frontend/apps/crates/entry/asset/play/src/jig/state.rs
+++ b/frontend/apps/crates/entry/asset/play/src/jig/state.rs
@@ -1,9 +1,10 @@
-use std::{cell::RefCell, rc::Rc};
+use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
 use awsm_web::loaders::helpers::AsyncLoader;
 use components::audio::mixer::AudioHandle;
 use futures_signals::signal::Mutable;
 use shared::domain::{
+    category::{Category, CategoryId},
     jig::{player::PlayerNavigationHandler, JigId, JigResponse},
     meta::ResourceType,
     module::{
@@ -43,6 +44,8 @@ pub struct JigPlayer {
     pub bg_audio_playing: Mutable<bool>,
     pub module_assist_audio_handle: Rc<RefCell<Option<AudioHandle>>>,
     pub resource_types: Mutable<Vec<ResourceType>>,
+    pub categories: Mutable<Vec<Category>>,
+    pub category_label_lookup: Mutable<HashMap<CategoryId, String>>,
     pub playlists: Mutable<Vec<PlaylistResponse>>,
     pub module_assist: Mutable<Option<PlayModuleAssist>>,
     pub module_assist_visible: Mutable<bool>,
@@ -84,6 +87,8 @@ impl JigPlayer {
             bg_audio_playing: Mutable::new(true),
             module_assist_audio_handle: Rc::new(RefCell::new(None)),
             resource_types: Default::default(),
+            categories: Default::default(),
+            category_label_lookup: Default::default(),
             playlists: Default::default(),
             module_assist: Mutable::new(None),
             module_assist_visible: Mutable::new(false),

--- a/frontend/elements/src/_bundles/asset/play/imports.ts
+++ b/frontend/elements/src/_bundles/asset/play/imports.ts
@@ -28,6 +28,7 @@ import "@elements/entry/asset/_common/sidebar-modules/module";
 import "@elements/entry/asset/_common/age-range";
 import "@elements/entry/asset/play/jig/sidebar/action";
 import "@elements/entry/asset/play/jig/sidebar/jig-info";
+import "@elements/entry/asset/play/jig/sidebar/jig-info-category"
 import "@elements/entry/asset/play/jig/sidebar/report";
 import "@elements/entry/asset/play/jig/sidebar/sidebar";
 import "@elements/core/images/composed/module-screenshot";

--- a/frontend/elements/src/entry/asset/play/jig/sidebar/jig-info-category.ts
+++ b/frontend/elements/src/entry/asset/play/jig/sidebar/jig-info-category.ts
@@ -1,0 +1,29 @@
+import { LitElement, html, css, customElement, property } from "lit-element";
+
+@customElement("jig-info-category")
+export class _ extends LitElement {
+    static get styles() {
+        return [
+            css`
+                :host {
+                    display: inline-block;
+                    box-sizing: border-box;
+                    padding: 2px 8px;
+                    font-size: 11px;
+                    border-radius: 16px;
+                    border: solid 1px #d6e6fd;
+                    color: #2d6ee3;
+                    background-color: #d6e6fd;
+                    margin: 6px 6px 6px 0px;
+                }
+            `,
+        ];
+    }
+
+    @property()
+    label: string = "";
+
+    render() {
+        return html` ${this.label} `;
+    }
+}

--- a/frontend/elements/src/entry/asset/play/jig/sidebar/jig-info.ts
+++ b/frontend/elements/src/entry/asset/play/jig/sidebar/jig-info.ts
@@ -100,6 +100,12 @@ export class _ extends LitElement {
                     flex-wrap: wrap;
                     grid-gap: 8px;
                 }
+                ::slotted([slot="category-labels"]) {
+                    display: flex;
+                    flex-wrap: wrap;
+                    column-gap: 10px;
+                    row-gap: 12px;
+                }
                 .additional-resources-items {
                     display: flex;
                     flex-wrap: wrap;
@@ -242,7 +248,7 @@ export class _ extends LitElement {
                         </div>
                         <p class="description" dir="auto">${this.description}</p>
                         <div class="categories">
-                            <slot name="categories"></slot>
+                            <slot name="category-labels"></slot>
                         </div>
                     </section>
                     ${this.showResources ? html`


### PR DESCRIPTION
https://github.com/ji-devs/ji-cloud/issues/3817

## Added 
- A JIG's categories/keywords are listed on the sidebar info panel 