### PR TITLE
Tweak: Change order of sections on My Likes

### DIFF
--- a/frontend/apps/crates/entry/user/src/likes/dom.rs
+++ b/frontend/apps/crates/entry/user/src/likes/dom.rs
@@ -21,6 +21,7 @@ impl Likes {
                 .style("height", "86px")
                 .style("background-color", "var(--light-blue-6)")
                 .style("margin", "0px")
+                .style("margin-bottom", "20px")
                 .style("display", "grid")
                 .style("align-items", "center")
                 .style("justify-content", "start")
@@ -30,8 +31,8 @@ impl Likes {
                 .style("color", "var(--main-yellow)")
                 .text("My likes")
             }))
-            .child(state.jigs.render())
             .child(state.playlists.render())
+            .child(state.jigs.render())
             .child(state.resources.render())
             .child_signal(state.play_asset.signal_cloned().map(clone!(state => move |play_asset| {
                 play_asset.map(|asset_id| {


### PR DESCRIPTION
Move Playlists to above Jigs

Also, there was little space between the header and the first section (Playlists), so I added a 20px gap there

<img width="866" height="931" alt="image" src="https://github.com/user-attachments/assets/ee0cb9d9-4c67-4617-ae0e-a011b6c57977" />
