### PR TITLE
chore: Move billing, account, service error handling to shared crate

### DIFF
--- a/backend/api/Cargo.lock
+++ b/backend/api/Cargo.lock
@@ -1582,16 +1582,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
 
 [[package]]
-name = "http-serde"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d98b3d9662de70952b14c4840ee0f37e23973542a363e2275f4b9d024ff6cca"
-dependencies = [
- "http",
- "serde",
-]
-
-[[package]]
 name = "http-types"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3386,7 +3376,6 @@ dependencies = [
  "csv",
  "derive_setters",
  "http",
- "http-serde",
  "macros",
  "rgb",
  "serde",

--- a/backend/api/sqlx-data.json
+++ b/backend/api/sqlx-data.json
@@ -855,30 +855,6 @@
     },
     "query": "\nselect exists (\n    select 1 from user_scope where user_id = $1 and scope = any($2)\n) or (\n    exists (select 1 from user_scope where user_id = $1 and scope = $3) and\n    not exists (select 1 from jig where jig.id = $4 and jig.author_id <> $1)\n) as \"authed!\"\n"
   },
-  "13a585a91078e3a8d974641dd55160e6057508e815fabeb3386fe4011c79153f": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Left": [
-          "Uuid"
-        ]
-      }
-    },
-    "query": "\n        update user_asset_data \n        set resource_count = resource_count + 1,\n        total_asset_count = total_asset_count + 1\n        from resource\n        where author_id = user_id and\n              published_at is null and \n              id = $1"
-  },
-  "13ff5f48acc1806d421ced3ab8c3fd2e59e5d3912a6ba12b6d08c42b89672a2e": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Left": [
-          "Uuid"
-        ]
-      }
-    },
-    "query": "\n        update user_asset_data \n        set playlist_count = playlist_count + 1,\n        total_asset_count = total_asset_count + 1\n        from playlist\n        where author_id = user_id and\n              published_at is null and \n              id = $1"
-  },
   "140ff97c5bd0b551e1c2b0026a53c713117faf011a3f7f9e6f7e420cc481204a": {
     "describe": {
       "columns": [],
@@ -7031,6 +7007,18 @@
     },
     "query": "\nselect play_count from jig_play_count\nwhere jig_id = $1;\n            "
   },
+  "68b0cdf2330e61ee24a41779cd6a9a2d5d4b6aa32856cb5168bf45afd98d6ccf": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\n        update user_asset_data\n        set resource_count = resource_count + 1,\n        total_asset_count = total_asset_count + 1\n        from resource\n        where author_id = user_id and\n              published_at is null and\n              id = $1"
+  },
   "695ed5200a6ec80ca01f9ca3950a0ff0bc60dee8bcbe4a0954376eb26a38af1b": {
     "describe": {
       "columns": [],
@@ -11848,6 +11836,18 @@
     },
     "query": "\nselect\n    school_name_id as \"id!: SchoolNameId\",\n    name::text as \"name!\",\n    verified\nfrom school_name\nwhere school_name_id = $1\n"
   },
+  "b112cb6d91c1a044dc07e04f50d8a9529160e5d8f410dd23bf2b0b5004111342": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\n        update user_asset_data\n        set playlist_count = playlist_count + 1,\n        total_asset_count = total_asset_count + 1\n        from playlist\n        where author_id = user_id and\n              published_at is null and\n              id = $1"
+  },
   "b1513ce8a836f80987c480701be8ab9dbc124d8a4556503a4ad2dc77b1ae50d2": {
     "describe": {
       "columns": [
@@ -14715,6 +14715,18 @@
     },
     "query": "\ninsert into playlist_data_resource(playlist_data_id, resource_type_id, display_name, resource_content)\nselect $2, resource_type_id, display_name, resource_content\nfrom playlist_data_resource\nwhere playlist_data_id = $1\n        "
   },
+  "eab2089a1c8b9b7544a0577117381536a67d58cea994f56ed3f512375de03083": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\n        update user_asset_data\n        set jig_count = jig_count + 1,\n        total_asset_count = total_asset_count + 1\n        from jig\n        where author_id = user_id and\n              published_at is null and\n              id = $1"
+  },
   "eb44eafd34c17ff3cd679cd11f53fcde64f4b6039ba2b1625dd2c78ca2494a2d": {
     "describe": {
       "columns": [],
@@ -15058,18 +15070,6 @@
       }
     },
     "query": "\nupdate jig_data\nset display_name = $2,\n    translated_name = '{}',\n    updated_at = now()\nwhere id = $1 and $2 is distinct from display_name"
