### PR TITLE
chore: Load asset and decrease opacity of backdrop

### DIFF
--- a/frontend/apps/crates/entry/asset/play/src/jig/actions.rs
+++ b/frontend/apps/crates/entry/asset/play/src/jig/actions.rs
@@ -284,9 +284,9 @@ impl JigPlayer {
                         self.play_login_popup_shown.set(true);
                     }
                 }
-                return;
+            } else {
+                restrictions::increase_played_count();
             }
-            restrictions::increase_played_count();
         }
 
         state.loader.load(clone!(state => async move {

--- a/frontend/apps/crates/utils/src/quick_elements.rs
+++ b/frontend/apps/crates/utils/src/quick_elements.rs
@@ -15,7 +15,7 @@ macro_rules! dialog {
             .child(html!("style", {
                 .text(r#"
                     dialog::backdrop {
-                        background-color: #d8e7fade;
+                        background-color: #d8e7facc;
                     }
                 "#)
             }))


### PR DESCRIPTION
- Closes #4108 
- Loads the asset so that there is something visible behind the modal;
- Decreases the opacity slightly so that whatever is behind the modal is a little bit more visible.

![image](https://github.com/ji-devs/ji-cloud/assets/4161106/a3647041-59eb-470b-be27-940f509bdbe7)
