### PR TITLE
Ji Tap to Jig

### DIFF
--- a/shared/rust/src/domain/jig/report.rs
+++ b/shared/rust/src/domain/jig/report.rs
@@ -104,7 +104,7 @@ impl JigReportType {
             JigReportType::CopyrightInfringement => "Copyright Infringement",
             JigReportType::Spam => "Spam",
             JigReportType::Privacy => "Privacy",
-            JigReportType::JiTapGameNotPlaying => "Ji Tap Game Not Playing",
+            JigReportType::JiTapGameNotPlaying => "JIG Not Playing",
             JigReportType::Other => "Other",
         }
     }


### PR DESCRIPTION
There are no more Ji Tap games

In the 'i' button on the Teacher panel on the left-hand side, there is a button at the bottom to report a JIG. In the pull-down menu, one of the options is 'Ji Tap game not working'. There are no longer any Ji Tap games - changed it to say 'JIG not working'.
