### PR TITLE
fix: Prevent jig info popup getting cut off in Safari

### DIFF
--- a/frontend/apps/crates/entry/asset/play/src/jig/sidebar/dom/share.rs
+++ b/frontend/apps/crates/entry/asset/play/src/jig/sidebar/dom/share.rs
@@ -17,7 +17,7 @@ impl Sidebar {
             .prop("kind", "share")
             .prop_signal("active", share_jig.active_popup.signal_cloned().map(|active| active.is_some()))
             .event(clone!(state => move |_: events::Click| {
-                state.track_action("Information Click");
+                state.track_action("Share Click");
             }))
         });
 

--- a/frontend/elements/src/core/popups/popup-body.ts
+++ b/frontend/elements/src/core/popups/popup-body.ts
@@ -13,7 +13,7 @@ export class _ extends LitElement {
                 }
                 header {
                     padding: 12px 12px 10px 12px;
-                    height: 80px;
+                    min-height: 80px;
                 }
                 nav {
                     display: flex;

--- a/frontend/elements/src/entry/asset/play/jig/sidebar/jig-info.ts
+++ b/frontend/elements/src/entry/asset/play/jig/sidebar/jig-info.ts
@@ -17,13 +17,17 @@ export class _ extends LitElement {
                 :host {
                     display: block;
                     width: 400px;
-                    background-color: #ffffff;
                     font-size: 14px;
                 }
                 .body {
-                    padding: 13px 24px;
+                    padding: 0 24px 24px 24px;
                     overflow-y: auto;
                     max-height: 496px;
+                }
+                popup-body {
+                    border-radius: 16px;
+                    box-shadow: rgb(0 0 0 / 25%) 0px 3px 16px 0px;
+                    background-color: #ffffff;
                 }
                 .body section {
                     padding: 20px 0;
@@ -200,7 +204,7 @@ export class _ extends LitElement {
             <popup-body>
                 <slot slot="close" name="close"></slot>
                 <h3 slot="heading">${this.name}</h3>
-                <h4 slot="author-line">                
+                <h4 slot="author-line">
                     <div class="author-published">
                             <a href=${this.href} .target=${this.target}>
                                 <div class="author">


### PR DESCRIPTION
- Fixes #4087
- Uses the same close button as the Share popup;
- Fixes the header of the info popup so that it resizes cleanly for titles that wrap.