### PR TITLE
Text change: Change from limit to 3 jigs to 5

### DIFF
--- a/frontend/elements/src/entry/home/pricing/table.ts
+++ b/frontend/elements/src/entry/home/pricing/table.ts
@@ -465,8 +465,8 @@ export class _ extends LitElement {
                                 <div class="cell"><fa-icon icon="fa-solid fa-check"></fa-icon></div>
                             `,
                             individuals: html`
-                                <div class="cell">Limited to 3 JIGs</div>
-                                <div class="cell">Limited to 3 JIGs</div>
+                                <div class="cell">Limited to 5 JIGs</div>
+                                <div class="cell">Limited to 5 JIGs</div>
                                 <div class="cell"><fa-icon icon="fa-solid fa-check"></fa-icon></div>
                             `
                         })}


### PR DESCRIPTION
With a free account, you can create 5 (ie the limit is set at 5 and the pop-up that appears says 5), so we need to change on the plans page to limit to 5.

Before 
<img width="1113" height="173" alt="image" src="https://github.com/user-attachments/assets/6b8c5668-d01d-4099-979b-68a095bb8d82" />


After
<img width="1145" height="150" alt="image" src="https://github.com/user-attachments/assets/a89ee50a-6a95-46b4-b6ea-fa590d935ced" />
