### PR TITLE
fix: Ensure that the editing grid is always visible when editing a design module

### DIFF
--- a/frontend/apps/crates/entry/module/cover/edit/src/base/main/dom.rs
+++ b/frontend/apps/crates/entry/module/cover/edit/src/base/main/dom.rs
@@ -16,6 +16,9 @@ impl DomRenderable for Main {
             .style("overflow", "hidden")
             .child(html!("img-ui", {
                 .prop("path", "jig/play/design-grid-jig.svg")
+                .style("position", "absolute")
+                .style("z-index", "100")
+                .style("pointer-events", "none")
                 .style("height", "100%")
                 .style("width", "100%")
             }))

--- a/frontend/apps/crates/entry/module/drag-drop/edit/src/base/main/dom.rs
+++ b/frontend/apps/crates/entry/module/drag-drop/edit/src/base/main/dom.rs
@@ -24,6 +24,9 @@ impl DomRenderable for Main {
             .style("touch-action", "none")
             .child(html!("img-ui", {
                 .prop("path", "jig/play/design-grid-jig.svg")
+                .style("position", "absolute")
+                .style("z-index", "100")
+                .style("pointer-events", "none")
                 .style("height", "100%")
                 .style("width", "100%")
             }))

--- a/frontend/apps/crates/entry/module/embed/edit/src/base/main/dom.rs
+++ b/frontend/apps/crates/entry/module/embed/edit/src/base/main/dom.rs
@@ -17,6 +17,9 @@ impl DomRenderable for Main {
             .style("overflow", "hidden")
             .child(html!("img-ui", {
                 .prop("path", "jig/play/design-grid-jig.svg")
+                .style("position", "absolute")
+                .style("z-index", "100")
+                .style("pointer-events", "none")
                 .style("height", "100%")
                 .style("width", "100%")
             }))

--- a/frontend/apps/crates/entry/module/find-answer/edit/src/base/main/dom.rs
+++ b/frontend/apps/crates/entry/module/find-answer/edit/src/base/main/dom.rs
@@ -46,6 +46,9 @@ impl DomRenderable for Main {
             })))
             .child(html!("img-ui", {
                 .prop("path", "jig/play/design-grid-jig.svg")
+                .style("position", "absolute")
+                .style("z-index", "100")
+                .style("pointer-events", "none")
                 .style("height", "100%")
                 .style("width", "100%")
             }))

--- a/frontend/apps/crates/entry/module/poster/edit/src/base/main/dom.rs
+++ b/frontend/apps/crates/entry/module/poster/edit/src/base/main/dom.rs
@@ -16,6 +16,9 @@ impl DomRenderable for Main {
             .style("overflow", "hidden")
             .child(html!("img-ui", {
                 .prop("path", "jig/play/design-grid-jig.svg")
+                .style("position", "absolute")
+                .style("z-index", "100")
+                .style("pointer-events", "none")
                 .style("height", "100%")
                 .style("width", "100%")
             }))

--- a/frontend/apps/crates/entry/module/tapping-board/edit/src/base/main/dom.rs
+++ b/frontend/apps/crates/entry/module/tapping-board/edit/src/base/main/dom.rs
@@ -19,6 +19,9 @@ impl DomRenderable for Main {
             .style("overflow", "hidden")
             .child(html!("img-ui", {
                 .prop("path", "jig/play/design-grid-jig.svg")
+                .style("position", "absolute")
+                .style("z-index", "100")
+                .style("pointer-events", "none")
                 .style("height", "100%")
                 .style("width", "100%")
             }))

--- a/frontend/apps/crates/entry/module/video/edit/src/base/main/dom.rs
+++ b/frontend/apps/crates/entry/module/video/edit/src/base/main/dom.rs
@@ -17,6 +17,9 @@ impl DomRenderable for Main {
             .style("overflow", "hidden")
             .child(html!("img-ui", {
                 .prop("path", "jig/play/design-grid-jig.svg")
+                .style("position", "absolute")
+                .style("z-index", "100")
+                .style("pointer-events", "none")
                 .style("height", "100%")
                 .style("width", "100%")
             }))


### PR DESCRIPTION
Closes #4118