### PR TITLE
Limit the unlimited plan (!) to 30 and add text to contact for more

### DIFF
--- a/frontend/apps/crates/entry/home/src/pricing/dom.rs
+++ b/frontend/apps/crates/entry/home/src/pricing/dom.rs
@@ -236,6 +236,7 @@ impl Pricing {
                         .prop("school_level_2_max", billing::PLAN_SCHOOL_LEVEL_2_TEACHER_COUNT)
                         .prop("school_level_3_max", billing::PLAN_SCHOOL_LEVEL_3_TEACHER_COUNT)
                         .prop("school_level_4_max", billing::PLAN_SCHOOL_LEVEL_4_TEACHER_COUNT)
+                        .prop("school_unlimited_max", billing::PLAN_SCHOOL_UNLIMITED_TEACHER_COUNT)
                         .prop_signal("plan_price", map_ref! {
                             let selected_index = selected_index.signal(),
                             let billing_interval = state.billing_interval.signal() => move {

--- a/frontend/elements/src/entry/home/pricing/school-pricing.ts
+++ b/frontend/elements/src/entry/home/pricing/school-pricing.ts
@@ -78,12 +78,11 @@ export class _ extends LitElement {
                 display: none;
             }
             .price-line {
-                display: grid;
-                grid-template-columns: 1fr auto 1fr;
+                display: flex;
                 gap: 8px;
+                align-items: center;
             }
             .price {
-                grid-column: 2;
                 font-size: 38px;
                 font-weight: 700;
                 color: var(--dark-gray-6);
@@ -94,7 +93,8 @@ export class _ extends LitElement {
                 gap: 16px;
             }
             .price-original {
-                grid-column: 3;
+                display: flex;
+                align-items: center;
                 font-size: 16px;
                 font-weight: 600;
                 color: var(--dark-gray-3);

--- a/frontend/elements/src/entry/home/pricing/school-pricing.ts
+++ b/frontend/elements/src/entry/home/pricing/school-pricing.ts
@@ -17,6 +17,10 @@ export class _ extends LitElement {
                 color: var(--dark-blue-4);
                 margin: 0;
             }
+            .plans-wrapper {
+                display: flex;
+                flex-direction: column;
+            }
             .options-wrapper {
                 height: 48px;
                 width: 300px;
@@ -117,6 +121,10 @@ export class _ extends LitElement {
                 font-weight: 500;
                 margin-top: 12px;
             }
+            .contact-line {
+                font-size: 12px;
+                margin-bottom: 12px;
+            }
         `];
     }
 
@@ -141,6 +149,9 @@ export class _ extends LitElement {
     @property({ type: Number })
     school_level_4_max?: number;
 
+    @property({ type: Number })
+    school_unlimited_max?: number;
+
     @property()
     billing_interval: string = "";
 
@@ -163,37 +174,43 @@ export class _ extends LitElement {
                 }
             </style>
             <h3>How many Teacher Pro accounts?</h3>
-            <div class="options-wrapper">
-                <div class="indicator-wrapper">
-                    <div class="indicator"></div>
+            <div class="plans-wrapper">
+                <div class="options-wrapper">
+                    <div class="indicator-wrapper">
+                        <div class="indicator"></div>
+                    </div>
+                    <div class="options">
+                        <label>
+                            <span class="label-top">up to</span>
+                            <span class="count">${this.school_level_1_max}</span>
+                            <input name="count" type="radio" @change=${() => this.onChange(0)}>
+                        </label>
+                        <label>
+                            <span class="label-top">up to</span>
+                            <span class="count">${this.school_level_2_max}</span>
+                            <input name="count" type="radio" @change=${() => this.onChange(1)}>
+                        </label>
+                        <label>
+                            <span class="label-top">up to</span>
+                            <span class="count">${this.school_level_3_max}</span>
+                            <input name="count" type="radio" @change=${() => this.onChange(2)}>
+                        </label>
+                        <label>
+                            <span class="label-top">up to</span>
+                            <span class="count">${this.school_level_4_max}</span>
+                            <input name="count" type="radio" @change=${() => this.onChange(3)}>
+                        </label>
+                        <label>
+                            <span class="label-top">up to</span>
+                            <span class="count">${this.school_unlimited_max}</span>
+                            <input name="count" type="radio" @change=${() => this.onChange(4)}>
+                        </label>
+                    </div>
                 </div>
-                <div class="options">
-                    <label>
-                        <span class="label-top">up to</span>
-                        <span class="count">${this.school_level_1_max}</span>
-                        <input name="count" type="radio" @change=${() => this.onChange(0)}>
-                    </label>
-                    <label>
-                        <span class="label-top">up to</span>
-                        <span class="count">${this.school_level_2_max}</span>
-                        <input name="count" type="radio" @change=${() => this.onChange(1)}>
-                    </label>
-                    <label>
-                        <span class="label-top">up to</span>
-                        <span class="count">${this.school_level_3_max}</span>
-                        <input name="count" type="radio" @change=${() => this.onChange(2)}>
-                    </label>
-                    <label>
-                        <span class="label-top">up to</span>
-                        <span class="count">${this.school_level_4_max}</span>
-                        <input name="count" type="radio" @change=${() => this.onChange(3)}>
-                    </label>
-                    <label>
-                        <span class="label-top">More than</span>
-                        <span class="count">${this.school_level_4_max}+</span>
-                        <input name="count" type="radio" @change=${() => this.onChange(4)}>
-                    </label>
-                </div>
+                
+            </div>
+            <div class="contact-line">
+                <div class="contact-line-text">Contact us if you need more than ${this.school_unlimited_max} accounts.</div>
             </div>
             <div class="price-line">
                 <div class="price">${price(

--- a/shared/rust/src/domain/billing.rs
+++ b/shared/rust/src/domain/billing.rs
@@ -26,6 +26,8 @@ pub const PLAN_SCHOOL_LEVEL_2_TEACHER_COUNT: i64 = 10;
 pub const PLAN_SCHOOL_LEVEL_3_TEACHER_COUNT: i64 = 15;
 /// Level 4 max teacher count
 pub const PLAN_SCHOOL_LEVEL_4_TEACHER_COUNT: i64 = 20;
+/// Level 5 max teacher count
+pub const PLAN_SCHOOL_UNLIMITED_TEACHER_COUNT: i64 = 30;
 
 /// Individual plan trial period in days
 pub const INDIVIDUAL_TRIAL_PERIOD: i64 = 7;
@@ -820,8 +822,8 @@ impl PlanType {
                 PLAN_SCHOOL_LEVEL_4_TEACHER_COUNT
             ),
             Self::SchoolUnlimitedMonthly => formatcp!(
-                "School - More than {} teachers - Monthly",
-                PLAN_SCHOOL_LEVEL_4_TEACHER_COUNT
+                "School - Up to {} teachers - Monthly",
+                PLAN_SCHOOL_UNLIMITED_TEACHER_COUNT
             ),
             Self::SchoolLevel1Annually => formatcp!(
                 "School - Up to {} teachers",
@@ -840,8 +842,8 @@ impl PlanType {
                 PLAN_SCHOOL_LEVEL_4_TEACHER_COUNT
             ),
             Self::SchoolUnlimitedAnnually => formatcp!(
-                "School - More than {} teachers",
-                PLAN_SCHOOL_LEVEL_4_TEACHER_COUNT
+                "School - Up to {} teachers",
+                PLAN_SCHOOL_UNLIMITED_TEACHER_COUNT
             ),
         }
     }
@@ -865,7 +867,7 @@ impl PlanType {
                 formatcp!("Up to {} teachers", PLAN_SCHOOL_LEVEL_4_TEACHER_COUNT)
             }
             Self::SchoolUnlimitedMonthly | Self::SchoolUnlimitedAnnually => {
-                formatcp!("More than {} teachers", PLAN_SCHOOL_LEVEL_4_TEACHER_COUNT)
+                formatcp!("Up to {} teachers", PLAN_SCHOOL_UNLIMITED_TEACHER_COUNT)
             }
         }
     }


### PR DESCRIPTION
As per: 
<img width="1510" height="462" alt="image" src="https://github.com/user-attachments/assets/3227c1d4-6185-475e-b163-2d21a97b727a" />

@johnnynotsolucky 
This is a bit involved, since it affects price plans. The instruction is to just change the text for the unlimited plan to limit it to 30, and not add a new price plan limiting it to 30.

I've done it so that it should only affect the text instructions and not anything else. This won't stop someone from adding more than 30. Handling whether or not someone can go over 30 will be on a case-by-case basis.



## Note
@corinnewo 
The price line is offset and misaligned with the rest of the rows.  This looks deliberate, but I can center it like the other rows if needed: see below
<img width="428" height="300" alt="image" src="https://github.com/user-attachments/assets/c0b5fd6d-885e-4aa2-bda8-d83ce85f84c0" />
