### PR TITLE
Reduce gap on home page

### DIFF
--- a/frontend/apps/crates/entry/home/src/home/dom/mod.rs
+++ b/frontend/apps/crates/entry/home/src/home/dom/mod.rs
@@ -68,7 +68,7 @@ impl Home {
             .child(html!("empty-fragment", {
                 // there's a 10px top margin in the iframe content
                 .style("display", "block")
-                .style("transform", "translateY(-16px)")
+                .style("transform", "translateY(-10px)")
                 .child_signal(state.mode.signal_cloned().map(move |mode| {
                     match mode {
                         HomePageMode::Home => {


### PR DESCRIPTION
Just reduce from 16px to 10px now that the wix gap is removed

cc @johnnynotsolucky @corinnewo 