### PR TITLE
Remove French email language

### DIFF
--- a/frontend/apps/crates/utils/src/languages.rs
+++ b/frontend/apps/crates/utils/src/languages.rs
@@ -36,7 +36,6 @@ lazy_static! {
     pub static ref EMAIL_LANGUAGES: Vec<Language> = vec![
         Language(LANGUAGE_ENGLISH_CODE, STR_LANGUAGE_ENGLISH),
         Language(LANGUAGE_HEBREW_CODE, STR_LANGUAGE_HEBREW),
-        Language(LANGUAGE_FRENCH_CODE, STR_LANGUAGE_FRENCH),
     ];
     pub static ref JIG_LANGUAGES: Vec<Language> = vec![
         Language(LANGUAGE_ENGLISH_CODE, STR_LANGUAGE_ENGLISH),


### PR DESCRIPTION
Emails are no longer sent in French

Before
<img width="899" height="406" alt="image" src="https://github.com/user-attachments/assets/278b57f1-786a-4db5-a3c8-448e277a3a33" />

<img width="758" height="332" alt="image" src="https://github.com/user-attachments/assets/8cad92d9-fcaf-42c8-a932-78221079cf70" />


After
<img width="711" height="328" alt="image" src="https://github.com/user-attachments/assets/a6e4b80d-6cc7-41a9-a36c-ee7a7bdb14d8" />