-  },
-  "f1bb0858fbc395bf5d1b2f4563bab9d4fbea0924387e66c745022f1a7fefb28c": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Left": [
-          "Uuid"
-        ]
-      }
-    },
-    "query": "\n        update user_asset_data \n        set jig_count = jig_count + 1,\n        total_asset_count = total_asset_count + 1\n        from jig\n        where author_id = user_id and\n              published_at is null and \n              id = $1"
   },
   "f1da735aa16c69d6e293d1c1b28cb018017f891f1e79dc7f3ed2a633880f493b": {
     "describe": {

--- a/backend/api/src/error/event_arc.rs
+++ b/backend/api/src/error/event_arc.rs
@@ -24,7 +24,7 @@ impl<T: Into<anyhow::Error>> From<T> for EventArc {
 impl Into<actix_web::Error> for EventArc {
     fn into(self) -> actix_web::Error {
         match self {
-            Self::Disabled => super::ServiceKind::GoogleCloudEventArc.into(),
+            Self::Disabled => super::ServiceKindError::GoogleCloudEventArc.into(),
             Self::InvalidEventSource => BasicError::with_message(
                 StatusCode::NO_CONTENT,
                 "Non-supported event type received".to_owned(),

--- a/backend/api/src/error/oauth.rs
+++ b/backend/api/src/error/oauth.rs
@@ -82,7 +82,7 @@ impl Into<actix_web::Error> for GoogleOAuth {
         match self {
             Self::InternalServerError(e) => super::ise(e.context("google oauth error")),
 
-            Self::Disabled => super::ServiceKind::GoogleOAuth.into(),
+            Self::Disabled => super::ServiceKindError::GoogleOAuth.into(),
 
             GoogleOAuth::InvalidCode => {
                 BasicError::with_message(http::StatusCode::UNAUTHORIZED, "Invalid Code".to_owned())

--- a/backend/api/src/error/storage.rs
+++ b/backend/api/src/error/storage.rs
@@ -32,7 +32,7 @@ impl<T: Into<anyhow::Error>> From<T> for Storage {
 impl Into<actix_web::Error> for Storage {
     fn into(self) -> actix_web::Error {
         match self {
-            Self::Disabled => super::ServiceKind::GoogleCloudStorage.into(),
+            Self::Disabled => super::ServiceKindError::GoogleCloudStorage.into(),
             Self::FileTooLarge => super::Upload::FileTooLarge.into(),
             Self::InvalidGrant => BasicError::with_message(
                 StatusCode::UNAUTHORIZED,

--- a/backend/api/src/error/user.rs
+++ b/backend/api/src/error/user.rs
@@ -1,4 +1,4 @@
-use super::{ise, BasicError, Service, ServiceSession};
+use super::{ise, BasicError, ServiceError, ServiceSession};
 use http::StatusCode;
 
 pub enum NotFound {
@@ -67,12 +67,12 @@ pub enum Register {
     InternalServerError(anyhow::Error),
     Username(Username),
     VerifyEmail(VerifyEmail),
-    Service(Service),
+    Service(ServiceError),
 }
 
-impl<T: Into<anyhow::Error>> From<T> for Register {
-    fn from(e: T) -> Self {
-        Self::InternalServerError(e.into())
+impl From<anyhow::Error> for Register {
+    fn from(e: anyhow::Error) -> Self {
+        Self::InternalServerError(e)
     }
 }
 
@@ -101,8 +101,8 @@ impl From<VerifyEmail> for Register {
     }
 }
 
-impl From<Service> for Register {
-    fn from(err: Service) -> Self {
+impl From<ServiceError> for Register {
+    fn from(err: ServiceError) -> Self {
         Self::Service(err)
     }
 }

--- a/backend/api/src/http.rs
+++ b/backend/api/src/http.rs
@@ -16,12 +16,13 @@ use ji_core::{
     http::{get_addr, get_tcp_fd},
     settings::RuntimeSettings,
 };
+use shared::error::ConfigError;
 use sqlx::postgres::PgPool;
 use tracing::Span;
 use tracing_actix_web::{root_span, DefaultRootSpanBuilder, RootSpanBuilder, TracingLogger};
 
 use crate::{
-    error::{BasicError, ConfigError},
+    error::BasicError,
     service::{self, mail, s3, upload::cleaner, ServiceData},
     translate,
 };
@@ -314,9 +315,7 @@ where
     E: Into<ConfigError>,
 {
     // Convert the error into our custom user-facing error, and then into an actix error.
-    // Note: error.into().into() works fine, but doesn't look pretty.
-    let config_error = error.into();
-    config_error.into()
+    Into::<ConfigError>::into(error).into()
 }
 
 pub struct JigziSpanBuilder;

--- a/backend/api/src/http/endpoints/account.rs
+++ b/backend/api/src/http/endpoints/account.rs
@@ -1,6 +1,6 @@
+use crate::db;
 use crate::domain::{user_authorization, UserAuthorization};
 use crate::extractor::TokenUser;
-use crate::{db, error};
 use actix_web::web::{Data, Json, Path, ServiceConfig};
 use actix_web::HttpResponse;
 use futures::try_join;
@@ -14,6 +14,7 @@ use shared::domain::billing::{
     IndividualAccountResponse, SchoolId, SchoolNameRequest, SchoolNameValue,
     UpdateSchoolAccountRequest,
 };
+use shared::error::{AccountError, IntoAnyhow};
 use sqlx::PgPool;
 use tracing::instrument;
 
@@ -27,10 +28,13 @@ async fn create_school_account(
         Json<<CreateSchoolAccount as ApiEndpoint>::Res>,
         http::StatusCode,
     ),
-    error::Account,
+    <CreateSchoolAccount as ApiEndpoint>::Err,
 > {
-    if db::account::check_user_has_account(db.as_ref(), auth.user_id()).await? {
-        return Err(error::Account::UserHasAccount);
+    if db::account::check_user_has_account(db.as_ref(), auth.user_id())
+        .await
+        .into_anyhow()?
+    {
+        return Err(AccountError::UserHasAccount);
     }
 
     let req: CreateSchoolAccountRequest = req.into_inner();
@@ -39,20 +43,28 @@ async fn create_school_account(
         SchoolNameRequest::Value(new_name) => {
             // If the user is creating a school with a new school name that we don't already
             // know about, then check whether that name already exists
-            if db::account::check_school_name_exists(db.as_ref(), new_name.as_ref()).await? {
+            if db::account::check_school_name_exists(db.as_ref(), new_name.as_ref())
+                .await
+                .into_anyhow()?
+            {
                 // Otherwise, return an error to the client
-                return Err(error::Account::SchoolNameExists(new_name));
+                return Err(AccountError::SchoolNameExists(new_name));
             }
 
             // If it doesnt exist, then add the name
-            db::account::add_school_name(db.as_ref(), new_name, false).await?
+            db::account::add_school_name(db.as_ref(), new_name, false)
+                .await
+                .into_anyhow()?
         }
         SchoolNameRequest::Id(id) => {
             // If they are creating a school with an existing school name, then check that
             // another school doesn't already exist that uses the same name.
-            if db::account::check_school_exists(db.as_ref(), &id).await? {
+            if db::account::check_school_exists(db.as_ref(), &id)
+                .await
+                .into_anyhow()?
+            {
                 // If one exists, return an error to the client.
-                return Err(error::Account::SchoolExists(id));
+                return Err(AccountError::SchoolExists(id));
             }
 
             id
@@ -63,7 +75,8 @@ async fn create_school_account(
     Ok((
         Json(
             db::account::create_school_account(db.as_ref(), auth.user_id(), &school_name_id, req)
-                .await?,
+                .await
+                .into_anyhow()?,
         ),
         http::StatusCode::CREATED,
     ))
@@ -75,13 +88,14 @@ async fn update_school_account(
     db: Data<PgPool>,
     path: Path<SchoolId>,
     req: Json<<UpdateSchoolAccount as ApiEndpoint>::Req>,
-) -> Result<HttpResponse, error::Account> {
+) -> Result<HttpResponse, <UpdateSchoolAccount as ApiEndpoint>::Err> {
     let user_id = auth.user_id();
     let school_id = path.into_inner();
 
     let school = db::account::get_school_account_by_id(db.as_ref(), &school_id)
-        .await?
-        .ok_or(error::Account::NotFound("School not found".into()))?;
+        .await
+        .into_anyhow()?
+        .ok_or(AccountError::NotFound("School not found".into()))?;
 
     user_authorization(db.as_ref(), &user_id, &school.account_id)
         .await?
@@ -89,7 +103,9 @@ async fn update_school_account(
 
     let req: UpdateSchoolAccountRequest = req.into_inner();
 
-    db::account::update_school_account(db.as_ref(), &school_id, req.into()).await?;
+    db::account::update_school_account(db.as_ref(), &school_id, req.into())
+        .await
+        .into_anyhow()?;
 
     Ok(HttpResponse::Ok().finish())
 }
@@ -100,23 +116,25 @@ async fn update_school_name(
     db: Data<PgPool>,
     path: Path<SchoolId>,
     req: Json<<UpdateSchoolName as ApiEndpoint>::Req>,
-) -> Result<HttpResponse, error::Account> {
+) -> Result<HttpResponse, <UpdateSchoolName as ApiEndpoint>::Err> {
     let user_id = auth.user_id();
     let school_id = path.into_inner();
 
     let new_name: SchoolNameValue = req.into_inner();
 
     let school = db::account::get_school_account_by_id(db.as_ref(), &school_id)
-        .await?
-        .ok_or(error::Account::NotFound("School not found".into()))?;
+        .await
+        .into_anyhow()?
+        .ok_or(AccountError::NotFound("School not found".into()))?;
 
     let authorization = user_authorization(db.as_ref(), &user_id, &school.account_id).await?;
     authorization.test_authorized(true)?;
 
     if db::account::check_renamed_school_name_exists(db.as_ref(), new_name.as_ref(), &school_id)
-        .await?
+        .await
+        .into_anyhow()?
     {
-        return Err(error::Account::SchoolNameExists(new_name));
+        return Err(AccountError::SchoolNameExists(new_name));
     }
 
     // If the user is a system administrator then the verified flag is automatically set to true.
@@ -127,7 +145,8 @@ async fn update_school_name(
         new_name,
         authorization.is_system_administrator(),
     )
-    .await?;
+    .await
+    .into_anyhow()?;
 
     Ok(HttpResponse::Ok().finish())
 }
@@ -136,9 +155,11 @@ async fn update_school_name(
 async fn get_school_names(
     _auth: TokenUser,
     db: Data<PgPool>,
-) -> Result<Json<<GetSchoolNames as ApiEndpoint>::Res>, error::Account> {
+) -> Result<Json<<GetSchoolNames as ApiEndpoint>::Res>, <GetSchoolNames as ApiEndpoint>::Err> {
     Ok(Json(
-        db::account::get_verified_school_names(db.as_ref()).await?,
+        db::account::get_verified_school_names(db.as_ref())
+            .await
+            .into_anyhow()?,
     ))
 }
 
@@ -146,13 +167,14 @@ async fn get_school_account(
     auth: TokenUser,
     db: Data<PgPool>,
     path: Path<SchoolId>,
-) -> Result<Json<<GetSchoolAccount as ApiEndpoint>::Res>, error::Account> {
+) -> Result<Json<<GetSchoolAccount as ApiEndpoint>::Res>, <GetSchoolAccount as ApiEndpoint>::Err> {
     let user_id = auth.user_id();
     let school_id = path.into_inner();
 
     let school = db::account::get_school_account_by_id(db.as_ref(), &school_id)
-        .await?
-        .ok_or(error::Account::NotFound("School not found".into()))?;
+        .await
+        .into_anyhow()?
+        .ok_or(AccountError::NotFound("School not found".into()))?;
 
     let authorization = user_authorization(db.as_ref(), &user_id, &school.account_id).await?;
 
@@ -182,13 +204,14 @@ async fn delete_school_account(
     auth: TokenUser,
     db: Data<PgPool>,
     path: Path<SchoolId>,
-) -> Result<HttpResponse, error::Account> {
+) -> Result<HttpResponse, <DeleteSchoolAccount as ApiEndpoint>::Err> {
     let user_id = auth.user_id();
     let school_id = path.into_inner();
 
     let school = db::account::get_school_account_by_id(db.as_ref(), &school_id)
-        .await?
-        .ok_or(error::Account::NotFound("School not found".into()))?;
+        .await
+        .into_anyhow()?
+        .ok_or(AccountError::NotFound("School not found".into()))?;
 
     let authorization = user_authorization(db.as_ref(), &user_id, &school.account_id).await?;
 
@@ -202,7 +225,7 @@ async fn delete_school_account(
 
     if let Some(subscription) = account.subscription {
         if subscription.status.is_valid() {
-            return Err(error::Account::Forbidden);
+            return Err(AccountError::Forbidden);
         }
     }
 
@@ -211,7 +234,7 @@ async fn delete_school_account(
             // If the current user is an account admin and they're the only member of this school,
             // then the school account can be deleted.
             if users.len() > 1 {
-                return Err(error::Account::Forbidden);
+                return Err(AccountError::Forbidden);
             }
         }
         UserAuthorization::SystemAdministrator => {
@@ -221,18 +244,20 @@ async fn delete_school_account(
                     let user = users.first().unwrap();
                     if user.user.id != user_id {
                         // Cannot delete if the associated user is not the current user
-                        return Err(error::Account::Forbidden);
+                        return Err(AccountError::Forbidden);
                     }
                 } else {
                     // Multiple users
-                    return Err(error::Account::Forbidden);
+                    return Err(AccountError::Forbidden);
                 }
             }
         }
-        _ => return Err(error::Account::Forbidden),
+        _ => return Err(AccountError::Forbidden),
     }
 
-    db::account::delete_school_account(db.as_ref(), &school.account_id).await?;
+    db::account::delete_school_account(db.as_ref(), &school.account_id)
+        .await
+        .into_anyhow()?;
 
     Ok(HttpResponse::Ok().finish())
 }
@@ -240,13 +265,16 @@ async fn delete_school_account(
 async fn get_individual_account(
     auth: TokenUser,
     db: Data<PgPool>,
-) -> Result<Json<<GetIndividualAccount as ApiEndpoint>::Res>, error::Account> {
+) -> Result<
+    Json<<GetIndividualAccount as ApiEndpoint>::Res>,
+    <GetIndividualAccount as ApiEndpoint>::Err,
+> {
     let account = db::account::get_account_by_user_id(db.as_ref(), &auth.user_id()).await?;
 
     if let Some(account) = &account {
         if account.account_type.has_admin() {
             // We only want to return individual account details here.
-            return Err(error::Account::Forbidden);
+            return Err(AccountError::Forbidden);
         }
     }
 

--- a/backend/api/src/http/endpoints/search.rs
+++ b/backend/api/src/http/endpoints/search.rs
@@ -3,6 +3,7 @@ use actix_web::{
     web::{Data, Json, Query, ServiceConfig},
 };
 use ji_core::settings::RuntimeSettings;
+use shared::error::ServiceError;
 use shared::{
     api::{endpoints::search, ApiEndpoint, PathParts},
     domain::search::{CreateSearchKeyResponse, WebImageSearchResponse},
@@ -16,7 +17,7 @@ use crate::{error, extractor::TokenUser, service::ServiceData};
 async fn create_key(
     algolia: ServiceData<crate::algolia::SearchKeyStore>,
     claims: TokenUser,
-) -> actix_web::Result<(Json<<search::CreateKey as ApiEndpoint>::Res>, StatusCode), error::Service> // TODO check this
+) -> actix_web::Result<(Json<<search::CreateKey as ApiEndpoint>::Res>, StatusCode), ServiceError> // TODO check this
 {
     let key =
         algolia.generate_virtual_key(Some(claims.0.user_id), Some(chrono::Duration::minutes(15)));

--- a/backend/api/src/service/mail.rs
+++ b/backend/api/src/service/mail.rs
@@ -3,9 +3,8 @@ use sendgrid::v3::{Content, Email, Message, Personalization, SGMap, Sender};
 use shared::domain::{
     jig::report::JigReportEmail, resource::report::ResourceReportEmail, session::OAuthProvider,
 };
+use shared::error::ServiceKindError;
 use tracing::instrument;
-
-use crate::error;
 
 use super::Service;
 
@@ -110,8 +109,8 @@ impl Client {
         let subject = format!("Reset your password");
 
         let value = format!(
-            r#" 
-Looks like you requested a reset password link but you didn't sign up with a password, you signed up with a {} account. 
+            r#"
+Looks like you requested a reset password link but you didn't sign up with a password, you signed up with a {} account.
 Please try logging in with your {} account.
             "#,
             oauth_provider.as_str(),
@@ -232,41 +231,41 @@ Please try logging in with your {} account.
         Ok(())
     }
 
-    pub fn signup_verify_template(&self) -> Result<SignupVerifyTemplate<'_>, error::ServiceKind> {
+    pub fn signup_verify_template(&self) -> Result<SignupVerifyTemplate<'_>, ServiceKindError> {
         // todo: make the error more specific?
         self.signup_verify_template
             .as_deref()
             .map(SignupVerifyTemplate)
-            .ok_or(error::ServiceKind::Mail)
+            .ok_or(ServiceKindError::Mail)
     }
 
-    pub fn password_reset_template(&self) -> Result<PasswordResetTemplate<'_>, error::ServiceKind> {
+    pub fn password_reset_template(&self) -> Result<PasswordResetTemplate<'_>, ServiceKindError> {
         // todo: make the error more specific?
         self.password_reset_template
             .as_deref()
             .map(PasswordResetTemplate)
-            .ok_or(error::ServiceKind::Mail)
+            .ok_or(ServiceKindError::Mail)
     }
 
-    pub fn email_reset_template(&self) -> Result<EmailResetTemplate<'_>, error::ServiceKind> {
+    pub fn email_reset_template(&self) -> Result<EmailResetTemplate<'_>, ServiceKindError> {
         // todo: make the error more specific?
         self.email_reset_template
             .as_deref()
             .map(EmailResetTemplate)
-            .ok_or(error::ServiceKind::Mail)
+            .ok_or(ServiceKindError::Mail)
     }
 
-    pub fn welcome_jigzi_template(&self) -> Result<WelcomeJigziTemplate<'_>, error::ServiceKind> {
+    pub fn welcome_jigzi_template(&self) -> Result<WelcomeJigziTemplate<'_>, ServiceKindError> {
         // todo: make the error more specific?
         self.welcome_jigzi_template
             .as_deref()
             .map(WelcomeJigziTemplate)
-            .ok_or(error::ServiceKind::Mail)
+            .ok_or(ServiceKindError::Mail)
     }
 }
 
 impl Service for Client {
-    const DISABLED_ERROR: error::ServiceKind = error::ServiceKind::Mail;
+    const DISABLED_ERROR: ServiceKindError = ServiceKindError::Mail;
 }
 
 #[repr(transparent)]

--- a/backend/api/tests/integration/auth/forbidden.rs
+++ b/backend/api/tests/integration/auth/forbidden.rs
@@ -38,9 +38,8 @@ async fn forbidden(
 
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 
-    let body: ApiResponseError<EmptyError> = resp.json().await?;
-
-    assert_eq!(body.code, StatusCode::FORBIDDEN);
+    // Make sure it doesn't panic decoding the error
+    let _: ApiResponseError<EmptyError> = resp.json().await?;
 
     Ok(())
 }

--- a/backend/api/tests/integration/auth/forbidden.rs
+++ b/backend/api/tests/integration/auth/forbidden.rs
@@ -1,13 +1,14 @@
 use http::{Method, StatusCode};
 use macros::test_service;
 use serde_json::json;
-use shared::error::{ApiError, EmptyError};
+use shared::error::EmptyError;
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
 
 use crate::{
     fixture::Fixture,
     helpers::{setup_service, LoginExt},
 };
+use ji_cloud_api::error::ApiResponseError;
 use shared::domain::{
     asset::AssetId,
     jig::JigId,
@@ -37,7 +38,7 @@ async fn forbidden(
 
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 
-    let body: ApiError<EmptyError> = resp.json().await?;
+    let body: ApiResponseError<EmptyError> = resp.json().await?;
 
     assert_eq!(body.code, StatusCode::FORBIDDEN);
 

--- a/backend/api/tests/integration/auth/unauthorized.rs
+++ b/backend/api/tests/integration/auth/unauthorized.rs
@@ -16,9 +16,8 @@ async fn unauthorized(route: &str, port: u16) -> anyhow::Result<()> {
 
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 
-    let body: ApiResponseError<EmptyError> = resp.json().await?;
-
-    assert_eq!(body.code, StatusCode::UNAUTHORIZED);
+    // Make sure it doesn't panic decoding the error
+    let _: ApiResponseError<EmptyError> = resp.json().await?;
 
     Ok(())
 }

--- a/backend/api/tests/integration/auth/unauthorized.rs
+++ b/backend/api/tests/integration/auth/unauthorized.rs
@@ -1,6 +1,7 @@
 use http::StatusCode;
+use ji_cloud_api::error::ApiResponseError;
 use macros::test_service;
-use shared::error::{ApiError, EmptyError};
+use shared::error::EmptyError;
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
 
 use crate::{fixture::Fixture, helpers::setup_service};
@@ -15,7 +16,7 @@ async fn unauthorized(route: &str, port: u16) -> anyhow::Result<()> {
 
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 
-    let body: ApiError<EmptyError> = resp.json().await?;
+    let body: ApiResponseError<EmptyError> = resp.json().await?;
 
     assert_eq!(body.code, StatusCode::UNAUTHORIZED);
 

--- a/backend/api/tests/integration/snapshots/integration__image__create_with_affiliation_error.snap
+++ b/backend/api/tests/integration/snapshots/integration__image__create_with_affiliation_error.snap
@@ -3,7 +3,6 @@ source: tests/integration/image.rs
 expression: body
 ---
 {
-  "code": 422,
   "message": "Metadata not Found",
   "id": "6389eaa0-de76-11ea-b7ab-0399bcf84df2",
   "index": null,

--- a/backend/api/tests/integration/snapshots/integration__image__create_with_age_range_error.snap
+++ b/backend/api/tests/integration/snapshots/integration__image__create_with_age_range_error.snap
@@ -3,7 +3,6 @@ source: tests/integration/image.rs
 expression: body
 ---
 {
-  "code": 422,
   "message": "Metadata not Found",
   "id": "6389eaa0-de76-11ea-b7ab-0399bcf84df2",
   "index": null,

--- a/backend/api/tests/integration/snapshots/integration__image__create_with_category_error.snap
+++ b/backend/api/tests/integration/snapshots/integration__image__create_with_category_error.snap
@@ -3,7 +3,6 @@ source: tests/integration/image.rs
 expression: body
 ---
 {
-  "code": 422,
   "message": "Metadata not Found",
   "id": "6389eaa0-de76-11ea-b7ab-0399bcf84df2",
   "index": null,

--- a/backend/api/tests/integration/snapshots/integration__image__create_with_style_error.snap
+++ b/backend/api/tests/integration/snapshots/integration__image__create_with_style_error.snap
@@ -3,7 +3,6 @@ source: tests/integration/image.rs
 expression: body
 ---
 {
-  "code": 422,
   "message": "Metadata not Found",
   "id": "6389eaa0-de76-11ea-b7ab-0399bcf84df2",
   "index": null,

--- a/backend/api/tests/integration/snapshots/integration__image__create_with_tags_error.snap
+++ b/backend/api/tests/integration/snapshots/integration__image__create_with_tags_error.snap
@@ -3,7 +3,6 @@ source: tests/integration/image.rs
 expression: body
 ---
 {
-  "code": 422,
   "message": "Metadata not Found",
   "id": null,
   "index": 22,

--- a/backend/pages/Cargo.lock
+++ b/backend/pages/Cargo.lock
@@ -1279,15 +1279,6 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
@@ -1381,16 +1372,6 @@ name = "http-range"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
-
-[[package]]
-name = "http-serde"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e272971f774ba29341db2f686255ff8a979365a26fb9e4277f6b6d9ec0cdd5e"
-dependencies = [
- "http",
- "serde",
-]
 
 [[package]]
 name = "http-types"
@@ -2365,6 +2346,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
 name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2666,7 +2653,6 @@ dependencies = [
  "csv",
  "derive_setters",
  "http",
- "http-serde",
  "macros",
  "rgb",
  "serde",
@@ -2829,7 +2815,7 @@ checksum = "9966e64ae989e7e575b19d7265cb79d7fc3cbbdf179835cb0d716f294c2049c9"
 dependencies = [
  "dotenvy",
  "either",
- "heck 0.4.1",
+ "heck",
  "hex",
  "once_cell",
  "proc-macro2",
@@ -2879,20 +2865,21 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
-version = "0.22.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7ac893c7d471c8a21f31cfe213ec4f6d9afeed25537c772e08ef3f005f8729e"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 
 [[package]]
 name = "strum_macros"
-version = "0.22.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339f799d8b549e3744c7ac7feb216383e4005d94bdb22561b3ab8f3b808ae9fb"
+checksum = "6069ca09d878a33f883cc06aaa9718ede171841d3832450354410b718b097232"
 dependencies = [
- "heck 0.3.3",
+ "heck",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "rustversion",
+ "syn 2.0.18",
 ]
 
 [[package]]

--- a/backend/util/Cargo.lock
+++ b/backend/util/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -156,11 +156,11 @@ version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
- "heck 0.4.0",
+ "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -289,7 +289,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.9.3",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -303,7 +303,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -314,7 +314,7 @@ checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
  "darling_core 0.10.2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -325,7 +325,7 @@ checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core 0.13.4",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -337,7 +337,7 @@ dependencies = [
  "darling 0.10.2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -505,7 +505,7 @@ checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -599,18 +599,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -657,16 +648,6 @@ dependencies = [
  "bytes",
  "http",
  "pin-project-lite",
-]
-
-[[package]]
-name = "http-serde"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d98b3d9662de70952b14c4840ee0f37e23973542a363e2275f4b9d024ff6cca"
-dependencies = [
- "http",
- "serde",
 ]
 
 [[package]]
@@ -855,7 +836,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1012,7 +993,7 @@ checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1116,7 +1097,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1155,7 +1136,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1191,7 +1172,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
  "version_check",
 ]
 
@@ -1214,18 +1195,18 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
@@ -1485,6 +1466,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
 name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,7 +1558,7 @@ checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1593,7 +1580,7 @@ checksum = "1fe39d9fbb0ebf5eb2c7cb7e2a47e4f462fad1379f1166b8ae49ad9eae89a7ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1628,7 +1615,7 @@ dependencies = [
  "darling 0.13.4",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1656,7 +1643,6 @@ dependencies = [
  "csv",
  "derive_setters",
  "http",
- "http-serde",
  "macros",
  "rgb",
  "serde",
@@ -1745,20 +1731,21 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
-version = "0.22.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7ac893c7d471c8a21f31cfe213ec4f6d9afeed25537c772e08ef3f005f8729e"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 
 [[package]]
 name = "strum_macros"
-version = "0.22.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339f799d8b549e3744c7ac7feb216383e4005d94bdb22561b3ab8f3b808ae9fb"
+checksum = "6069ca09d878a33f883cc06aaa9718ede171841d3832450354410b718b097232"
 dependencies = [
- "heck 0.3.3",
+ "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "rustversion",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -1772,6 +1759,17 @@ name = "syn"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b60f673f44a8255b9c8c657daf66a596d435f2da81a555b06dc644d080ba45e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1834,7 +1832,7 @@ checksum = "e8f2591983642de85c921015f3f070c665a197ed69e417af436115e3a1407487"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1891,7 +1889,7 @@ checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -2080,7 +2078,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
  "wasm-bindgen-shared",
 ]
 
@@ -2114,7 +2112,7 @@ checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/backend/util/media-refresh/src/download.rs
+++ b/backend/util/media-refresh/src/download.rs
@@ -2,7 +2,7 @@ use std::{fs::File, io::BufWriter, path::PathBuf};
 
 use indicatif::ProgressBar;
 use shared::{
-    error::{ApiError, EmptyError},
+    error::{ApiResponseError, EmptyError},
     media::MediaKind,
 };
 
@@ -24,7 +24,7 @@ pub async fn run(
     match response.error_for_status_ref() {
         Ok(_) => {}
         Err(_) => {
-            let error_json = response.json::<ApiError<EmptyError>>().await?;
+            let error_json = response.json::<ApiResponseError<EmptyError>>().await?;
 
             anyhow::bail!(
                 "request failed ({}): {}",

--- a/frontend/apps/Cargo.lock
+++ b/frontend/apps/Cargo.lock
@@ -1195,7 +1195,7 @@ checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1502,7 +1502,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 1.0.103",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1519,7 +1519,7 @@ checksum = "309e4fb93eed90e1e14bea0da16b209f81813ba9fc7830c20ed151dd7bc0a4d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1563,7 +1563,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.9.3",
- "syn 1.0.103",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1577,7 +1577,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 1.0.103",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1591,7 +1591,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 1.0.103",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1602,7 +1602,7 @@ checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
  "darling_core 0.10.2",
  "quote",
- "syn 1.0.103",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1613,7 +1613,7 @@ checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core 0.13.4",
  "quote",
- "syn 1.0.103",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1624,7 +1624,7 @@ checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
 dependencies = [
  "darling_core 0.14.2",
  "quote",
- "syn 1.0.103",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1645,7 +1645,7 @@ dependencies = [
  "darling 0.14.2",
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1655,7 +1655,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f0314b72bed045f3a68671b3c86328386762c93f82d98c65c3cb5e5f573dd68"
 dependencies = [
  "derive_builder_core",
- "syn 1.0.103",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1667,7 +1667,7 @@ dependencies = [
  "darling 0.10.2",
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1801,7 +1801,7 @@ checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1998,16 +1998,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-serde"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e272971f774ba29341db2f686255ff8a979365a26fb9e4277f6b6d9ec0cdd5e"
-dependencies = [
- "http",
- "serde",
-]
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2121,9 +2111,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "link-cplusplus"
@@ -2152,7 +2142,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2175,7 +2165,7 @@ checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2274,7 +2264,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2312,9 +2302,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.31"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe8a65d69dd0808184ebb5f836ab526bb259db23c657efa38711b1072ee47f0"
+checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
@@ -2437,9 +2427,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "5d25439cd7397d044e2748a6fe2432b5e85db703d6d097bd014b3c0ad1ebff0b"
 dependencies = [
  "serde_derive",
 ]
@@ -2469,13 +2459,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "b23f7ade6f110613c0d63858ddb8b94c1041f550eab58a16b371bdf2c9c80ab4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -2508,7 +2498,7 @@ checksum = "1fe39d9fbb0ebf5eb2c7cb7e2a47e4f462fad1379f1166b8ae49ad9eae89a7ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2531,7 +2521,7 @@ dependencies = [
  "darling 0.13.4",
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2546,7 +2536,6 @@ dependencies = [
  "csv",
  "derive_setters",
  "http",
- "http-serde",
  "js-sys",
  "macros",
  "rgb",
@@ -2606,14 +2595,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.26",
+ "syn 2.0.27",
 ]
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2622,9 +2611,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.26"
+version = "2.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45c3457aacde3c65315de5031ec191ce46604304d2446e803d71ade03308d970"
+checksum = "b60f673f44a8255b9c8c657daf66a596d435f2da81a555b06dc644d080ba45e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2657,7 +2646,7 @@ checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2856,7 +2845,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
 
@@ -2890,7 +2879,7 @@ checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/frontend/apps/crates/entry/asset/edit/src/edit/actions/course_actions.rs
+++ b/frontend/apps/crates/entry/asset/edit/src/edit/actions/course_actions.rs
@@ -1,8 +1,9 @@
 use shared::{
     api::endpoints::{self},
     domain::course::{CourseGetDraftPath, CourseId, CourseResponse},
+    error::IntoAnyhow,
 };
-use utils::prelude::{ApiEndpointExt, ErrorExt, UnwrapJiExt};
+use utils::prelude::{ApiEndpointExt, UnwrapJiExt};
 
 use crate::edit::{sidebar::SidebarSpot, AssetEditState};
 

--- a/frontend/apps/crates/entry/asset/edit/src/edit/actions/jig_actions.rs
+++ b/frontend/apps/crates/entry/asset/edit/src/edit/actions/jig_actions.rs
@@ -6,6 +6,7 @@ use shared::{
         jig::{JigGetDraftPath, JigId, JigResponse},
         module::ModuleKind,
     },
+    error::IntoAnyhow,
 };
 use utils::prelude::*;
 

--- a/frontend/apps/crates/entry/asset/edit/src/edit/actions/playlist_actions.rs
+++ b/frontend/apps/crates/entry/asset/edit/src/edit/actions/playlist_actions.rs
@@ -4,8 +4,9 @@ use shared::{
         jig::{JigGetLivePath, JigId, JigResponse},
         playlist::{PlaylistGetDraftPath, PlaylistId, PlaylistResponse},
     },
+    error::IntoAnyhow,
 };
-use utils::prelude::{ApiEndpointExt, ErrorExt, UnwrapJiExt};
+use utils::prelude::{ApiEndpointExt, UnwrapJiExt};
 
 use crate::edit::{sidebar::SidebarSpot, AssetEditState};
 

--- a/frontend/apps/crates/entry/asset/edit/src/edit/actions/resource_actions.rs
+++ b/frontend/apps/crates/entry/asset/edit/src/edit/actions/resource_actions.rs
@@ -1,8 +1,9 @@
 use shared::{
     api::endpoints::resource,
     domain::resource::{ResourceGetDraftPath, ResourceId, ResourceResponse},
+    error::IntoAnyhow,
 };
-use utils::prelude::{ApiEndpointExt, ErrorExt};
+use utils::prelude::ApiEndpointExt;
 
 pub async fn load_resource(resource_id: ResourceId) -> anyhow::Result<ResourceResponse> {
     resource::GetDraft::api_with_auth(ResourceGetDraftPath(resource_id), None)

--- a/frontend/apps/crates/entry/asset/edit/src/edit/publish/pre_publish/actions/course_actions.rs
+++ b/frontend/apps/crates/entry/asset/edit/src/edit/publish/pre_publish/actions/course_actions.rs
@@ -3,8 +3,9 @@ use shared::{
     domain::course::{
         CourseGetDraftPath, CourseId, CoursePublishPath, CourseResponse, CourseUpdateDraftDataPath,
     },
+    error::IntoAnyhow,
 };
-use utils::prelude::{ApiEndpointExt, ErrorExt};
+use utils::prelude::ApiEndpointExt;
 
 use utils::editable_asset::EditableCourse;
 

--- a/frontend/apps/crates/entry/asset/edit/src/edit/publish/pre_publish/actions/jig_actions.rs
+++ b/frontend/apps/crates/entry/asset/edit/src/edit/publish/pre_publish/actions/jig_actions.rs
@@ -1,8 +1,9 @@
 use shared::{
     api::endpoints::jig,
     domain::jig::{JigGetDraftPath, JigId, JigPublishPath, JigResponse, JigUpdateDraftDataPath},
+    error::IntoAnyhow,
 };
-use utils::prelude::{ApiEndpointExt, ErrorExt};
+use utils::prelude::ApiEndpointExt;
 
 use utils::editable_asset::EditableJig;
 

--- a/frontend/apps/crates/entry/asset/edit/src/edit/publish/pre_publish/actions/mod.rs
+++ b/frontend/apps/crates/entry/asset/edit/src/edit/publish/pre_publish/actions/mod.rs
@@ -9,9 +9,10 @@ use shared::{
         category::{Category, CategoryId, CategoryTreeScope, GetCategoryPath, GetCategoryRequest},
         meta::{GetMetadataPath, MetadataResponse},
     },
+    error::IntoAnyhow,
 };
 use utils::{
-    prelude::{ApiEndpointExt, ErrorExt, UnwrapJiExt},
+    prelude::{ApiEndpointExt, UnwrapJiExt},
     routes::{CourseEditRoute, JigEditRoute, PlaylistEditRoute, ResourceEditRoute},
 };
 

--- a/frontend/apps/crates/entry/asset/edit/src/edit/publish/pre_publish/actions/playlist_actions.rs
+++ b/frontend/apps/crates/entry/asset/edit/src/edit/publish/pre_publish/actions/playlist_actions.rs
@@ -4,8 +4,9 @@ use shared::{
         PlaylistGetDraftPath, PlaylistId, PlaylistPublishPath, PlaylistResponse,
         PlaylistUpdateDraftDataPath,
     },
+    error::IntoAnyhow,
 };
-use utils::prelude::{ApiEndpointExt, ErrorExt};
+use utils::prelude::ApiEndpointExt;
 
 use utils::editable_asset::EditablePlaylist;
 

--- a/frontend/apps/crates/entry/asset/edit/src/edit/publish/pre_publish/actions/resource_actions.rs
+++ b/frontend/apps/crates/entry/asset/edit/src/edit/publish/pre_publish/actions/resource_actions.rs
@@ -4,8 +4,9 @@ use shared::{
         ResourceGetDraftPath, ResourceId, ResourcePublishPath, ResourceResponse,
         ResourceUpdateDraftDataPath,
     },
+    error::IntoAnyhow,
 };
-use utils::prelude::{ApiEndpointExt, ErrorExt};
+use utils::prelude::ApiEndpointExt;
 
 use utils::editable_asset::EditableResource;
 

--- a/frontend/apps/crates/entry/asset/edit/src/edit/sidebar/course/actions.rs
+++ b/frontend/apps/crates/entry/asset/edit/src/edit/sidebar/course/actions.rs
@@ -5,6 +5,7 @@ use shared::domain::course::unit::CourseUnit;
 use shared::{
     api::endpoints,
     domain::course::{CourseId, CourseUpdateDraftDataPath, CourseUpdateDraftDataRequest},
+    error::IntoAnyhow,
 };
 use std::rc::Rc;
 use utils::prelude::*;

--- a/frontend/apps/crates/entry/asset/edit/src/edit/sidebar/jig/actions.rs
+++ b/frontend/apps/crates/entry/asset/edit/src/edit/sidebar/jig/actions.rs
@@ -16,6 +16,7 @@ use shared::{
             ModuleKind, ModuleUpdateRequest, ModuleUploadPath,
         },
     },
+    error::IntoAnyhow,
 };
 use std::rc::Rc;
 use utils::{asset::JigPlayerOptions, iframe::ModuleToJigEditorMessage, prelude::*};

--- a/frontend/apps/crates/entry/asset/edit/src/edit/sidebar/playlist/actions.rs
+++ b/frontend/apps/crates/entry/asset/edit/src/edit/sidebar/playlist/actions.rs
@@ -2,6 +2,7 @@ use super::super::state::Sidebar;
 use shared::{
     api::endpoints,
     domain::playlist::{PlaylistId, PlaylistUpdateDraftDataPath, PlaylistUpdateDraftDataRequest},
+    error::IntoAnyhow,
 };
 use std::rc::Rc;
 use utils::prelude::*;

--- a/frontend/apps/crates/entry/asset/edit/src/gallery/actions/course_actions.rs
+++ b/frontend/apps/crates/entry/asset/edit/src/gallery/actions/course_actions.rs
@@ -10,6 +10,7 @@ use shared::{
         },
         module::{ModuleBody, ModuleCreatePath, ModuleCreateRequest, ModuleKind},
     },
+    error::IntoAnyhow,
 };
 use std::rc::Rc;
 use utils::prelude::*;

--- a/frontend/apps/crates/entry/asset/edit/src/gallery/actions/jig_actions.rs
+++ b/frontend/apps/crates/entry/asset/edit/src/gallery/actions/jig_actions.rs
@@ -8,6 +8,7 @@ use shared::{
             JigDeletePath, JigGetDraftPath, JigId, JigSearchPath, JigSearchQuery,
         },
     },
+    error::IntoAnyhow,
 };
 use std::rc::Rc;
 use utils::prelude::*;

--- a/frontend/apps/crates/entry/asset/edit/src/gallery/actions/playlist_actions.rs
+++ b/frontend/apps/crates/entry/asset/edit/src/gallery/actions/playlist_actions.rs
@@ -10,6 +10,7 @@ use shared::{
             PlaylistSearchPath, PlaylistSearchQuery,
         },
     },
+    error::IntoAnyhow,
 };
 use std::rc::Rc;
 use utils::prelude::*;

--- a/frontend/apps/crates/entry/asset/edit/src/gallery/actions/resource_actions.rs
+++ b/frontend/apps/crates/entry/asset/edit/src/gallery/actions/resource_actions.rs
@@ -11,6 +11,7 @@ use shared::{
             ResourceSearchPath, ResourceSearchQuery,
         },
     },
+    error::IntoAnyhow,
 };
 use std::rc::Rc;
 use utils::prelude::*;

--- a/frontend/apps/crates/entry/user/src/email/confirmation/actions.rs
+++ b/frontend/apps/crates/entry/user/src/email/confirmation/actions.rs
@@ -2,6 +2,7 @@ use super::state::*;
 use shared::{
     api::endpoints::user,
     domain::user::{VerifyEmailPath, VerifyEmailRequest},
+    error::IntoAnyhow,
 };
 use utils::prelude::*;
 

--- a/frontend/apps/crates/entry/user/src/email/verify/actions.rs
+++ b/frontend/apps/crates/entry/user/src/email/verify/actions.rs
@@ -5,6 +5,7 @@ use shared::{
         session::NewSessionResponse,
         user::{VerifyEmailPath, VerifyEmailRequest},
     },
+    error::IntoAnyhow,
 };
 use utils::{prelude::*, storage};
 

--- a/frontend/apps/crates/entry/user/src/register/pages/step_1/actions.rs
+++ b/frontend/apps/crates/entry/user/src/register/pages/step_1/actions.rs
@@ -1,8 +1,8 @@
 use super::state::*;
 use dominator::clone;
-use shared::{api::endpoints::user::*, domain::user::*};
+use shared::{api::endpoints::user::*, domain::user::*, error::IntoAnyhow};
 use std::rc::Rc;
-use utils::prelude::{ApiEndpointExt, ErrorExt};
+use utils::prelude::ApiEndpointExt;
 
 use crate::register::state::{Step, Step1Data};
 

--- a/frontend/apps/crates/utils/src/editable_asset/editable_course.rs
+++ b/frontend/apps/crates/utils/src/editable_asset/editable_course.rs
@@ -19,8 +19,9 @@ use shared::domain::{
     module::LiteModule,
     UpdateNonNullable,
 };
+use shared::error::IntoAnyhow;
 
-use crate::prelude::{ApiEndpointExt, ErrorExt};
+use crate::prelude::ApiEndpointExt;
 
 #[derive(Clone)]
 pub struct EditableCourse {

--- a/frontend/apps/crates/utils/src/editable_asset/editable_jig.rs
+++ b/frontend/apps/crates/utils/src/editable_asset/editable_jig.rs
@@ -22,8 +22,9 @@ use shared::domain::{
     module::LiteModule,
     UpdateNonNullable,
 };
+use shared::error::IntoAnyhow;
 
-use crate::prelude::{ApiEndpointExt, ErrorExt};
+use crate::prelude::ApiEndpointExt;
 
 #[derive(Clone)]
 pub struct EditableJig {

--- a/frontend/apps/crates/utils/src/editable_asset/editable_playlist.rs
+++ b/frontend/apps/crates/utils/src/editable_asset/editable_playlist.rs
@@ -21,8 +21,9 @@ use shared::domain::{
     playlist::{PlaylistId, PlaylistResponse, PlaylistUpdateDraftDataRequest},
     UpdateNonNullable,
 };
+use shared::error::IntoAnyhow;
 
-use crate::prelude::{ApiEndpointExt, ErrorExt};
+use crate::prelude::ApiEndpointExt;
 
 #[derive(Clone)]
 pub struct EditablePlaylist {

--- a/frontend/apps/crates/utils/src/editable_asset/editable_resource.rs
+++ b/frontend/apps/crates/utils/src/editable_asset/editable_resource.rs
@@ -20,8 +20,9 @@ use shared::domain::{
     resource::{ResourceId, ResourceResponse, ResourceUpdateDraftDataRequest},
     UpdateNonNullable,
 };
+use shared::error::IntoAnyhow;
 
-use crate::prelude::{ApiEndpointExt, ErrorExt};
+use crate::prelude::ApiEndpointExt;
 
 #[derive(Clone)]
 pub struct EditableResource {

--- a/frontend/apps/crates/utils/src/error_ext.rs
+++ b/frontend/apps/crates/utils/src/error_ext.rs
@@ -2,20 +2,14 @@ use std::error::Error;
 
 use crate::toasts::error_string;
 
-pub trait ErrorExt<T> {
-    fn into_anyhow(self) -> anyhow::Result<T>;
-
+pub trait ErrorExt {
     fn toast_on_err(self) -> Self;
 }
 
-impl<T, E> ErrorExt<T> for Result<T, E>
+impl<T, E> ErrorExt for Result<T, E>
 where
     E: Error + Send + Sync + 'static + Into<anyhow::Error>,
 {
-    fn into_anyhow(self) -> anyhow::Result<T> {
-        self.map_err(|e| e.into())
-    }
-
     fn toast_on_err(self) -> Self {
         if let Err(e) = &self {
             error_string(e.to_string());

--- a/shared/rust/Cargo.toml
+++ b/shared/rust/Cargo.toml
@@ -18,7 +18,6 @@ chrono = { version = "0.4.19", features = ["serde"] }
 chrono-tz = { version = "0.6.0", features = ["serde"] }
 csv = "1.1.6"
 http = "0.2.5"
-http-serde = "1.0.3"
 rgb = { version = "0.8.27", features = ["serde"] }
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"

--- a/shared/rust/src/api/endpoints/account.rs
+++ b/shared/rust/src/api/endpoints/account.rs
@@ -1,10 +1,11 @@
 use super::ApiEndpoint;
+use crate::api::Method;
 use crate::domain::billing::{
     CreateSchoolAccountPath, CreateSchoolAccountRequest, GetSchoolAccountResponse,
     IndividualAccountPath, IndividualAccountResponse, SchoolAccountPath, SchoolId, SchoolName,
     SchoolNamePath, SchoolNameValue, UpdateSchoolAccountRequest, UpdateSchoolNamePath,
 };
-use crate::{api::Method, error::EmptyError};
+use crate::error::AccountError;
 
 /// Return a list of known school names
 pub struct GetSchoolNames;
@@ -12,7 +13,7 @@ impl ApiEndpoint for GetSchoolNames {
     type Path = SchoolNamePath;
     type Req = ();
     type Res = Vec<SchoolName>;
-    type Err = EmptyError;
+    type Err = AccountError;
     const METHOD: Method = Method::Get;
 }
 
@@ -22,7 +23,7 @@ impl ApiEndpoint for CreateSchoolAccount {
     type Path = CreateSchoolAccountPath;
     type Req = CreateSchoolAccountRequest;
     type Res = SchoolId;
-    type Err = EmptyError;
+    type Err = AccountError;
     const METHOD: Method = Method::Post;
 }
 
@@ -32,7 +33,7 @@ impl ApiEndpoint for GetSchoolAccount {
     type Path = SchoolAccountPath;
     type Req = ();
     type Res = GetSchoolAccountResponse;
-    type Err = EmptyError;
+    type Err = AccountError;
     const METHOD: Method = Method::Get;
 }
 
@@ -42,7 +43,7 @@ impl ApiEndpoint for UpdateSchoolAccount {
     type Path = SchoolAccountPath;
     type Req = UpdateSchoolAccountRequest;
     type Res = ();
-    type Err = EmptyError;
+    type Err = AccountError;
     const METHOD: Method = Method::Put;
 }
 
@@ -52,7 +53,7 @@ impl ApiEndpoint for UpdateSchoolName {
     type Path = UpdateSchoolNamePath;
     type Req = SchoolNameValue;
     type Res = ();
-    type Err = EmptyError;
+    type Err = AccountError;
     const METHOD: Method = Method::Patch;
 }
 
@@ -62,7 +63,7 @@ impl ApiEndpoint for DeleteSchoolAccount {
     type Path = SchoolAccountPath;
     type Req = ();
     type Res = ();
-    type Err = EmptyError;
+    type Err = AccountError;
     const METHOD: Method = Method::Delete;
 }
 
@@ -72,6 +73,6 @@ impl ApiEndpoint for GetIndividualAccount {
     type Path = IndividualAccountPath;
     type Req = ();
     type Res = IndividualAccountResponse;
-    type Err = EmptyError;
+    type Err = AccountError;
     const METHOD: Method = Method::Get;
 }

--- a/shared/rust/src/api/endpoints/admin.rs
+++ b/shared/rust/src/api/endpoints/admin.rs
@@ -11,7 +11,7 @@ use crate::{
         billing::{SubscriptionPlanPath, UpdateSubscriptionPlansRequest},
         session::{ImpersonatePath, NewSessionResponse},
     },
-    error::{ApiError, EmptyError},
+    error::EmptyError,
 };
 
 /// Impersonate another user.
@@ -30,7 +30,7 @@ impl ApiEndpoint for ExportData {
     type Path = ExportDataPath;
     type Req = ExportDataRequest;
     type Res = ();
-    type Err = ApiError<()>;
+    type Err = EmptyError;
     const METHOD: Method = Method::Get;
 }
 

--- a/shared/rust/src/api/endpoints/billing.rs
+++ b/shared/rust/src/api/endpoints/billing.rs
@@ -3,12 +3,12 @@ use crate::domain::billing::{
     CreateSetupIntentPath, CreateSetupIntentRequest, SubscriptionCancellationStatusRequest,
     UpdateSubscriptionCancellationPath,
 };
+use crate::error::BillingError;
 use crate::{
     api::Method,
     domain::billing::{
         CreateSubscriptionPath, CreateSubscriptionRequest, CreateSubscriptionResponse,
     },
-    error::EmptyError,
 };
 
 /// Create a subscription and store payment info if provided
@@ -17,7 +17,7 @@ impl ApiEndpoint for CreateSubscription {
     type Path = CreateSubscriptionPath;
     type Req = CreateSubscriptionRequest;
     type Res = Option<CreateSubscriptionResponse>;
-    type Err = EmptyError;
+    type Err = BillingError;
     const METHOD: Method = Method::Post;
 }
 
@@ -27,7 +27,7 @@ impl ApiEndpoint for UpdateSubscriptionCancellation {
     type Path = UpdateSubscriptionCancellationPath;
     type Req = SubscriptionCancellationStatusRequest;
     type Res = ();
-    type Err = EmptyError;
+    type Err = BillingError;
     const METHOD: Method = Method::Patch;
 }
 
@@ -37,6 +37,6 @@ impl ApiEndpoint for CreateSetupIntent {
     type Path = CreateSetupIntentPath;
     type Req = CreateSetupIntentRequest;
     type Res = String;
-    type Err = EmptyError;
+    type Err = BillingError;
     const METHOD: Method = Method::Post;
 }

--- a/shared/rust/src/error/account.rs
+++ b/shared/rust/src/error/account.rs
@@ -1,0 +1,62 @@
+use crate::domain::billing::{SchoolNameId, SchoolNameValue};
+use crate::error::billing::BillingError;
+use crate::error::TransientError;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[cfg(feature = "backend")]
+use actix_web::{body::BoxBody, HttpResponse, ResponseError};
+
+#[allow(missing_docs)]
+#[derive(Debug, Error, Serialize, Deserialize)]
+pub enum AccountError {
+    #[cfg_attr(feature = "backend", error(transparent))]
+    #[cfg_attr(not(feature = "backend"), error("Internal server error"))]
+    InternalServerError(
+        #[serde(skip)]
+        #[from]
+        TransientError<anyhow::Error>,
+    ),
+    #[error("User already has an existing account")]
+    UserHasAccount,
+    #[error("A school name of {0} already exists")]
+    SchoolNameExists(SchoolNameValue),
+    #[error("A school using a name with ID {0} already exists")]
+    SchoolExists(SchoolNameId),
+    #[error("{0}")]
+    NotFound(String),
+    #[error("Forbidden")]
+    Forbidden,
+}
+
+#[cfg(feature = "backend")]
+impl ResponseError for AccountError {
+    fn status_code(&self) -> http::StatusCode {
+        match self {
+            Self::InternalServerError { .. } => http::StatusCode::INTERNAL_SERVER_ERROR,
+            Self::NotFound(_) => http::StatusCode::NOT_FOUND,
+            Self::Forbidden => http::StatusCode::FORBIDDEN,
+            _ => http::StatusCode::BAD_REQUEST,
+        }
+    }
+
+    fn error_response(&self) -> HttpResponse<BoxBody> {
+        HttpResponse::build(self.status_code()).json(self)
+    }
+}
+
+impl From<anyhow::Error> for AccountError {
+    fn from(e: anyhow::Error) -> Self {
+        Self::InternalServerError(e.into())
+    }
+}
+
+impl From<AccountError> for BillingError {
+    fn from(value: AccountError) -> Self {
+        match value {
+            AccountError::Forbidden => Self::Forbidden,
+            AccountError::InternalServerError(error) => Self::InternalServerError(error),
+            error => TransientError::from(anyhow::Error::from(error)).into(),
+        }
+    }
+}

--- a/shared/rust/src/error/billing.rs
+++ b/shared/rust/src/error/billing.rs
@@ -1,0 +1,90 @@
+use crate::domain::billing::{AccountType, SubscriptionType};
+use crate::error::service::ServiceError;
+use crate::error::TransientError;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[cfg(feature = "backend")]
+use actix_web::{body::BoxBody, HttpResponse, ResponseError};
+#[cfg(feature = "backend")]
+use stripe::StripeError;
+
+#[allow(missing_docs)]
+#[derive(Debug, Error, Serialize, Deserialize)]
+pub enum BillingError {
+    #[cfg_attr(feature = "backend", error(transparent))]
+    #[cfg_attr(not(feature = "backend"), error("Internal server error"))]
+    InternalServerError(
+        #[serde(skip)]
+        #[from]
+        TransientError<anyhow::Error>,
+    ),
+    #[error(transparent)]
+    Service(ServiceError),
+    #[cfg_attr(feature = "backend", error(transparent))]
+    #[cfg_attr(not(feature = "backend"), error("Stripe error"))]
+    Stripe(
+        #[cfg(feature = "backend")]
+        #[serde(skip)]
+        #[from]
+        TransientError<StripeError>,
+    ),
+    #[error("Not found: {0}")]
+    NotFound(String),
+    #[error("Missing Stripe signature")]
+    MissingStripeSignature,
+    #[error("Invalid Setup Intent ID")]
+    InvalidSetupIntentId,
+    #[error("No active subscription for user")]
+    NoActiveSubscription,
+    #[error("No canceled subscription for user")]
+    NoCanceledSubscription,
+    #[error("Account has an existing subscription")]
+    SubscriptionExists,
+    #[error("School not found")]
+    SchoolNotFound,
+    #[error("Incorrect plan type. Expected {0}, found {1}.")]
+    IncorrectPlanType(AccountType, SubscriptionType),
+    #[error("Invalid promotion code {0}")]
+    InvalidPromotionCode(String),
+    #[error("Forbidden")]
+    Forbidden,
+}
+
+#[cfg(feature = "backend")]
+impl From<StripeError> for BillingError {
+    fn from(value: StripeError) -> Self {
+        Self::from(TransientError::from(value))
+    }
+}
+
+impl From<anyhow::Error> for BillingError {
+    fn from(e: anyhow::Error) -> Self {
+        Self::InternalServerError(e.into())
+    }
+}
+
+#[cfg(feature = "backend")]
+impl ResponseError for BillingError {
+    fn status_code(&self) -> http::StatusCode {
+        match self {
+            Self::InternalServerError { .. } | Self::Stripe { .. } => {
+                http::StatusCode::INTERNAL_SERVER_ERROR
+            }
+            Self::Service(service) => service.status_code(),
+            Self::NotFound(_) | Self::SchoolNotFound => http::StatusCode::NOT_FOUND,
+            Self::Forbidden => http::StatusCode::FORBIDDEN,
+            _ => http::StatusCode::BAD_REQUEST,
+        }
+    }
+
+    fn error_response(&self) -> HttpResponse<BoxBody> {
+        HttpResponse::build(self.status_code()).json(self)
+    }
+}
+
+impl From<ServiceError> for BillingError {
+    fn from(err: ServiceError) -> Self {
+        Self::Service(err)
+    }
+}

--- a/shared/rust/src/error/config.rs
+++ b/shared/rust/src/error/config.rs
@@ -1,0 +1,80 @@
+use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
+use thiserror::Error;
+
+#[cfg(feature = "backend")]
+use crate::error::TransientError;
+
+#[cfg(feature = "backend")]
+use actix_web::{
+    body::BoxBody,
+    error::{JsonPayloadError, PathError, QueryPayloadError},
+    HttpResponse, ResponseError,
+};
+
+/// Represents actix-web config errors
+#[allow(missing_docs)]
+#[allow(clippy::module_name_repetitions)]
+#[derive(Debug, Error, Serialize, Deserialize)]
+pub enum ConfigError {
+    #[cfg_attr(feature = "backend", error(transparent))]
+    #[cfg_attr(not(feature = "backend"), error("Invalid JSON body"))]
+    JsonPayloadError {
+        #[cfg(feature = "backend")]
+        #[serde(skip)]
+        #[from]
+        source: TransientError<JsonPayloadError>,
+    },
+    #[cfg_attr(feature = "backend", error(transparent))]
+    #[cfg_attr(not(feature = "backend"), error("Invalid query"))]
+    QueryPayloadError {
+        #[cfg(feature = "backend")]
+        #[serde(skip)]
+        #[from]
+        source: TransientError<QueryPayloadError>,
+    },
+    #[cfg_attr(feature = "backend", error(transparent))]
+    #[cfg_attr(not(feature = "backend"), error("Invalid path parameters"))]
+    PathError {
+        #[cfg(feature = "backend")]
+        #[serde(skip)]
+        #[from]
+        source: TransientError<PathError>,
+    },
+}
+
+#[cfg(feature = "backend")]
+impl From<JsonPayloadError> for ConfigError {
+    fn from(error: JsonPayloadError) -> Self {
+        Self::from(TransientError::from(error))
+    }
+}
+
+#[cfg(feature = "backend")]
+impl From<QueryPayloadError> for ConfigError {
+    fn from(error: QueryPayloadError) -> Self {
+        Self::from(TransientError::from(error))
+    }
+}
+
+#[cfg(feature = "backend")]
+impl From<PathError> for ConfigError {
+    fn from(error: PathError) -> Self {
+        Self::from(TransientError::from(error))
+    }
+}
+
+#[cfg(feature = "backend")]
+impl ResponseError for ConfigError {
+    fn status_code(&self) -> http::StatusCode {
+        match self {
+            Self::JsonPayloadError { source } => source.status_code(),
+            Self::QueryPayloadError { source } => source.status_code(),
+            Self::PathError { source } => source.status_code(),
+        }
+    }
+
+    fn error_response(&self) -> HttpResponse<BoxBody> {
+        HttpResponse::build(self.status_code()).json(self)
+    }
+}

--- a/shared/rust/src/error/service.rs
+++ b/shared/rust/src/error/service.rs
@@ -1,0 +1,85 @@
+use crate::error::TransientError;
+use serde::{Deserialize, Serialize};
+use strum_macros::Display;
+use thiserror::Error;
+
+#[cfg(feature = "backend")]
+use actix_web::{body::BoxBody, HttpResponse, ResponseError};
+
+#[allow(missing_docs)]
+#[derive(Debug, Error, Serialize, Deserialize)]
+pub enum ServiceError {
+    #[cfg_attr(feature = "backend", error(transparent))]
+    #[cfg_attr(not(feature = "backend"), error("Internal server error"))]
+    InternalServerError(
+        #[serde(skip)]
+        #[from]
+        TransientError<anyhow::Error>,
+    ),
+    #[error("{0}")]
+    DisabledService(ServiceKindError),
+    #[error("Forbidden")]
+    Forbidden,
+    #[error("Resource not found")]
+    ResourceNotFound,
+}
+
+#[cfg(feature = "backend")]
+impl ResponseError for ServiceError {
+    fn status_code(&self) -> http::StatusCode {
+        match self {
+            Self::InternalServerError { .. } => http::StatusCode::INTERNAL_SERVER_ERROR,
+            Self::DisabledService(_) => http::StatusCode::NOT_IMPLEMENTED,
+            Self::Forbidden => http::StatusCode::FORBIDDEN,
+            Self::ResourceNotFound => http::StatusCode::NOT_FOUND,
+        }
+    }
+
+    fn error_response(&self) -> HttpResponse<BoxBody> {
+        HttpResponse::build(self.status_code()).json(self)
+    }
+}
+
+impl From<anyhow::Error> for ServiceError {
+    fn from(e: anyhow::Error) -> Self {
+        Self::InternalServerError(e.into())
+    }
+}
+
+#[allow(missing_docs)]
+#[derive(Debug, Copy, Clone, Display, Serialize, Deserialize)]
+pub enum ServiceKindError {
+    #[strum(serialize = "Algolia")]
+    Algolia,
+    #[strum(serialize = "S3")]
+    S3,
+    #[strum(serialize = "Google Cloud Storage")]
+    GoogleCloudStorage,
+    #[strum(serialize = "Google Cloud EventArc")]
+    GoogleCloudEventArc,
+    #[strum(serialize = "Google OAuth")]
+    GoogleOAuth,
+    #[strum(serialize = "Google Cloud Access Key Store")]
+    GoogleCloudAccessKeyStore,
+    #[strum(serialize = "Sendgrid Mail")]
+    Mail,
+    #[strum(serialize = "Firebase Cloud Messaging")]
+    FirebaseCloudMessaging,
+    #[strum(serialize = "Media Upload Cleaner")]
+    UploadCleaner,
+    #[strum(serialize = "Google Translate")]
+    GoogleTranslate,
+    #[strum(serialize = "Stripe")]
+    Stripe,
+}
+
+#[cfg(feature = "backend")]
+impl ResponseError for ServiceKindError {
+    fn status_code(&self) -> http::StatusCode {
+        http::StatusCode::NOT_IMPLEMENTED
+    }
+
+    fn error_response(&self) -> HttpResponse<BoxBody> {
+        HttpResponse::build(self.status_code()).json(self)
+    }
+}


### PR DESCRIPTION
**Warning:** Fairly significant refactor.

- Renames original `ApiError` to `ApiResponseError`
  - `ResponseError` conflicts with an actix trait;
  - deprecating the struct made a bunch of noise during compile - once other errors are moved over we can deprecated and handle the issues.
  - Moves `ApiResponseError` to the backend crate.
- Creates a _new_ `ApiError` enum which lets us handle errors from the API on the frontend:
  - This enum is marked as `#[serde(untagged)]` so that we can serialize and send the _actual_ error (for example `BillingError`) from the backend, and the front-end can serialize it into an `ApiError` correctly.
  - This is necessary because the backend has at least 2 points of failure when serving requests: Deserializing JSON and the actual request handler -- We want to be able to send either error type to the client and have it deserialize correctly.
- Moves `BillingError`, `AccountError`, `ServiceError`, `ServiceKindError` and `ConfigError` into the shared crate so that they can be used correctly by the frontend.
- Updates billing and account endpoint definitions to change the `::Err` type to `BillingError` and `AccountError` respectively
- Updates the billing and account request handlers to use the `::Err` type for declaring the error type in the response.
- Renames the frontend `ApiError` to `FetchError`
- Updates `FetchError`'s `Response` variant to hold an `ApiError<T>` so that we can correctly parse errors from the server into the correct error variant and type.
- Removes `into_anyhow` from frontends `ErrorExt` preferring the implementation from the `IntoAnyhow` trait in shared crate.