### PR TITLE
fix(fe/asset/edit/course): keep Update Unit button activated

### DIFF
--- a/frontend/apps/crates/entry/asset/edit/src/edit/course/unit_editor/actions.rs
+++ b/frontend/apps/crates/entry/asset/edit/src/edit/course/unit_editor/actions.rs
@@ -182,9 +182,7 @@ impl UnitEditor {
                 let mut units = state.editable_course.units.lock_mut();
                 let mut spots = state.asset_edit_state.sidebar_spots.lock_mut();
 
-
                 let unit_index = units.iter().position(|x| x.id == state.unit_id.unwrap_ji());
-
 
                 if let Some(unit_index) = unit_index {
                     let mut unit = units.remove(unit_index);

--- a/frontend/apps/crates/entry/asset/edit/src/edit/course/unit_editor/dom.rs
+++ b/frontend/apps/crates/entry/asset/edit/src/edit/course/unit_editor/dom.rs
@@ -37,11 +37,10 @@ impl Component<UnitEditor> for Rc<UnitEditor> {
         let is_valid = map_ref! {
             let display_name = state.display_name.signal_cloned(),
             let description = state.description.signal_cloned(),
-            let value = state.value.signal_cloned(),
-            let changed = state.changed.signal_cloned()
+            let value = state.value.signal_cloned()
 
             => {
-                !display_name.trim().is_empty() && !description.trim().is_empty() && UnitValue::is_some(value) && changed.to_owned()
+                !display_name.trim().is_empty() && !description.trim().is_empty() && UnitValue::is_some(value)
             }
         };
 


### PR DESCRIPTION
https://github.com/ji-devs/ji-cloud/issues/3998

## Added
- Update Unit button stays activated in Unit Editor