### PR TITLE
chore: Move PlanTier to shared crate

### DIFF
--- a/frontend/apps/crates/utils/src/init/user.rs
+++ b/frontend/apps/crates/utils/src/init/user.rs
@@ -1,6 +1,7 @@
 use crate::{fetch::*, unwrap::UnwrapJiExt};
 use futures_signals::signal::{Mutable, Signal};
 use once_cell::sync::OnceCell;
+use shared::domain::billing::PlanTier;
 use shared::{
     api::endpoints::user::Profile,
     domain::{
@@ -74,27 +75,9 @@ pub fn get_user_email() -> Option<String> {
     Some(email)
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub enum PlanTier {
-    Pro,
-    Basic,
-    Free,
-}
-
 pub fn get_plan_tier() -> PlanTier {
     match get_plan_type() {
-        Some(
-            PlanType::IndividualProMonthly
-            | PlanType::IndividualProAnnually
-            | PlanType::SchoolLevel1
-            | PlanType::SchoolLevel2
-            | PlanType::SchoolLevel3
-            | PlanType::SchoolLevel4
-            | PlanType::SchoolUnlimited,
-        ) => PlanTier::Pro,
-        Some(PlanType::IndividualBasicMonthly | PlanType::IndividualBasicAnnually) => {
-            PlanTier::Basic
-        }
+        Some(plan_type) => plan_type.plan_tier(),
         None => PlanTier::Free,
     }
 }

--- a/frontend/apps/crates/utils/src/paywall/checks.rs
+++ b/frontend/apps/crates/utils/src/paywall/checks.rs
@@ -1,4 +1,5 @@
-use crate::prelude::{get_plan_tier, PlanTier};
+use crate::prelude::get_plan_tier;
+use shared::domain::billing::PlanTier;
 
 pub fn can_create_jig(total_existing: u64) -> bool {
     match get_plan_tier() {

--- a/shared/rust/src/domain/billing.rs
+++ b/shared/rust/src/domain/billing.rs
@@ -569,6 +569,19 @@ pub enum SubscriptionType {
     School = 1,
 }
 
+/// Subscription plan tier
+#[derive(Debug, Display, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "backend", derive(sqlx::Type))]
+#[repr(i16)]
+pub enum PlanTier {
+    /// Free tier
+    Free = 0,
+    /// Basic tier
+    Basic = 1,
+    /// Pro tier
+    Pro = 2,
+}
+
 /// Possible individual subscription plans
 #[derive(
     Debug, Display, Serialize, Deserialize, Clone, Copy, Eq, Ord, PartialOrd, PartialEq, Hash,
@@ -750,6 +763,21 @@ impl PlanType {
                 | Self::SchoolLevel4
                 | Self::SchoolUnlimited
         )
+    }
+
+    /// The tier this plan type is associated with
+    #[must_use]
+    pub const fn plan_tier(&self) -> PlanTier {
+        match self {
+            PlanType::IndividualProMonthly
+            | PlanType::IndividualProAnnually
+            | PlanType::SchoolLevel1
+            | PlanType::SchoolLevel2
+            | PlanType::SchoolLevel3
+            | PlanType::SchoolLevel4
+            | PlanType::SchoolUnlimited => PlanTier::Pro,
+            PlanType::IndividualBasicMonthly | PlanType::IndividualBasicAnnually => PlanTier::Basic,
+        }
     }
 }
 


### PR DESCRIPTION
Moving PlanTier to the shared crate so that it can be used in the backend too.