### PR TITLE
Sharing a game on social media should share game image, not homepage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ __pycache__
 # Local config
 .editorconfig
 .nvmrc
+.codex/AGENTS.md

--- a/backend/pages/src/templates/spa.rs
+++ b/backend/pages/src/templates/spa.rs
@@ -90,7 +90,6 @@ const DEFAULT_PAGE_KEYWORDS: &str = "Jigzi, Judaism, Hebrew, educational, teachi
 struct PageMeta {
     title: String,
     description: String,
-    keywords: String,
     image: Option<String>,
 }
 
@@ -99,10 +98,17 @@ impl Default for PageMeta {
         Self {
             title: DEFAULT_PAGE_TITLE.to_string(),
             description: DEFAULT_PAGE_DESCRIPTION.to_string(),
-            keywords: DEFAULT_PAGE_KEYWORDS.to_string(),
             image: None,
         }
     }
+}
+
+fn default_spa_template(
+    settings: &RuntimeSettings,
+    spa: SpaPage,
+    req: &HttpRequest,
+) -> actix_web::Result<HttpResponse> {
+    spa_template(settings, spa, req, PageMeta::default())
 }
 
 fn spa_template(
@@ -130,7 +136,7 @@ fn spa_template(
             .spa_url(&*spa.as_str(), "elements/custom-elements.js"),
         page_title: page_meta.title,
         page_description: page_meta.description,
-        page_keywords: page_meta.keywords,
+        page_keywords: DEFAULT_PAGE_KEYWORDS.to_string(),
         page_url: format!(
             "{}{}",
             settings.remote_target().pages_url(),
@@ -161,42 +167,42 @@ pub async fn home_template(
     settings: Data<RuntimeSettings>,
     req: HttpRequest,
 ) -> actix_web::Result<HttpResponse> {
-    spa_template(&settings, SpaPage::Home, &req, PageMeta::default())
+    default_spa_template(&settings, SpaPage::Home, &req)
 }
 
 pub async fn user_template(
     settings: Data<RuntimeSettings>,
     req: HttpRequest,
 ) -> actix_web::Result<HttpResponse> {
-    spa_template(&settings, SpaPage::User, &req, PageMeta::default())
+    default_spa_template(&settings, SpaPage::User, &req)
 }
 
 pub async fn community_template(
     settings: Data<RuntimeSettings>,
     req: HttpRequest,
 ) -> actix_web::Result<HttpResponse> {
-    spa_template(&settings, SpaPage::Community, &req, PageMeta::default())
+    default_spa_template(&settings, SpaPage::Community, &req)
 }
 
 pub async fn kids_template(
     settings: Data<RuntimeSettings>,
     req: HttpRequest,
 ) -> actix_web::Result<HttpResponse> {
-    spa_template(&settings, SpaPage::Kids, &req, PageMeta::default())
+    default_spa_template(&settings, SpaPage::Kids, &req)
 }
 
 pub async fn classroom_template(
     settings: Data<RuntimeSettings>,
     req: HttpRequest,
 ) -> actix_web::Result<HttpResponse> {
-    spa_template(&settings, SpaPage::Classroom, &req, PageMeta::default())
+    default_spa_template(&settings, SpaPage::Classroom, &req)
 }
 
 pub async fn admin_template(
     settings: Data<RuntimeSettings>,
     req: HttpRequest,
 ) -> actix_web::Result<HttpResponse> {
-    spa_template(&settings, SpaPage::Admin, &req, PageMeta::default())
+    default_spa_template(&settings, SpaPage::Admin, &req)
 }
 
 pub async fn asset_template(
@@ -218,7 +224,7 @@ pub async fn legacy_template(
     req: HttpRequest,
     _path: Path<String>, // (jig_id)
 ) -> actix_web::Result<HttpResponse> {
-    spa_template(&settings, SpaPage::LegacyJig, &req, PageMeta::default())
+    default_spa_template(&settings, SpaPage::LegacyJig, &req)
 }
 
 pub async fn legacy_template_with_module(
@@ -226,7 +232,7 @@ pub async fn legacy_template_with_module(
     req: HttpRequest,
     _path: Path<(String, String)>, // (_jig_id, _module_id)
 ) -> actix_web::Result<HttpResponse> {
-    spa_template(&settings, SpaPage::LegacyJig, &req, PageMeta::default())
+    default_spa_template(&settings, SpaPage::LegacyJig, &req)
 }
 
 pub async fn module_template(
@@ -235,12 +241,7 @@ pub async fn module_template(
     path: Path<(String, ModuleAssetPageKind, String)>,
 ) -> actix_web::Result<HttpResponse> {
     let (module_kind, page_kind, _) = path.into_inner();
-    spa_template(
-        &settings,
-        SpaPage::Module(module_kind, page_kind),
-        &req,
-        PageMeta::default(),
-    )
+    default_spa_template(&settings, SpaPage::Module(module_kind, page_kind), &req)
 }
 
 pub async fn dev_template(
@@ -248,12 +249,7 @@ pub async fn dev_template(
     req: HttpRequest,
     path: Path<String>,
 ) -> actix_web::Result<HttpResponse> {
-    spa_template(
-        &settings,
-        SpaPage::Dev(path.into_inner()),
-        &req,
-        PageMeta::default(),
-    )
+    default_spa_template(&settings, SpaPage::Dev(path.into_inner()), &req)
 }
 
 async fn load_asset_page_meta(settings: &RuntimeSettings, asset_path: &str) -> PageMeta {
@@ -266,12 +262,12 @@ async fn load_asset_page_meta(settings: &RuntimeSettings, asset_path: &str) -> P
 fn parse_jig_id(asset_path: &str) -> Option<JigId> {
     let mut segments = asset_path.split('/');
 
-    match segments.next() {
-        Some("jig") => segments.next(),
-        Some(id) => Some(id),
-        None => None,
-    }
-    .and_then(|id| JigId::from_str(id).ok())
+    let id = match segments.next()? {
+        "jig" => segments.next()?,
+        id => id,
+    };
+
+    JigId::from_str(id).ok()
 }
 
 async fn load_jig_page_meta(settings: &RuntimeSettings, jig_id: JigId) -> PageMeta {
@@ -345,7 +341,6 @@ fn jig_page_meta(settings: &RuntimeSettings, jig: &JigResponse) -> PageMeta {
     PageMeta {
         title,
         description,
-        keywords: DEFAULT_PAGE_KEYWORDS.to_string(),
         image,
     }
 }

--- a/backend/pages/src/templates/spa.rs
+++ b/backend/pages/src/templates/spa.rs
@@ -1,11 +1,16 @@
 use actix_web::{
     error::ErrorInternalServerError,
     web::{Data, Path},
-    HttpResponse,
+    HttpRequest, HttpResponse,
 };
 use ji_core::settings::RuntimeSettings;
-use shared::config::RemoteTarget;
+use shared::{
+    config::RemoteTarget,
+    domain::jig::{JigId, JigResponse},
+};
 use std::borrow::Cow;
+use std::str::FromStr;
+use std::time::Duration;
 
 use askama::Template;
 
@@ -65,6 +70,11 @@ struct SpaPageInfo {
     app_css: String,
     app_favicon: String,
     app_custom_elements_js: String,
+    page_title: String,
+    page_description: String,
+    page_keywords: String,
+    page_url: String,
+    page_image: Option<String>,
     firebase: bool,
     google_maps_url: Option<String>,
     local_dev: bool,
@@ -72,7 +82,35 @@ struct SpaPageInfo {
     is_release: bool,
 }
 
-fn spa_template(settings: &RuntimeSettings, spa: SpaPage) -> actix_web::Result<HttpResponse> {
+const DEFAULT_PAGE_TITLE: &str = "Jigzi";
+const DEFAULT_PAGE_DESCRIPTION: &str = "Jigzi is a game-creation tool and crowd-sourcing platform which currently holds thousands of educational activities that teach children about Judaism, Hebrew, Israel and their culture in an engaging and interactive way. Educators can use current games, as well as create their own to complement their curriculum at any level and any language. The creation tool includes a huge collection of educational clipart that updates constantly.";
+const DEFAULT_PAGE_KEYWORDS: &str = "Jigzi, Judaism, Hebrew, educational, teaching, interactive";
+
+#[derive(Clone, Debug)]
+struct PageMeta {
+    title: String,
+    description: String,
+    keywords: String,
+    image: Option<String>,
+}
+
+impl Default for PageMeta {
+    fn default() -> Self {
+        Self {
+            title: DEFAULT_PAGE_TITLE.to_string(),
+            description: DEFAULT_PAGE_DESCRIPTION.to_string(),
+            keywords: DEFAULT_PAGE_KEYWORDS.to_string(),
+            image: None,
+        }
+    }
+}
+
+fn spa_template(
+    settings: &RuntimeSettings,
+    spa: SpaPage,
+    req: &HttpRequest,
+    page_meta: PageMeta,
+) -> actix_web::Result<HttpResponse> {
     let google_maps_url = match spa {
         // todo: `Cow::borrowed` ('static)
         SpaPage::User | SpaPage::Community => {
@@ -90,6 +128,18 @@ fn spa_template(settings: &RuntimeSettings, spa: SpaPage) -> actix_web::Result<H
         app_custom_elements_js: settings
             .remote_target()
             .spa_url(&*spa.as_str(), "elements/custom-elements.js"),
+        page_title: page_meta.title,
+        page_description: page_meta.description,
+        page_keywords: page_meta.keywords,
+        page_url: format!(
+            "{}{}",
+            settings.remote_target().pages_url(),
+            req.uri()
+                .path_and_query()
+                .map(|path| path.as_str())
+                .unwrap_or("/")
+        ),
+        page_image: page_meta.image,
         firebase: matches!(spa, SpaPage::User),
         google_maps_url,
         local_dev: settings.is_local(),
@@ -107,67 +157,195 @@ fn spa_template(settings: &RuntimeSettings, spa: SpaPage) -> actix_web::Result<H
     Ok(actix_web::HttpResponse::Ok().body(info))
 }
 
-pub async fn home_template(settings: Data<RuntimeSettings>) -> actix_web::Result<HttpResponse> {
-    spa_template(&settings, SpaPage::Home)
+pub async fn home_template(
+    settings: Data<RuntimeSettings>,
+    req: HttpRequest,
+) -> actix_web::Result<HttpResponse> {
+    spa_template(&settings, SpaPage::Home, &req, PageMeta::default())
 }
 
-pub async fn user_template(settings: Data<RuntimeSettings>) -> actix_web::Result<HttpResponse> {
-    spa_template(&settings, SpaPage::User)
+pub async fn user_template(
+    settings: Data<RuntimeSettings>,
+    req: HttpRequest,
+) -> actix_web::Result<HttpResponse> {
+    spa_template(&settings, SpaPage::User, &req, PageMeta::default())
 }
 
 pub async fn community_template(
     settings: Data<RuntimeSettings>,
+    req: HttpRequest,
 ) -> actix_web::Result<HttpResponse> {
-    spa_template(&settings, SpaPage::Community)
+    spa_template(&settings, SpaPage::Community, &req, PageMeta::default())
 }
 
-pub async fn kids_template(settings: Data<RuntimeSettings>) -> actix_web::Result<HttpResponse> {
-    spa_template(&settings, SpaPage::Kids)
+pub async fn kids_template(
+    settings: Data<RuntimeSettings>,
+    req: HttpRequest,
+) -> actix_web::Result<HttpResponse> {
+    spa_template(&settings, SpaPage::Kids, &req, PageMeta::default())
 }
 
 pub async fn classroom_template(
     settings: Data<RuntimeSettings>,
+    req: HttpRequest,
 ) -> actix_web::Result<HttpResponse> {
-    spa_template(&settings, SpaPage::Classroom)
+    spa_template(&settings, SpaPage::Classroom, &req, PageMeta::default())
 }
 
-pub async fn admin_template(settings: Data<RuntimeSettings>) -> actix_web::Result<HttpResponse> {
-    spa_template(&settings, SpaPage::Admin)
+pub async fn admin_template(
+    settings: Data<RuntimeSettings>,
+    req: HttpRequest,
+) -> actix_web::Result<HttpResponse> {
+    spa_template(&settings, SpaPage::Admin, &req, PageMeta::default())
 }
 
 pub async fn asset_template(
     settings: Data<RuntimeSettings>,
+    req: HttpRequest,
     path: Path<(ModuleAssetPageKind, String)>,
 ) -> actix_web::Result<HttpResponse> {
-    let (page_kind, _asset_kind) = path.into_inner();
-    spa_template(&settings, SpaPage::Asset(page_kind))
+    let (page_kind, asset_path) = path.into_inner();
+    let page_meta = match page_kind {
+        ModuleAssetPageKind::Play => load_asset_page_meta(&settings, &asset_path).await,
+        ModuleAssetPageKind::Edit => PageMeta::default(),
+    };
+
+    spa_template(&settings, SpaPage::Asset(page_kind), &req, page_meta)
 }
 
 pub async fn legacy_template(
     settings: Data<RuntimeSettings>,
+    req: HttpRequest,
     _path: Path<String>, // (jig_id)
 ) -> actix_web::Result<HttpResponse> {
-    spa_template(&settings, SpaPage::LegacyJig)
+    spa_template(&settings, SpaPage::LegacyJig, &req, PageMeta::default())
 }
 
 pub async fn legacy_template_with_module(
     settings: Data<RuntimeSettings>,
+    req: HttpRequest,
     _path: Path<(String, String)>, // (_jig_id, _module_id)
 ) -> actix_web::Result<HttpResponse> {
-    spa_template(&settings, SpaPage::LegacyJig)
+    spa_template(&settings, SpaPage::LegacyJig, &req, PageMeta::default())
 }
 
 pub async fn module_template(
     settings: Data<RuntimeSettings>,
+    req: HttpRequest,
     path: Path<(String, ModuleAssetPageKind, String)>,
 ) -> actix_web::Result<HttpResponse> {
     let (module_kind, page_kind, _) = path.into_inner();
-    spa_template(&settings, SpaPage::Module(module_kind, page_kind))
+    spa_template(
+        &settings,
+        SpaPage::Module(module_kind, page_kind),
+        &req,
+        PageMeta::default(),
+    )
 }
 
 pub async fn dev_template(
     settings: Data<RuntimeSettings>,
+    req: HttpRequest,
     path: Path<String>,
 ) -> actix_web::Result<HttpResponse> {
-    spa_template(&settings, SpaPage::Dev(path.into_inner()))
+    spa_template(
+        &settings,
+        SpaPage::Dev(path.into_inner()),
+        &req,
+        PageMeta::default(),
+    )
+}
+
+async fn load_asset_page_meta(settings: &RuntimeSettings, asset_path: &str) -> PageMeta {
+    match parse_jig_id(asset_path) {
+        Some(jig_id) => load_jig_page_meta(settings, jig_id).await,
+        None => PageMeta::default(),
+    }
+}
+
+fn parse_jig_id(asset_path: &str) -> Option<JigId> {
+    let mut segments = asset_path.split('/');
+
+    match segments.next() {
+        Some("jig") => segments.next(),
+        Some(id) => Some(id),
+        None => None,
+    }
+    .and_then(|id| JigId::from_str(id).ok())
+}
+
+async fn load_jig_page_meta(settings: &RuntimeSettings, jig_id: JigId) -> PageMeta {
+    let url = format!(
+        "{}/v1/jig/{}/live",
+        settings.remote_target().api_url(),
+        jig_id
+    );
+
+    let client = match reqwest::Client::builder()
+        .timeout(Duration::from_secs(2))
+        .build()
+    {
+        Ok(client) => client,
+        Err(err) => {
+            log::warn!(
+                "Unable to create HTTP client for social sharing metadata: {:?}",
+                err
+            );
+            return PageMeta::default();
+        }
+    };
+
+    match client.get(url).send().await {
+        Ok(response) if response.status().is_success() => {
+            match response.json::<JigResponse>().await {
+                Ok(jig) => jig_page_meta(settings, &jig),
+                Err(err) => {
+                    log::warn!("Unable to parse JIG metadata for social sharing: {:?}", err);
+                    PageMeta::default()
+                }
+            }
+        }
+        Ok(response) => {
+            log::warn!(
+                "Unable to load JIG metadata for social sharing: HTTP {}",
+                response.status()
+            );
+            PageMeta::default()
+        }
+        Err(err) => {
+            log::warn!("Unable to load JIG metadata for social sharing: {:?}", err);
+            PageMeta::default()
+        }
+    }
+}
+
+fn jig_page_meta(settings: &RuntimeSettings, jig: &JigResponse) -> PageMeta {
+    let display_name = jig.jig_data.display_name.trim();
+    let title = if display_name.is_empty() {
+        DEFAULT_PAGE_TITLE.to_string()
+    } else {
+        format!("{} | Jigzi", display_name)
+    };
+
+    let description = match jig.jig_data.description.trim() {
+        "" if display_name.is_empty() => DEFAULT_PAGE_DESCRIPTION.to_string(),
+        "" => format!("Play {} on Jigzi.", display_name),
+        description => description.to_string(),
+    };
+
+    let image = jig.jig_data.modules.first().map(|module| {
+        format!(
+            "{}/screenshot/{}/{}/full.jpg",
+            settings.remote_target().uploads_url(),
+            jig.id,
+            module.id
+        )
+    });
+
+    PageMeta {
+        title,
+        description,
+        keywords: DEFAULT_PAGE_KEYWORDS.to_string(),
+        image,
+    }
 }

--- a/backend/pages/templates/spa.html
+++ b/backend/pages/templates/spa.html
@@ -5,15 +5,28 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-    <meta name="description" content="Jigzi is a game-creation tool and crowd-sourcing platform which currently holds thousands of educational activities that teach children about Judaism, Hebrew, Israel and their culture in an engaging and interactive way. Educators can use current games, as well as create their own to complement their curriculum at any level and any language. The creation tool includes a huge collection of educational clipart that updates constantly.">
-    <meta name="keywords" content="Jigzi, Judaism, Hebrew, educational, teaching, interactive">
+    <meta name="description" content="{{ page_description }}">
+    <meta name="keywords" content="{{ page_keywords }}">
+    <meta property="og:title" content="{{ page_title }}">
+    <meta property="og:description" content="{{ page_description }}">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="{{ page_url }}">
+    {% match page_image %}
+    {% when Some with (image) %}
+    <meta property="og:image" content="{{ image }}">
+    <meta name="twitter:image" content="{{ image }}">
+    {% else %}
+    {% endmatch %}
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="{{ page_title }}">
+    <meta name="twitter:description" content="{{ page_description }}">
     <link rel="shortcut icon" href="{{ app_favicon|safe }}" type="image/x-icon">
     <link rel="stylesheet" type="text/css" href="{{ app_css|safe }}">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Roboto:wght@400;500&display=swap" rel="stylesheet">
     <link rel="manifest" href="/manifest.json" />
-    <title>Jigzi</title>
+    <title>{{ page_title }}</title>
 
     {% if is_release -%}
     <!-- Google tag (gtag.js) -->

--- a/frontend/apps/crates/components/src/lib.rs
+++ b/frontend/apps/crates/components/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(type_alias_impl_trait)]
-//see: https://github.com/rust-lang/cargo/issues/8010
 #![feature(impl_trait_in_assoc_type)]
 // see: https://github.com/rust-lang/rust/issues/63063
 

--- a/frontend/apps/package-lock.json
+++ b/frontend/apps/package-lock.json
@@ -163,6 +163,7 @@
             "version": "0.9.13",
             "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.9.13.tgz",
             "integrity": "sha512-GfiI1JxJ7ecluEmDjPzseRXk/PX31hS7+tjgBopL7XjB2hLUdR+0FTMXy2Q3/hXezypDvU6or7gVFizDESrkXw==",
+            "peer": true,
             "dependencies": {
                 "@firebase/component": "0.6.4",
                 "@firebase/logger": "0.4.0",
@@ -215,6 +216,7 @@
             "version": "0.2.13",
             "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.2.13.tgz",
             "integrity": "sha512-j6ANZaWjeVy5zg6X7uiqh6lM6o3n3LD1+/SJFNs9V781xyryyZWXe+tmnWNWPkP086QfJoNkWN9pMQRqSG4vMg==",
+            "peer": true,
             "dependencies": {
                 "@firebase/app": "0.9.13",
                 "@firebase/component": "0.6.4",
@@ -226,7 +228,8 @@
         "node_modules/@firebase/app-types": {
             "version": "0.9.0",
             "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.0.tgz",
-            "integrity": "sha512-AeweANOIo0Mb8GiYm3xhTEBVCmPwTYAu9Hcd2qSkLuga/6+j9b1Jskl5bpiSQWy9eJ/j5pavxj6eYogmnuzm+Q=="
+            "integrity": "sha512-AeweANOIo0Mb8GiYm3xhTEBVCmPwTYAu9Hcd2qSkLuga/6+j9b1Jskl5bpiSQWy9eJ/j5pavxj6eYogmnuzm+Q==",
+            "peer": true
         },
         "node_modules/@firebase/auth": {
             "version": "0.23.2",
@@ -698,6 +701,7 @@
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.9.3.tgz",
             "integrity": "sha512-DY02CRhOZwpzO36fHpuVysz6JZrscPiBXD0fXp6qSrL9oNOx5KWICKdR95C0lSITzxp0TZosVyHqzatE8JbcjA==",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.1.0"
             }
@@ -1068,6 +1072,7 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
             "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -4823,6 +4828,7 @@
             "version": "4.37.0",
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.37.0.tgz",
             "integrity": "sha512-iAtQy/L4QFU+rTJ1YUjXqJOJzuwEghqWzCEYD2FEghT7Gsy1VdABntrO4CLopA5IkflTyqNiLNwPcOJ3S7UKLg==",
+            "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.6"
             },
@@ -5049,8 +5055,7 @@
         "node_modules/scheduler": {
             "version": "0.25.0",
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
-            "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
-            "peer": true
+            "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA=="
         },
         "node_modules/scroll-into-view-if-needed": {
             "version": "2.2.31",
@@ -5342,6 +5347,7 @@
             "version": "0.94.1",
             "resolved": "https://registry.npmjs.org/slate/-/slate-0.94.1.tgz",
             "integrity": "sha512-GH/yizXr1ceBoZ9P9uebIaHe3dC/g6Plpf9nlUwnvoyf6V1UOYrRwkabtOCd3ZfIGxomY4P7lfgLr7FPH8/BKA==",
+            "peer": true,
             "dependencies": {
                 "immer": "^9.0.6",
                 "is-plain-object": "^5.0.0",

--- a/frontend/apps/package-lock.json
+++ b/frontend/apps/package-lock.json
@@ -163,7 +163,6 @@
             "version": "0.9.13",
             "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.9.13.tgz",
             "integrity": "sha512-GfiI1JxJ7ecluEmDjPzseRXk/PX31hS7+tjgBopL7XjB2hLUdR+0FTMXy2Q3/hXezypDvU6or7gVFizDESrkXw==",
-            "peer": true,
             "dependencies": {
                 "@firebase/component": "0.6.4",
                 "@firebase/logger": "0.4.0",
@@ -216,7 +215,6 @@
             "version": "0.2.13",
             "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.2.13.tgz",
             "integrity": "sha512-j6ANZaWjeVy5zg6X7uiqh6lM6o3n3LD1+/SJFNs9V781xyryyZWXe+tmnWNWPkP086QfJoNkWN9pMQRqSG4vMg==",
-            "peer": true,
             "dependencies": {
                 "@firebase/app": "0.9.13",
                 "@firebase/component": "0.6.4",
@@ -228,8 +226,7 @@
         "node_modules/@firebase/app-types": {
             "version": "0.9.0",
             "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.0.tgz",
-            "integrity": "sha512-AeweANOIo0Mb8GiYm3xhTEBVCmPwTYAu9Hcd2qSkLuga/6+j9b1Jskl5bpiSQWy9eJ/j5pavxj6eYogmnuzm+Q==",
-            "peer": true
+            "integrity": "sha512-AeweANOIo0Mb8GiYm3xhTEBVCmPwTYAu9Hcd2qSkLuga/6+j9b1Jskl5bpiSQWy9eJ/j5pavxj6eYogmnuzm+Q=="
         },
         "node_modules/@firebase/auth": {
             "version": "0.23.2",
@@ -701,7 +698,6 @@
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.9.3.tgz",
             "integrity": "sha512-DY02CRhOZwpzO36fHpuVysz6JZrscPiBXD0fXp6qSrL9oNOx5KWICKdR95C0lSITzxp0TZosVyHqzatE8JbcjA==",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.1.0"
             }
@@ -1072,7 +1068,6 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
             "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -4828,7 +4823,6 @@
             "version": "4.37.0",
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.37.0.tgz",
             "integrity": "sha512-iAtQy/L4QFU+rTJ1YUjXqJOJzuwEghqWzCEYD2FEghT7Gsy1VdABntrO4CLopA5IkflTyqNiLNwPcOJ3S7UKLg==",
-            "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.6"
             },
@@ -5055,7 +5049,8 @@
         "node_modules/scheduler": {
             "version": "0.25.0",
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
-            "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA=="
+            "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+            "peer": true
         },
         "node_modules/scroll-into-view-if-needed": {
             "version": "2.2.31",
@@ -5347,7 +5342,6 @@
             "version": "0.94.1",
             "resolved": "https://registry.npmjs.org/slate/-/slate-0.94.1.tgz",
             "integrity": "sha512-GH/yizXr1ceBoZ9P9uebIaHe3dC/g6Plpf9nlUwnvoyf6V1UOYrRwkabtOCd3ZfIGxomY4P7lfgLr7FPH8/BKA==",
-            "peer": true,
             "dependencies": {
                 "immer": "^9.0.6",
                 "is-plain-object": "^5.0.0",

--- a/shared/rust/src/domain/module/body/card_quiz.rs
+++ b/shared/rust/src/domain/module/body/card_quiz.rs
@@ -1,5 +1,5 @@
 use crate::domain::module::{
-    body::{Body, BodyConvert, BodyExt, ThemeId, _groups::cards::*},
+    body::{_groups::cards::*, Body, BodyConvert, BodyExt, ThemeId},
     ModuleKind,
 };
 use serde::{Deserialize, Serialize};

--- a/shared/rust/src/domain/module/body/cover.rs
+++ b/shared/rust/src/domain/module/body/cover.rs
@@ -1,5 +1,5 @@
 use crate::domain::module::{
-    body::{Body, BodyConvert, BodyExt, StepExt, ThemeId, _groups::design::*},
+    body::{_groups::design::*, Body, BodyConvert, BodyExt, StepExt, ThemeId},
     ModuleKind,
 };
 use serde::{de::IntoDeserializer, Deserialize, Serialize};

--- a/shared/rust/src/domain/module/body/drag_drop.rs
+++ b/shared/rust/src/domain/module/body/drag_drop.rs
@@ -1,7 +1,7 @@
 use crate::domain::module::{
     body::{
-        Audio, Body, BodyConvert, BodyExt, ModeExt, ModuleAssist, StepExt, ThemeId, Transform,
         _groups::design::{Backgrounds, Sticker, Trace},
+        Audio, Body, BodyConvert, BodyExt, ModeExt, ModuleAssist, StepExt, ThemeId, Transform,
     },
     ModuleKind,
 };

--- a/shared/rust/src/domain/module/body/embed.rs
+++ b/shared/rust/src/domain/module/body/embed.rs
@@ -1,5 +1,5 @@
 use crate::domain::module::{
-    body::{Body, BodyExt, ModeExt, StepExt, ThemeId, _groups::design::*},
+    body::{_groups::design::*, Body, BodyExt, ModeExt, StepExt, ThemeId},
     ModuleKind,
 };
 use serde::{Deserialize, Serialize};

--- a/shared/rust/src/domain/module/body/find_answer.rs
+++ b/shared/rust/src/domain/module/body/find_answer.rs
@@ -1,7 +1,7 @@
 use crate::domain::module::{
     body::{
-        Body, BodyConvert, BodyExt, ModeExt, StepExt, ThemeId,
         _groups::design::{BaseContent, Trace},
+        Body, BodyConvert, BodyExt, ModeExt, StepExt, ThemeId,
     },
     ModuleKind,
 };
@@ -12,8 +12,8 @@ mod play_settings;
 pub use play_settings::*;
 
 use super::{
-    Audio, Transform,
     _groups::design::{Sticker, Text},
+    Audio, Transform,
 };
 
 /// The body for [`FindAnswer`](crate::domain::module::ModuleKind::FindAnswer) modules.

--- a/shared/rust/src/domain/module/body/flashcards.rs
+++ b/shared/rust/src/domain/module/body/flashcards.rs
@@ -1,5 +1,5 @@
 use crate::domain::module::{
-    body::{Body, BodyConvert, BodyExt, ModeExt, ThemeId, _groups::cards::*},
+    body::{_groups::cards::*, Body, BodyConvert, BodyExt, ModeExt, ThemeId},
     ModuleKind,
 };
 use serde::{Deserialize, Serialize};

--- a/shared/rust/src/domain/module/body/matching.rs
+++ b/shared/rust/src/domain/module/body/matching.rs
@@ -1,5 +1,5 @@
 use crate::domain::module::{
-    body::{Body, BodyConvert, BodyExt, ModeExt, ThemeId, _groups::cards::*},
+    body::{_groups::cards::*, Body, BodyConvert, BodyExt, ModeExt, ThemeId},
     ModuleKind,
 };
 use serde::{Deserialize, Serialize};

--- a/shared/rust/src/domain/module/body/memory.rs
+++ b/shared/rust/src/domain/module/body/memory.rs
@@ -1,5 +1,5 @@
 use crate::domain::module::{
-    body::{Body, BodyConvert, BodyExt, ThemeId, _groups::cards::*},
+    body::{_groups::cards::*, Body, BodyConvert, BodyExt, ThemeId},
     ModuleKind,
 };
 use serde::{Deserialize, Serialize};

--- a/shared/rust/src/domain/module/body/poster.rs
+++ b/shared/rust/src/domain/module/body/poster.rs
@@ -1,5 +1,5 @@
 use crate::domain::module::{
-    body::{Body, BodyConvert, BodyExt, ModeExt, StepExt, ThemeId, _groups::design::*},
+    body::{_groups::design::*, Body, BodyConvert, BodyExt, ModeExt, StepExt, ThemeId},
     ModuleKind,
 };
 use serde::{Deserialize, Serialize};

--- a/shared/rust/src/domain/module/body/resource_cover.rs
+++ b/shared/rust/src/domain/module/body/resource_cover.rs
@@ -1,5 +1,5 @@
 use crate::domain::module::{
-    body::{Body, BodyConvert, BodyExt, StepExt, ThemeId, _groups::design::*},
+    body::{_groups::design::*, Body, BodyConvert, BodyExt, StepExt, ThemeId},
     ModuleKind,
 };
 use serde::{Deserialize, Serialize};

--- a/shared/rust/src/domain/module/body/tapping_board.rs
+++ b/shared/rust/src/domain/module/body/tapping_board.rs
@@ -1,7 +1,7 @@
 use crate::domain::module::{
     body::{
-        Body, BodyConvert, BodyExt, ModeExt, StepExt, ThemeId,
         _groups::design::{BaseContent, Trace},
+        Body, BodyConvert, BodyExt, ModeExt, StepExt, ThemeId,
     },
     ModuleKind,
 };

--- a/shared/rust/src/domain/module/body/video.rs
+++ b/shared/rust/src/domain/module/body/video.rs
@@ -1,5 +1,5 @@
 use crate::domain::module::{
-    body::{Body, BodyExt, ModeExt, StepExt, ThemeId, _groups::design::*},
+    body::{_groups::design::*, Body, BodyExt, ModeExt, StepExt, ThemeId},
     ModuleKind,
 };
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
This is the requirement.
<img width="1213" height="209" alt="image" src="https://github.com/user-attachments/assets/dca0d868-d03e-4677-a574-86c16e4d5104" />

I can't really test this locally by sharing on social media, obviously, and I'm having trouble running that game locally, so this ill need to be tested, but I think it works.

## Summary

- Add server-rendered social metadata for JIG play pages.
- Use the live JIG name, description, and cover screenshot for Open Graph and Twitter previews.
- Keep default Jigzi metadata for non-JIG pages or when JIG metadata cannot be loaded.

## Details

JIG play URLs now render page-specific metadata in the SPA shell:

- `og:title` / `twitter:title`
- `og:description` / `twitter:description`
- `og:image` / `twitter:image`
- `og:url`
- dynamic `<title>`

For `/asset/play/jig/{id}` pages, the pages server fetches live JIG metadata from the API and builds the preview image from the first module screenshot. If the request fails, the response falls back to the existing generic Jigzi title and description.

## Verification

- Ran `cargo +stable check` in `backend/pages`.
- Check passed.
- Existing `shared` / `sqlx` cfg warnings are still present and unrelated.