### PR TITLE
Make empty search results hint conditional

### DIFF
--- a/frontend/apps/crates/entry/home/src/home/search_results/dom.rs
+++ b/frontend/apps/crates/entry/home/src/home/search_results/dom.rs
@@ -36,6 +36,7 @@ impl SearchResults {
             .prop_signal("jigCount", state.jigs.total.signal())
             .prop_signal("playlistCount", state.playlists.total.signal())
             .prop_signal("resourceCount", state.resources.total.signal())
+            .prop("isRated", state.rated_only)
             .prop("query", &state.query)
             .child(state.jigs.home_state.search_bar.render_rated_toggle(Rc::new(clone!(state => move || {
                 search(&state.jigs.home_state)

--- a/frontend/apps/crates/entry/home/src/home/search_results/state.rs
+++ b/frontend/apps/crates/entry/home/src/home/search_results/state.rs
@@ -25,7 +25,7 @@ impl SearchResults {
             .search_bar
             .search_selected
             .rated_only
-            .get_cloned();
+            .get();
 
         Rc::new(Self {
             loading: Mutable::new(loading),

--- a/frontend/apps/crates/entry/home/src/home/search_results/state.rs
+++ b/frontend/apps/crates/entry/home/src/home/search_results/state.rs
@@ -21,11 +21,7 @@ pub struct SearchResults {
 impl SearchResults {
     pub fn new(home_state: &Rc<Home>, loading: bool) -> Rc<Self> {
         let query = home_state.search_bar.search_selected.query.get_cloned();
-        let rated_only = home_state
-            .search_bar
-            .search_selected
-            .rated_only
-            .get();
+        let rated_only = home_state.search_bar.search_selected.rated_only.get();
 
         Rc::new(Self {
             loading: Mutable::new(loading),

--- a/frontend/apps/crates/entry/home/src/home/search_results/state.rs
+++ b/frontend/apps/crates/entry/home/src/home/search_results/state.rs
@@ -12,7 +12,7 @@ use super::{super::state::Home, search_results_section::SearchResultsSection};
 pub struct SearchResults {
     pub loading: Mutable<bool>,
     pub query: String,
-    pub rated_only: bool, 
+    pub rated_only: bool,
     pub jigs: Rc<SearchResultsSection>,
     pub resources: Rc<SearchResultsSection>,
     pub playlists: Rc<SearchResultsSection>,
@@ -21,7 +21,11 @@ pub struct SearchResults {
 impl SearchResults {
     pub fn new(home_state: &Rc<Home>, loading: bool) -> Rc<Self> {
         let query = home_state.search_bar.search_selected.query.get_cloned();
-        let rated_only = home_state.search_bar.search_selected.rated_only.get_cloned();
+        let rated_only = home_state
+            .search_bar
+            .search_selected
+            .rated_only
+            .get_cloned();
 
         Rc::new(Self {
             loading: Mutable::new(loading),

--- a/frontend/apps/crates/entry/home/src/home/search_results/state.rs
+++ b/frontend/apps/crates/entry/home/src/home/search_results/state.rs
@@ -12,6 +12,7 @@ use super::{super::state::Home, search_results_section::SearchResultsSection};
 pub struct SearchResults {
     pub loading: Mutable<bool>,
     pub query: String,
+    pub rated_only: bool, 
     pub jigs: Rc<SearchResultsSection>,
     pub resources: Rc<SearchResultsSection>,
     pub playlists: Rc<SearchResultsSection>,
@@ -20,10 +21,12 @@ pub struct SearchResults {
 impl SearchResults {
     pub fn new(home_state: &Rc<Home>, loading: bool) -> Rc<Self> {
         let query = home_state.search_bar.search_selected.query.get_cloned();
+        let rated_only = home_state.search_bar.search_selected.rated_only.get_cloned();
 
         Rc::new(Self {
             loading: Mutable::new(loading),
             query,
+            rated_only,
             jigs: SearchResultsSection::new(Rc::clone(&home_state), AssetType::Jig),
             resources: SearchResultsSection::new(Rc::clone(&home_state), AssetType::Resource),
             playlists: SearchResultsSection::new(Rc::clone(&home_state), AssetType::Playlist),

--- a/frontend/elements/src/entry/home/home/search-results/search-results.ts
+++ b/frontend/elements/src/entry/home/home/search-results/search-results.ts
@@ -59,6 +59,9 @@ export class _ extends LitElement {
     @property()
     query: string = "";
 
+    @property()
+    isRated: boolean = true;
+
     @property({ type: Number })
     jigCount: number = 0;
 
@@ -130,8 +133,10 @@ export class _ extends LitElement {
                 ${
                     this.query.trim() !== "" ? html`
                         ${STR_FOR}
-                        <span class="query">${this.query}</span>.
-                        Try selecting <strong>All</strong> instead of <strong>Top Rated</strong>
+                        <span class="query">"${this.query}"</span>.
+                        ${this.isRated ? html`
+                            <br />Try selecting <strong>All</strong> instead of <strong>Top Rated</strong>`
+                            : nothing}
                     ` : nothing
                 }
             </h1>


### PR DESCRIPTION
If a user searches and there are no results, a message comes up saying - can't find matches, try selecting 'all' 
But this needs to be changed now, as we changed the default to "All"

Solution: Only have the suggestion showing if the tab is set to 'Top rated'. If the tab is set to 'All', the message should be only the first sentence: "Oh snap! We couldn't find any matches for [string]."

Rated
<img width="749" height="281" alt="image" src="https://github.com/user-attachments/assets/f9dcdcbd-238a-44d8-9e34-3cd9dda8f84f" />

All
<img width="810" height="185" alt="image" src="https://github.com/user-attachments/assets/b5461aa6-5ba2-4430-8552-630e28d8f296" />

With results works as normal
<img width="904" height="267" alt="image" src="https://github.com/user-attachments/assets/31d503c6-caa1-42ba-a672-58ef3abc9d46" />


@johnnynotsolucky @corinnewo 