### PR TITLE
Remove tips and featured jigs for non logged in users

### DIFF
--- a/frontend/apps/crates/entry/home/src/home/dom/mod.rs
+++ b/frontend/apps/crates/entry/home/src/home/dom/mod.rs
@@ -69,6 +69,9 @@ impl Home {
                 }
             })).to_signal_vec())
             .child(html!("empty-fragment", {
+                // there's a 10px top margin in the iframe content
+                .style("display", "block")
+                .style("transform", "translateY(-10px)")
                 .child_signal(state.mode.signal_cloned().map(move |mode| {
                     match mode {
                         HomePageMode::Home => {

--- a/frontend/apps/crates/entry/home/src/home/dom/mod.rs
+++ b/frontend/apps/crates/entry/home/src/home/dom/mod.rs
@@ -69,7 +69,6 @@ impl Home {
                 }
             })).to_signal_vec())
             .child(html!("empty-fragment", {
-                
                 .child_signal(state.mode.signal_cloned().map(move |mode| {
                     match mode {
                         HomePageMode::Home => {

--- a/frontend/apps/crates/entry/home/src/home/dom/mod.rs
+++ b/frontend/apps/crates/entry/home/src/home/dom/mod.rs
@@ -34,11 +34,14 @@ impl Home {
             }))
             .child(search_section::render(state.clone(), is_search))
             .child(html!("empty-fragment", {
+                // remove slight gap
+                .style("display", "block") 
+                .style("line-height", "0")
                 .child_signal(state.mode.signal_cloned().map(move |mode| {
                     match mode {
                         HomePageMode::Home => {
                             Some(html!("iframe", {
-                                .prop("src", "https://corinne4371.wixstudio.io/basic/blank")
+                                .prop("src", "https://corinne4371.wixstudio.io/basic/blank") // wix
                                 .style("width", "100%")
                                 .style("height", "200px")
                                 .style("border", "0")
@@ -55,9 +58,9 @@ impl Home {
                     HomePageMode::Search(_) => vec![],
                     HomePageMode::Home => {
                         let mut divs = vec![];
-                        divs.push(state.render_strip("Trending JIGs", "trending", state.trending.read_only()));
-                        divs.push(state.render_strip("Top picks", "featured", state.featured.read_only()));
                         if is_user_set() {
+                            divs.push(state.render_strip("Trending JIGs", "trending", state.trending.read_only()));
+                            divs.push(state.render_strip("Top picks", "featured", state.featured.read_only()));
                             divs.push(state.render_strip("My likes", "liked", state.liked.read_only()));
                             divs.push(state.render_strip("Recently played", "played", state.played.read_only()));
                         }
@@ -66,6 +69,7 @@ impl Home {
                 }
             })).to_signal_vec())
             .child(html!("empty-fragment", {
+                
                 .child_signal(state.mode.signal_cloned().map(move |mode| {
                     match mode {
                         HomePageMode::Home => {

--- a/frontend/apps/crates/entry/home/src/home/dom/mod.rs
+++ b/frontend/apps/crates/entry/home/src/home/dom/mod.rs
@@ -34,9 +34,6 @@ impl Home {
             }))
             .child(search_section::render(state.clone(), is_search))
             .child(html!("empty-fragment", {
-                // remove slight gap
-                .style("display", "block") 
-                .style("line-height", "0")
                 .child_signal(state.mode.signal_cloned().map(move |mode| {
                     match mode {
                         HomePageMode::Home => {
@@ -71,7 +68,7 @@ impl Home {
             .child(html!("empty-fragment", {
                 // there's a 10px top margin in the iframe content
                 .style("display", "block")
-                .style("transform", "translateY(-10px)")
+                .style("transform", "translateY(-16px)")
                 .child_signal(state.mode.signal_cloned().map(move |mode| {
                     match mode {
                         HomePageMode::Home => {


### PR DESCRIPTION
Hide all the extra rows  (Trending and Top Picks)so that a new user gets to see the animation about jigzi first.

I also removed a slight space on the `empty-fragment` element of the wix segment above it.

@johnnynotsolucky @corinnewo 