### PR TITLE
fix: Set backface visibility to hidden to prevent front card anchor being clickable

### DIFF
--- a/frontend/elements/src/core/asset/asset-card.ts
+++ b/frontend/elements/src/core/asset/asset-card.ts
@@ -21,6 +21,7 @@ export class _ extends LitElement {
                     height: 246px;
                     grid-template-rows: auto 0px 1fr;
                     position: relative;
+                    backface-visibility: hidden;
                 }
                 :host([dense]) {
                     width: 216px;


### PR DESCRIPTION
- Closes #4096
- This issue affected Chrome browsers. Firefox seemed Ok. 